### PR TITLE
Remove configure-destination deeplink and destination management

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,29 +331,19 @@ const storage: PulseVaultStorage = {
 };
 ```
 
-## Deep link helpers
+## Deep link helper
 
-Use these to generate `pulsecam://` deep links for pairing the Pulse mobile app with your server. Typically encoded as QR codes on a pairing page.
+Use this to generate a `pulsecam://` deep link for pairing the Pulse mobile app with your server. Typically encoded as a QR code on a pairing page.
 
 ```ts
-import {
-  buildConfigureDestinationLink,
-  buildUploadLink,
-} from "@mieweb/pulsevault";
+import { buildUploadLink } from "@mieweb/pulsevault";
 import { randomUUID } from "node:crypto";
-
-// Adds this server as a saved destination in the Pulse app.
-const configureLink = buildConfigureDestinationLink({
-  server: "https://example.com",
-  name: "My Server", // optional — shown in the app's destination list
-  token: "secret", // optional — forwarded to your authorize hook
-});
 
 // Opens the app directly on the upload screen for a specific video.
 const uploadLink = buildUploadLink({
   server: "https://example.com",
   videoid: randomUUID(), // generate server-side; skip POST /reserve on the app
-  token: "secret", // optional
+  token: "secret", // optional — forwarded to your authorize hook
 });
 ```
 

--- a/examples/rn-demo/public/index.html
+++ b/examples/rn-demo/public/index.html
@@ -80,8 +80,7 @@
       <strong>How to use</strong>
       <ol>
         <li>Make sure the Pulse app is on <strong>version 1.1.2 Build 3</strong> or higher.</li>
-        <li>Scan the <em>Save server</em> QR — it adds "Demo Server" to your Pulse destinations.</li>
-        <li>To upload a specific draft: scan the <em>Upload draft</em> QR and follow the prompt in the app.</li>
+        <li>Scan the <em>Upload draft</em> QR below — it opens the app pointed at this server with a fresh draft ready to upload.</li>
         <li><span style="color:#8b949e;font-size:0.75rem;">(local only)</span> Make sure your phone is on the <strong>same WiFi</strong> as this computer.</li>
         <li><span style="color:#8b949e;font-size:0.75rem;">(local only)</span> Open this page from your phone's browser using your laptop's IP address.</li>
       </ol>
@@ -89,27 +88,7 @@
     </div>
 
     <div class="card">
-      <strong>1 — Save this server in the app</strong>
-
-      <label style="margin-top:0.75rem;">Server</label>
-      <p class="mono" id="serverUrl"></p>
-
-      <hr class="divider" />
-
-      <p style="font-size:0.875rem; color:#8b949e; margin:0 0 0.5rem;">
-        Scan from your phone's camera app, or tap the button if you're on the same device:
-      </p>
-
-      <img id="qrConfigure" width="224" height="224" style="display:block;margin:1.25rem auto;border-radius:8px;background:#fff;padding:10px;" />
-
-      <a id="openBtnConfigure" class="open-btn" href="#">Open in Pulse App</a>
-
-      <label>Deep link</label>
-      <p class="mono" id="deeplinkConfigure"></p>
-    </div>
-
-    <div class="card">
-      <strong>2 — Upload a specific draft</strong>
+      <strong>Upload a specific draft</strong>
       <p style="font-size:0.875rem; color:#8b949e; margin:0.5rem 0 0;">
         Each QR is tied to one draft. Scan it in the app to open that draft's upload screen pointed at this server.
       </p>
@@ -128,36 +107,14 @@
         ↻ New draft QR
       </button>
 
+      <label>Server</label>
+      <p class="mono" id="serverUrl"></p>
+
       <label>Video ID</label>
       <p class="mono" id="uploadVideoid"></p>
 
       <label>Deep link</label>
       <p class="mono" id="deeplinkUpload"></p>
-    </div>
-
-    <div class="card" style="border-color:#1f6feb;">
-      <strong>3 — Save this server <em>with token</em> <span style="font-size:0.75rem;color:#1f6feb;font-weight:400;">(auth demo)</span></strong>
-      <p style="font-size:0.875rem; color:#8b949e; margin:0.5rem 0 0;">
-        Scan this QR to save the server <strong>with a session token</strong> in the app.
-        Any video you upload using that saved destination will be token-protected:
-        the watch link will include the token, and the server will reject playback without it.
-      </p>
-
-      <hr class="divider" />
-
-      <p style="font-size:0.875rem; color:#8b949e; margin:0 0 0.5rem;">
-        Scan from your phone's camera app, or tap the button if you're on the same device:
-      </p>
-
-      <img id="qrConfigureToken" width="224" height="224" style="display:block;margin:1.25rem auto;border-radius:8px;background:#fff;padding:10px;" />
-
-      <a id="openBtnConfigureToken" class="open-btn" style="background:#1f6feb;" href="#">Save server with token in Pulse App</a>
-
-      <label>Session Token <span style="color:#6e7681;">(verified on every watch request)</span></label>
-      <p class="mono" id="sessionToken"></p>
-
-      <label>Deep link</label>
-      <p class="mono" id="deeplinkConfigureToken"></p>
     </div>
 
     <div class="card">
@@ -175,29 +132,13 @@
         const data = await fetch("/deeplinks").then((r) => r.json());
 
         document.getElementById("serverUrl").textContent = window.location.origin;
-
-        document.getElementById("deeplinkConfigure").textContent = data.configureDestination;
-        document.getElementById("openBtnConfigure").href = data.configureDestination;
-
         document.getElementById("uploadVideoid").textContent = data.videoid;
         document.getElementById("deeplinkUpload").textContent = data.upload;
         document.getElementById("openBtnUpload").href = data.upload;
-
-        document.getElementById("qrConfigure").src = data.qrConfigure;
         document.getElementById("qrUpload").src = data.qrUpload;
       }
 
-      async function loadTokenDeeplinks() {
-        const data = await fetch("/deeplinks-token").then((r) => r.json());
-
-        document.getElementById("sessionToken").textContent = data.token;
-        document.getElementById("deeplinkConfigureToken").textContent = data.configureDestination;
-        document.getElementById("openBtnConfigureToken").href = data.configureDestination;
-        document.getElementById("qrConfigureToken").src = data.qrConfigure;
-      }
-
       loadDeeplinks();
-      loadTokenDeeplinks();
       document.getElementById("refreshUpload").addEventListener("click", loadDeeplinks);
 
       function formatSize(bytes) {
@@ -216,8 +157,8 @@
         }
         list.innerHTML = videos.map((v) => `
           <div style="margin-bottom:1rem;padding-bottom:1rem;border-bottom:1px solid #30363d;">
-            <video src="/${v.videoid}${v.token ? '?token=' + encodeURIComponent(v.token) : ''}" controls preload="metadata" style="width:100%;max-height:26rem;border-radius:6px;background:#000;display:block;object-fit:contain;"></video>
-            <p class="mono" style="margin:0.4rem 0 0;">${v.filename}${v.token ? ' <span style="color:#1f6feb;">🔒 token-protected</span>' : ''}</p>
+            <video src="/${v.videoid}" controls preload="metadata" style="width:100%;max-height:26rem;border-radius:6px;background:#000;display:block;object-fit:contain;"></video>
+            <p class="mono" style="margin:0.4rem 0 0;">${v.filename}</p>
             <p class="mono" style="margin:0.15rem 0 0;color:#6e7681;">${formatSize(v.size)} • ${new Date(v.creation_date).toLocaleString()}</p>
             <p class="mono" style="margin:0.15rem 0 0;color:#6e7681;">${v.videoid}</p>
           </div>

--- a/examples/rn-demo/server.mjs
+++ b/examples/rn-demo/server.mjs
@@ -11,31 +11,12 @@ import QRCode from "qrcode";
 import pulseVault, {
   createLocalStorage,
   createMp4Sniffer,
-  buildConfigureDestinationLink,
   buildUploadLink,
 } from "@mieweb/pulsevault";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const html = readFileSync(path.join(__dirname, "public/index.html"), "utf8");
 const dataDir = path.join(__dirname, "data");
-
-/**
- * In-memory token store: maps videoid → token for token-protected uploads.
- * Populated in the authorize hook during the 'create' phase when the app
- * sends a Bearer token that matches SESSION_TOKEN.
- * No persistence — tokens are lost when the server restarts.
- */
-const tokenStore = new Map();
-
-/**
- * A single server-level session token generated at startup.
- * Embed it in the configure-destination QR so the Pulse app stores it
- * alongside the server URL. Every upload made with that saved destination
- * will include the token as a Bearer header, registering the video as
- * token-protected.
- */
-const SESSION_TOKEN = randomUUID();
-console.log(`[auth] Session token: ${SESSION_TOKEN}`);
 
 const app = Fastify({
   logger: true,
@@ -76,7 +57,7 @@ app.get(
       tags: ["demo"],
       summary: "Pairing page (HTML)",
       description:
-        "Returns the static pairing UI that renders the configure-destination and upload QR codes.",
+        "Returns the static pairing UI that renders the upload QR code.",
       response: {
         200: {
           description: "HTML pairing page.",
@@ -125,7 +106,6 @@ const videoSummarySchema = {
     filename: { type: "string" },
     size: { type: "integer", minimum: 0 },
     creation_date: { type: "string", format: "date-time" },
-    token: { type: "string", description: "Present when this video requires a token to watch." },
   },
   required: ["videoid", "filename", "size", "creation_date"],
 };
@@ -189,7 +169,6 @@ app.get(
             size: mp4Stat.size,
             creation_date:
               meta?.creation_date ?? mp4Stat.birthtime.toISOString(),
-            ...(tokenStore.has(videoid) && { token: tokenStore.get(videoid) }),
           };
         }),
     );
@@ -202,41 +181,29 @@ app.get(
   },
 );
 
-// Return pre-built deep links for the pairing page.
-// draftId and videoid are generated here so the server is the single source of truth.
+// Return a pre-built upload deep link for the pairing page.
+// videoid is generated here so the server is the single source of truth.
 app.get(
   "/deeplinks",
   {
     schema: {
       tags: ["demo"],
-      summary: "Deep links + QR codes for RN pairing",
+      summary: "Upload deep link + QR code for RN pairing",
       description:
-        "Builds a configure-destination link and a videoid-scoped upload link, then encodes both as data-URL PNG QR codes.",
+        "Builds a videoid-scoped upload link and encodes it as a data-URL PNG QR code.",
       response: {
         200: {
-          description: "Deep links and their QR-code renderings.",
+          description: "Deep link and its QR-code rendering.",
           type: "object",
           properties: {
-            configureDestination: { type: "string", format: "uri" },
             upload: { type: "string", format: "uri" },
             videoid: { type: "string", format: "uuid" },
-            qrConfigure: {
-              type: "string",
-              description:
-                "data:image/png;base64 QR for `configureDestination`.",
-            },
             qrUpload: {
               type: "string",
               description: "data:image/png;base64 QR for `upload`.",
             },
           },
-          required: [
-            "configureDestination",
-            "upload",
-            "videoid",
-            "qrConfigure",
-            "qrUpload",
-          ],
+          required: ["upload", "videoid", "qrUpload"],
         },
       },
     },
@@ -247,10 +214,6 @@ app.get(
     const server = `${proto}://${host}`;
     const videoid = randomUUID();
 
-    const configureDestination = buildConfigureDestinationLink({
-      server,
-      name: "Demo Server",
-    });
     const upload = buildUploadLink({ server, videoid });
 
     const qrOpts = {
@@ -258,66 +221,13 @@ app.get(
       margin: 1,
       color: { dark: "#000000", light: "#ffffff" },
     };
-    const [qrConfigure, qrUpload] = await Promise.all([
-      QRCode.toDataURL(configureDestination, qrOpts),
-      QRCode.toDataURL(upload, qrOpts),
-    ]);
+    const qrUpload = await QRCode.toDataURL(upload, qrOpts);
 
     return reply.send({
-      configureDestination,
       upload,
       videoid,
-      qrConfigure,
       qrUpload,
     });
-  },
-);
-
-// Token-protected server-configuration QR: uses buildConfigureDestinationLink
-// (same as Section 1) but embeds SESSION_TOKEN so the Pulse app stores the
-// token alongside the server URL. Uploads made with this saved destination
-// send "Authorization: Bearer <token>", which the authorize hook uses to
-// register the videoid as token-protected before the bytes are written.
-app.get(
-  "/deeplinks-token",
-  {
-    schema: {
-      tags: ["demo"],
-      summary: "Token-protected server-config QR",
-      description:
-        "Returns a configure-destination deep link that embeds the server-level session token. " +
-        "Scanning this QR saves the server + token in the app. Any subsequent upload from that " +
-        "saved destination will be token-protected: the server registers the videoid in its token " +
-        "store and rejects watch requests that omit the correct token.",
-      response: {
-        200: {
-          description: "Token-scoped configure-destination link and QR code.",
-          type: "object",
-          properties: {
-            configureDestination: { type: "string", format: "uri" },
-            token: { type: "string", description: "The session token embedded in the QR." },
-            qrConfigure: { type: "string", description: "data:image/png;base64 QR for the token-scoped configure-destination link." },
-          },
-          required: ["configureDestination", "token", "qrConfigure"],
-        },
-      },
-    },
-  },
-  async (req, reply) => {
-    const proto = req.headers["x-forwarded-proto"] ?? "http";
-    const host = req.headers["x-forwarded-host"] ?? req.headers.host;
-    const server = `${proto}://${host}`;
-
-    const configureDestination = buildConfigureDestinationLink({
-      server,
-      name: "Demo Server (Token Auth)",
-      token: SESSION_TOKEN,
-    });
-
-    const qrOpts = { width: 224, margin: 1, color: { dark: "#000000", light: "#ffffff" } };
-    const qrConfigure = await QRCode.toDataURL(configureDestination, qrOpts);
-
-    return reply.send({ configureDestination, token: SESSION_TOKEN, qrConfigure });
   },
 );
 
@@ -332,45 +242,13 @@ await app.register(pulseVault, {
   validatePayload: createMp4Sniffer(pulseStorage),
   /**
    * Authorization hook — called before every create/patch/resolve/delete.
+   * This demo server has no real auth store and accepts all requests.
    *
-   * For the "resolve" phase the mobile app forwards any upload token as
-   * `?token=<value>` in the watch URL; the plugin surfaces it here as
-   * `ctx.token` so the parent server can validate it without a separate
-   * browser login.
-   *
-   * This demo server has no real auth store, so it accepts all requests.
-   * A production deployment would look up the token in a DB/session store
-   * and throw to reject (e.g. `throw { statusCode: 403, message: "Forbidden" }`).
+   * TODO: plug real auth here — sessions, JWT, mTLS, etc. Throw to reject,
+   * e.g. `throw { statusCode: 403, message: "Forbidden" }`.
    */
-  authorize: async (request, ctx) => {
-    if (ctx.phase === "create") {
-      // When the app uploads using the token-protected saved destination it
-      // sends "Authorization: Bearer <SESSION_TOKEN>". Register this videoid
-      // in the token store so the resolve phase can protect it.
-      const authHeader = request.headers["authorization"];
-      const bearer = typeof authHeader === "string" && authHeader.startsWith("Bearer ")
-        ? authHeader.slice(7)
-        : undefined;
-      if (bearer !== undefined && bearer === SESSION_TOKEN) {
-        tokenStore.set(ctx.videoid, SESSION_TOKEN);
-        app.log.info(
-          { videoid: ctx.videoid },
-          "pulsevault authorize: token-protected videoid registered",
-        );
-      }
-    } else if (ctx.phase === "resolve") {
-      const expectedToken = tokenStore.get(ctx.videoid);
-      if (expectedToken !== undefined) {
-        // This videoid requires a token to watch.
-        if (ctx.token !== expectedToken) {
-          throw { statusCode: 403, message: "Invalid or missing watch token" };
-        }
-        app.log.info(
-          { videoid: ctx.videoid },
-          "pulsevault authorize: token-protected watch request verified",
-        );
-      }
-    }
+  authorize: async (_request, _ctx) => {
+    // no-op
   },
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -190,11 +190,5 @@ export type {
 export type { PulseVaultOnUploadComplete } from "./lib/pulsevaultTus.js";
 export { sniffMp4, createMp4Sniffer } from "./lib/magic.js";
 export type { PulseVaultValidatePayload } from "./lib/magic.js";
-export {
-  buildConfigureDestinationLink,
-  buildUploadLink,
-} from "./lib/deeplinks.js";
-export type {
-  ConfigureDestinationLinkOptions,
-  UploadLinkOptions,
-} from "./lib/deeplinks.js";
+export { buildUploadLink } from "./lib/deeplinks.js";
+export type { UploadLinkOptions } from "./lib/deeplinks.js";

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -1,12 +1,3 @@
-export type ConfigureDestinationLinkOptions = {
-  /** Full origin of the PulseVault server, e.g. `https://example.com` or `http://192.168.1.10:3030`. */
-  server: string;
-  /** Opaque token forwarded to the server's `authorize` hook. Omit for unauthenticated servers. */
-  token?: string;
-  /** Human-readable name shown in the Pulse app's destination list. Defaults to the server hostname. */
-  name?: string;
-};
-
 export type UploadLinkOptions = {
   /** Full origin of the PulseVault server. */
   server: string;
@@ -19,20 +10,6 @@ export type UploadLinkOptions = {
    */
   videoid: string;
 };
-
-/**
- * Build a `pulsecam://` deep link that adds this server as a saved upload
- * destination in the Pulse app. No server request is made when the link is
- * opened — the app stores the config locally.
- */
-export function buildConfigureDestinationLink(
-  opts: ConfigureDestinationLinkOptions,
-): string {
-  const params = new URLSearchParams({ mode: "configure_destination", server: opts.server });
-  if (opts.token) params.set("token", opts.token);
-  if (opts.name) params.set("name", opts.name);
-  return `pulsecam://?${params.toString()}`;
-}
 
 /**
  * Build a `pulsecam://` deep link that opens the Pulse app directly on the


### PR DESCRIPTION
Drop the `configure_destination` deeplink flow end-to-end: the public API surface (`buildConfigureDestinationLink`, `ConfigureDestinationLinkOptions`), the rn-demo server's destination-list UI, and the README sections describing saved destinations. The Pulse app now stores upload server config per-draft at deeplink scan time, so a separate destination registry is no longer needed.