### PR TITLE
feat: Forward watch token through authorize hook; add token-auth demo (#339)

### DIFF
--- a/examples/rn-demo/public/index.html
+++ b/examples/rn-demo/public/index.html
@@ -135,6 +135,31 @@
       <p class="mono" id="deeplinkUpload"></p>
     </div>
 
+    <div class="card" style="border-color:#1f6feb;">
+      <strong>3 — Save this server <em>with token</em> <span style="font-size:0.75rem;color:#1f6feb;font-weight:400;">(auth demo)</span></strong>
+      <p style="font-size:0.875rem; color:#8b949e; margin:0.5rem 0 0;">
+        Scan this QR to save the server <strong>with a session token</strong> in the app.
+        Any video you upload using that saved destination will be token-protected:
+        the watch link will include the token, and the server will reject playback without it.
+      </p>
+
+      <hr class="divider" />
+
+      <p style="font-size:0.875rem; color:#8b949e; margin:0 0 0.5rem;">
+        Scan from your phone's camera app, or tap the button if you're on the same device:
+      </p>
+
+      <img id="qrConfigureToken" width="224" height="224" style="display:block;margin:1.25rem auto;border-radius:8px;background:#fff;padding:10px;" />
+
+      <a id="openBtnConfigureToken" class="open-btn" style="background:#1f6feb;" href="#">Save server with token in Pulse App</a>
+
+      <label>Session Token <span style="color:#6e7681;">(verified on every watch request)</span></label>
+      <p class="mono" id="sessionToken"></p>
+
+      <label>Deep link</label>
+      <p class="mono" id="deeplinkConfigureToken"></p>
+    </div>
+
     <div class="card">
       <div style="display:flex;align-items:center;justify-content:space-between;">
         <strong>Uploaded Videos</strong>
@@ -162,7 +187,17 @@
         document.getElementById("qrUpload").src = data.qrUpload;
       }
 
+      async function loadTokenDeeplinks() {
+        const data = await fetch("/deeplinks-token").then((r) => r.json());
+
+        document.getElementById("sessionToken").textContent = data.token;
+        document.getElementById("deeplinkConfigureToken").textContent = data.configureDestination;
+        document.getElementById("openBtnConfigureToken").href = data.configureDestination;
+        document.getElementById("qrConfigureToken").src = data.qrConfigure;
+      }
+
       loadDeeplinks();
+      loadTokenDeeplinks();
       document.getElementById("refreshUpload").addEventListener("click", loadDeeplinks);
 
       function formatSize(bytes) {
@@ -181,8 +216,8 @@
         }
         list.innerHTML = videos.map((v) => `
           <div style="margin-bottom:1rem;padding-bottom:1rem;border-bottom:1px solid #30363d;">
-            <video src="/${v.videoid}" controls preload="metadata" style="width:100%;max-height:26rem;border-radius:6px;background:#000;display:block;object-fit:contain;"></video>
-            <p class="mono" style="margin:0.4rem 0 0;">${v.filename}</p>
+            <video src="/${v.videoid}${v.token ? '?token=' + encodeURIComponent(v.token) : ''}" controls preload="metadata" style="width:100%;max-height:26rem;border-radius:6px;background:#000;display:block;object-fit:contain;"></video>
+            <p class="mono" style="margin:0.4rem 0 0;">${v.filename}${v.token ? ' <span style="color:#1f6feb;">🔒 token-protected</span>' : ''}</p>
             <p class="mono" style="margin:0.15rem 0 0;color:#6e7681;">${formatSize(v.size)} • ${new Date(v.creation_date).toLocaleString()}</p>
             <p class="mono" style="margin:0.15rem 0 0;color:#6e7681;">${v.videoid}</p>
           </div>

--- a/examples/rn-demo/server.mjs
+++ b/examples/rn-demo/server.mjs
@@ -19,6 +19,24 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const html = readFileSync(path.join(__dirname, "public/index.html"), "utf8");
 const dataDir = path.join(__dirname, "data");
 
+/**
+ * In-memory token store: maps videoid → token for token-protected uploads.
+ * Populated in the authorize hook during the 'create' phase when the app
+ * sends a Bearer token that matches SESSION_TOKEN.
+ * No persistence — tokens are lost when the server restarts.
+ */
+const tokenStore = new Map();
+
+/**
+ * A single server-level session token generated at startup.
+ * Embed it in the configure-destination QR so the Pulse app stores it
+ * alongside the server URL. Every upload made with that saved destination
+ * will include the token as a Bearer header, registering the video as
+ * token-protected.
+ */
+const SESSION_TOKEN = randomUUID();
+console.log(`[auth] Session token: ${SESSION_TOKEN}`);
+
 const app = Fastify({
   logger: true,
   bodyLimit: 16 * 1024 * 1024, // max single PATCH chunk (RN app sends 1 MB chunks)
@@ -107,6 +125,7 @@ const videoSummarySchema = {
     filename: { type: "string" },
     size: { type: "integer", minimum: 0 },
     creation_date: { type: "string", format: "date-time" },
+    token: { type: "string", description: "Present when this video requires a token to watch." },
   },
   required: ["videoid", "filename", "size", "creation_date"],
 };
@@ -170,6 +189,7 @@ app.get(
             size: mp4Stat.size,
             creation_date:
               meta?.creation_date ?? mp4Stat.birthtime.toISOString(),
+            ...(tokenStore.has(videoid) && { token: tokenStore.get(videoid) }),
           };
         }),
     );
@@ -253,6 +273,54 @@ app.get(
   },
 );
 
+// Token-protected server-configuration QR: uses buildConfigureDestinationLink
+// (same as Section 1) but embeds SESSION_TOKEN so the Pulse app stores the
+// token alongside the server URL. Uploads made with this saved destination
+// send "Authorization: Bearer <token>", which the authorize hook uses to
+// register the videoid as token-protected before the bytes are written.
+app.get(
+  "/deeplinks-token",
+  {
+    schema: {
+      tags: ["demo"],
+      summary: "Token-protected server-config QR",
+      description:
+        "Returns a configure-destination deep link that embeds the server-level session token. " +
+        "Scanning this QR saves the server + token in the app. Any subsequent upload from that " +
+        "saved destination will be token-protected: the server registers the videoid in its token " +
+        "store and rejects watch requests that omit the correct token.",
+      response: {
+        200: {
+          description: "Token-scoped configure-destination link and QR code.",
+          type: "object",
+          properties: {
+            configureDestination: { type: "string", format: "uri" },
+            token: { type: "string", description: "The session token embedded in the QR." },
+            qrConfigure: { type: "string", description: "data:image/png;base64 QR for the token-scoped configure-destination link." },
+          },
+          required: ["configureDestination", "token", "qrConfigure"],
+        },
+      },
+    },
+  },
+  async (req, reply) => {
+    const proto = req.headers["x-forwarded-proto"] ?? "http";
+    const host = req.headers["x-forwarded-host"] ?? req.headers.host;
+    const server = `${proto}://${host}`;
+
+    const configureDestination = buildConfigureDestinationLink({
+      server,
+      name: "Demo Server (Token Auth)",
+      token: SESSION_TOKEN,
+    });
+
+    const qrOpts = { width: 224, margin: 1, color: { dark: "#000000", light: "#ffffff" } };
+    const qrConfigure = await QRCode.toDataURL(configureDestination, qrOpts);
+
+    return reply.send({ configureDestination, token: SESSION_TOKEN, qrConfigure });
+  },
+);
+
 // Mount plugin at root prefix so TUS is at POST /upload and video GET is at /:videoid
 const pulseStorage = createLocalStorage({ workspaceDir: dataDir });
 await app.register(pulseVault, {
@@ -262,6 +330,48 @@ await app.register(pulseVault, {
   allowedExtensions: [".mp4"],
   // Reject anything that doesn't look like an MP4 at the final PATCH.
   validatePayload: createMp4Sniffer(pulseStorage),
+  /**
+   * Authorization hook — called before every create/patch/resolve/delete.
+   *
+   * For the "resolve" phase the mobile app forwards any upload token as
+   * `?token=<value>` in the watch URL; the plugin surfaces it here as
+   * `ctx.token` so the parent server can validate it without a separate
+   * browser login.
+   *
+   * This demo server has no real auth store, so it accepts all requests.
+   * A production deployment would look up the token in a DB/session store
+   * and throw to reject (e.g. `throw { statusCode: 403, message: "Forbidden" }`).
+   */
+  authorize: async (request, ctx) => {
+    if (ctx.phase === "create") {
+      // When the app uploads using the token-protected saved destination it
+      // sends "Authorization: Bearer <SESSION_TOKEN>". Register this videoid
+      // in the token store so the resolve phase can protect it.
+      const authHeader = request.headers["authorization"];
+      const bearer = typeof authHeader === "string" && authHeader.startsWith("Bearer ")
+        ? authHeader.slice(7)
+        : undefined;
+      if (bearer !== undefined && bearer === SESSION_TOKEN) {
+        tokenStore.set(ctx.videoid, SESSION_TOKEN);
+        app.log.info(
+          { videoid: ctx.videoid },
+          "pulsevault authorize: token-protected videoid registered",
+        );
+      }
+    } else if (ctx.phase === "resolve") {
+      const expectedToken = tokenStore.get(ctx.videoid);
+      if (expectedToken !== undefined) {
+        // This videoid requires a token to watch.
+        if (ctx.token !== expectedToken) {
+          throw { statusCode: 403, message: "Invalid or missing watch token" };
+        }
+        app.log.info(
+          { videoid: ctx.videoid },
+          "pulsevault authorize: token-protected watch request verified",
+        );
+      }
+    }
+  },
 });
 
 const port = Number(process.env.PORT ?? 3000);

--- a/src/routes/pulsevault.ts
+++ b/src/routes/pulsevault.ts
@@ -36,6 +36,8 @@ export type PulseVaultAuthorizePhase =
 export type PulseVaultAuthorizeContext = {
   phase: PulseVaultAuthorizePhase;
   videoid: string;
+  /** Bearer / query-string token forwarded from the watch URL, if present. Only populated during the `"resolve"` phase. */
+  token?: string;
 };
 
 export type PulseVaultAuthorize = (
@@ -195,6 +197,16 @@ const videoGetSchema: OpenApiRouteSchema = {
       },
     },
     required: ["videoid"],
+  },
+  querystring: {
+    type: "object",
+    properties: {
+      token: {
+        type: "string",
+        description:
+          "Optional bearer token for pre-authenticated watch links. Forwarded to the `authorize` hook as `ctx.token` so parent servers can validate it without a separate login step.",
+      },
+    },
   },
   response: {
     400: {
@@ -387,12 +399,15 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
 
     request.pulseVault = { videoid };
 
+    // Extract the optional token forwarded by the mobile app in the watch URL.
+    const token = (request.query as { token?: string })?.token;
+
     // Run authorize *before* resolve so consumers can reject without the
     // response leaking "this videoid exists but you don't own it" vs. "no such
     // videoid".
     if (authorize) {
       try {
-        await authorize(request, { phase: "resolve", videoid });
+        await authorize(request, { phase: "resolve", videoid, token });
       } catch (err) {
         const statusCode = extractAuthzStatus(err);
         const message = extractAuthzMessage(err);


### PR DESCRIPTION
**Demo:**
https://youtube.com/shorts/7mj40VDqUBc


**Changes**
- `src/routes/pulsevault.ts`
  - `PulseVaultAuthorizeContext` gains `token?: string` — populated from `?token=` query param on `GET /:videoid` during the `"resolve"` phase
  - `videoGetSchema` documents the optional `token` querystring field (Swagger)

- `examples/rn-demo/server.mjs`
  - `SESSION_TOKEN` (random UUID) generated at startup; printed to console
  - In-memory `tokenStore` (`Map<videoid, token>`) — no DB required
  - `authorize` hook: on `"create"` registers the videoid if the Bearer token matches `SESSION_TOKEN`; on `"resolve"` rejects with `403` if the videoid is token-protected and the token doesn't match
  - New `GET /deeplinks-token` endpoint — returns a `configure-destination` QR with `SESSION_TOKEN` embedded (same shape as Section 1, no videoid)
  - `GET /videos` includes `token` in the response for token-protected entries

- `examples/rn-demo/public/index.html`
  - **Section 3** card — "Save this server with token" configure-destination QR for testing token auth end-to-end
  - Video list appends `?token=...` to the `<video src>` for token-protected uploads and shows a 🔒 badge