### PR TITLE
Simplify rn-demo and add opt-in auth proof-of-concept

### DIFF
--- a/examples/rn-demo/public/index.html
+++ b/examples/rn-demo/public/index.html
@@ -3,109 +3,44 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Pulse — Connect Your Phone</title>
+    <title>PulseVault demo</title>
     <style>
-      :root {
-        font-family: system-ui, sans-serif;
-        background: #0f1419;
-        color: #e6edf3;
-      }
-      body {
-        max-width: 44rem;
-        margin: 2rem auto;
-        padding: 0 1rem;
-        line-height: 1.5;
-      }
-      h1 {
-        font-size: 1.25rem;
-        font-weight: 600;
-      }
-      .card {
-        background: #161b22;
-        border: 1px solid #30363d;
-        border-radius: 8px;
-        padding: 1rem 1.25rem;
-        margin-top: 1rem;
-      }
-      .open-btn {
-        display: block;
-        padding: 0.6rem 1.2rem;
-        font-size: 0.9rem;
-        font-weight: 600;
-        color: #fff;
-        background: #238636;
-        border-radius: 6px;
-        text-align: center;
-        text-decoration: none;
-        margin-bottom: 0.75rem;
-      }
-      .open-btn:hover {
-        background: #2ea043;
-      }
-      .mono {
-        font-family: ui-monospace, monospace;
-        font-size: 0.75rem;
-        word-break: break-all;
-        color: #8b949e;
-      }
-      label {
-        display: block;
-        font-size: 0.875rem;
-        color: #8b949e;
-        margin-bottom: 0.25rem;
-      }
-      ol {
-        padding-left: 1.25rem;
-        margin: 0.5rem 0 0;
-      }
-      li {
-        margin-bottom: 0.5rem;
-        font-size: 0.9rem;
-      }
-      .divider {
-        border: none;
-        border-top: 1px solid #30363d;
-        margin: 1rem 0;
-      }
+      :root { font-family: system-ui, sans-serif; background: #0f1419; color: #e6edf3; }
+      body { max-width: 44rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
+      h1 { font-size: 1.25rem; font-weight: 600; margin: 0; }
+      .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 1rem 1.25rem; margin-top: 1rem; }
+      .open-btn { display: block; padding: 0.6rem 1.2rem; font-size: 0.9rem; font-weight: 600; color: #fff; background: #238636; border-radius: 6px; text-align: center; text-decoration: none; margin-bottom: 0.75rem; }
+      .open-btn:hover { background: #2ea043; }
+      .mono { font-family: ui-monospace, monospace; font-size: 0.75rem; word-break: break-all; color: #8b949e; }
+      label { display: block; font-size: 0.875rem; color: #8b949e; margin-bottom: 0.25rem; }
+      .ghost-btn { display: block; width: 100%; padding: 0.5rem; margin-bottom: 0.75rem; font-size: 0.875rem; background: #161b22; color: #8b949e; border: 1px solid #30363d; border-radius: 6px; cursor: pointer; }
+      .top-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+      .docs-link { display: inline-block; margin: 0; padding: 0.35rem 0.7rem; font-size: 0.75rem; background: #1f6feb; color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600; }
+      .auth-badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.7rem; font-weight: 600; background: #1f2937; border: 1px solid #30363d; color: #8b949e; }
+      .auth-badge.on { background: #1d3a1d; border-color: #2ea043; color: #b9e6b9; }
     </style>
   </head>
   <body>
-    <div style="display:flex;align-items:center;justify-content:space-between;gap:1rem;">
-      <h1 style="margin:0;">Pulse — Connect Your Phone</h1>
-      <a href="/docs" class="open-btn" style="display:inline-block;margin:0;padding:0.35rem 0.7rem;font-size:0.75rem;background:#1f6feb;">API Docs →</a>
+    <div class="top-row">
+      <h1>PulseVault demo</h1>
+      <a href="/docs" class="docs-link">API Docs →</a>
     </div>
-    <p>Pair the Pulse app with this local demo server to upload videos over your WiFi network.</p>
+    <p style="font-size: 0.9rem; color: #8b949e;">
+      <span id="authBadge" class="auth-badge">auth: off</span>
+      Pair the Pulse app with this demo server and upload a video.
+    </p>
 
     <div class="card">
-      <strong>How to use</strong>
-      <ol>
-        <li>Make sure the Pulse app is on <strong>version 1.1.2 Build 3</strong> or higher.</li>
-        <li>Scan the <em>Upload draft</em> QR below — it opens the app pointed at this server with a fresh draft ready to upload.</li>
-        <li><span style="color:#8b949e;font-size:0.75rem;">(local only)</span> Make sure your phone is on the <strong>same WiFi</strong> as this computer.</li>
-        <li><span style="color:#8b949e;font-size:0.75rem;">(local only)</span> Open this page from your phone's browser using your laptop's IP address.</li>
-      </ol>
-      <p style="font-size:0.75rem;color:#8b949e;margin:0.5rem 0 0;">Steps marked <em>local only</em> apply when running this demo on your laptop. Skip them if the server is deployed publicly.</p>
-    </div>
-
-    <div class="card">
-      <strong>Upload a specific draft</strong>
-      <p style="font-size:0.875rem; color:#8b949e; margin:0.5rem 0 0;">
-        Each QR is tied to one draft. Scan it in the app to open that draft's upload screen pointed at this server.
+      <strong>Upload</strong>
+      <p style="font-size: 0.875rem; color: #8b949e; margin: 0.5rem 0 0;">
+        Each scan opens the chooser in the Pulse app: record a new video, or
+        pick an existing draft to upload to this server.
       </p>
 
-      <hr class="divider" />
+      <img id="qrUpload" width="224" height="224" style="display: block; margin: 1.25rem auto; border-radius: 8px; background: #fff; padding: 10px;" />
 
-      <p style="font-size:0.875rem; color:#8b949e; margin:0 0 0.5rem;">
-        Scan from your phone's camera app, or tap the button if you're on the same device:
-      </p>
-
-      <img id="qrUpload" width="224" height="224" style="display:block;margin:1.25rem auto;border-radius:8px;background:#fff;padding:10px;" />
-
-      <a id="openBtnUpload" class="open-btn" href="#">Open in Pulse App</a>
-
-      <button id="refreshUpload" style="display:block;width:100%;padding:0.5rem;margin-bottom:0.75rem;font-size:0.875rem;background:#161b22;color:#8b949e;border:1px solid #30363d;border-radius:6px;cursor:pointer;">
-        ↻ New draft QR
-      </button>
+      <a id="openBtnUpload" class="open-btn" href="#">Open in Pulse app</a>
+      <button id="refreshUpload" class="ghost-btn">↻ New QR</button>
 
       <label>Server</label>
       <p class="mono" id="serverUrl"></p>
@@ -117,13 +52,24 @@
       <p class="mono" id="deeplinkUpload"></p>
     </div>
 
+    <div id="authHelp" class="card" hidden>
+      <strong>Auth demo enabled</strong>
+      <p style="font-size: 0.875rem; color: #8b949e; margin: 0.5rem 0 0;">
+        This server requires a bearer token for every upload and watch request.
+        The QR above embeds it, so the Pulse app handles auth automatically.
+        Tampering with the token in the deeplink should produce a 403 from
+        <code>authorize</code>. To disable, restart the server without
+        <code>DEMO_TOKEN</code> set.
+      </p>
+    </div>
+
     <div class="card">
-      <div style="display:flex;align-items:center;justify-content:space-between;">
-        <strong>Uploaded Videos</strong>
-        <button id="refreshVideos" style="padding:0.3rem 0.7rem;font-size:0.75rem;background:#161b22;color:#8b949e;border:1px solid #30363d;border-radius:6px;cursor:pointer;">↻ Refresh</button>
+      <div class="top-row">
+        <strong>Uploads</strong>
+        <button id="refreshVideos" class="ghost-btn" style="width: auto; margin: 0; padding: 0.3rem 0.7rem;">↻ Refresh</button>
       </div>
-      <div id="videoList" style="margin-top:0.75rem;max-height:48rem;overflow-y:auto;padding-right:0.25rem;">
-        <p id="videoListEmpty" class="mono" style="color:#8b949e;">Loading…</p>
+      <div id="videoList" style="margin-top: 0.75rem; max-height: 48rem; overflow-y: auto; padding-right: 0.25rem;">
+        <p class="mono">Loading…</p>
       </div>
     </div>
 
@@ -136,10 +82,12 @@
         document.getElementById("deeplinkUpload").textContent = data.upload;
         document.getElementById("openBtnUpload").href = data.upload;
         document.getElementById("qrUpload").src = data.qrUpload;
-      }
 
-      loadDeeplinks();
-      document.getElementById("refreshUpload").addEventListener("click", loadDeeplinks);
+        const badge = document.getElementById("authBadge");
+        badge.textContent = data.authMode ? "auth: on" : "auth: off";
+        badge.classList.toggle("on", data.authMode);
+        document.getElementById("authHelp").hidden = !data.authMode;
+      }
 
       function formatSize(bytes) {
         const units = ["B", "KB", "MB", "GB"];
@@ -152,20 +100,22 @@
         const list = document.getElementById("videoList");
         const videos = await fetch("/videos").then((r) => r.json());
         if (!videos.length) {
-          list.innerHTML = '<p class="mono" style="color:#8b949e;">No uploads yet.</p>';
+          list.innerHTML = '<p class="mono">No uploads yet.</p>';
           return;
         }
         list.innerHTML = videos.map((v) => `
-          <div style="margin-bottom:1rem;padding-bottom:1rem;border-bottom:1px solid #30363d;">
-            <video src="/${v.videoid}" controls preload="metadata" style="width:100%;max-height:26rem;border-radius:6px;background:#000;display:block;object-fit:contain;"></video>
-            <p class="mono" style="margin:0.4rem 0 0;">${v.filename}</p>
-            <p class="mono" style="margin:0.15rem 0 0;color:#6e7681;">${formatSize(v.size)} • ${new Date(v.creation_date).toLocaleString()}</p>
-            <p class="mono" style="margin:0.15rem 0 0;color:#6e7681;">${v.videoid}</p>
+          <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #30363d;">
+            <video src="/${v.videoid}" controls preload="metadata" style="width: 100%; max-height: 26rem; border-radius: 6px; background: #000; display: block; object-fit: contain;"></video>
+            <p class="mono" style="margin: 0.4rem 0 0;">${v.filename}</p>
+            <p class="mono" style="margin: 0.15rem 0 0; color: #6e7681;">${formatSize(v.size)} • ${new Date(v.creation_date).toLocaleString()}</p>
+            <p class="mono" style="margin: 0.15rem 0 0; color: #6e7681;">${v.videoid}</p>
           </div>
         `).join("");
       }
 
+      loadDeeplinks();
       loadVideos();
+      document.getElementById("refreshUpload").addEventListener("click", loadDeeplinks);
       document.getElementById("refreshVideos").addEventListener("click", loadVideos);
     </script>
   </body>

--- a/examples/rn-demo/server.mjs
+++ b/examples/rn-demo/server.mjs
@@ -18,237 +18,136 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const html = readFileSync(path.join(__dirname, "public/index.html"), "utf8");
 const dataDir = path.join(__dirname, "data");
 
+// Set DEMO_TOKEN to enable the auth demo: every upload + watch is verified
+// against this token. Leave unset for an open demo with no authentication.
+const DEMO_TOKEN = process.env.DEMO_TOKEN || null;
+
 const app = Fastify({
   logger: true,
   bodyLimit: 16 * 1024 * 1024, // max single PATCH chunk (RN app sends 1 MB chunks)
 });
 
-// Swagger MUST be registered before any route (including the plugin's) so
-// their schemas are picked up for the generated OpenAPI spec.
 await app.register(fastifySwagger, {
   openapi: {
     openapi: "3.0.3",
     info: {
-      title: "PulseVault Fastify",
-      description:
-        "Reference server pairing the React Native demo app with `@mieweb/pulsevault`.",
+      title: "PulseVault demo",
+      description: "Reference server pairing the Pulse RN app with @mieweb/pulsevault.",
       version: "0.0.1",
     },
-    tags: [
-      { name: "demo", description: "RN demo server endpoints" },
-      {
-        name: "pulsevault",
-        description: "Routes contributed by the `@mieweb/pulsevault` plugin",
-      },
-    ],
   },
 });
-
 await app.register(fastifySwaggerUI, {
   routePrefix: "/docs",
   uiConfig: { docExpansion: "list", deepLinking: false },
 });
 
-// Serve pairing page before the plugin so it isn't swallowed by /:videoid
-app.get(
-  "/",
-  {
-    schema: {
-      tags: ["demo"],
-      summary: "Pairing page (HTML)",
-      description:
-        "Returns the static pairing UI that renders the upload QR code.",
-      response: {
-        200: {
-          description: "HTML pairing page.",
-          type: "string",
-        },
-      },
-    },
-  },
-  (_req, reply) => reply.type("text/html").send(html),
-);
+// Pairing page — registered before the plugin so it isn't swallowed by /:videoid
+app.get("/", (_req, reply) => reply.type("text/html").send(html));
 
-// Reserve a videoid for an upload. The server owns ID generation so it can
-// later attach auth tokens, quotas, or other server-side state here.
-app.post(
-  "/reserve",
-  {
-    schema: {
-      tags: ["demo"],
-      summary: "Reserve a new videoid",
-      description:
-        "Generates a fresh UUID for the client to use as the `videoid` metadata entry on its TUS upload.",
-      response: {
-        200: {
-          description: "A newly minted videoid.",
-          type: "object",
-          properties: {
-            videoid: { type: "string", format: "uuid" },
-          },
-          required: ["videoid"],
-        },
-      },
-    },
-  },
-  async (_req, reply) => {
-    const videoid = randomUUID();
-    return reply.send({ videoid });
-  },
-);
+// One deeplink + matching QR per request. videoid is generated server-side so
+// it stays the source of truth.
+app.get("/deeplinks", async (req, reply) => {
+  const proto = req.headers["x-forwarded-proto"] ?? "http";
+  const host = req.headers["x-forwarded-host"] ?? req.headers.host;
+  const server = `${proto}://${host}`;
+  const videoid = randomUUID();
 
-// List all uploaded videos under dataDir. The TUS file-store layout is
-// data/<videoid>/video/<videoid>.<ext>(+ .json sidecar with metadata).
-const videoSummarySchema = {
-  type: "object",
-  properties: {
-    videoid: { type: "string", format: "uuid" },
-    filename: { type: "string" },
-    size: { type: "integer", minimum: 0 },
-    creation_date: { type: "string", format: "date-time" },
-  },
-  required: ["videoid", "filename", "size", "creation_date"],
-};
+  const upload = buildUploadLink({
+    server,
+    videoid,
+    ...(DEMO_TOKEN && { token: DEMO_TOKEN }),
+  });
 
-app.get(
-  "/videos",
-  {
-    schema: {
-      tags: ["demo"],
-      summary: "List previously uploaded videos",
-      description:
-        "Enumerates completed uploads on disk by scanning the local data directory.",
-      response: {
-        200: {
-          description: "Videos sorted by creation time, newest first.",
-          type: "array",
-          items: videoSummarySchema,
-        },
-      },
-    },
-  },
-  async (_req, reply) => {
-    let entries;
-    try {
-      entries = await readdir(dataDir, { withFileTypes: true });
-    } catch (err) {
-      if (err.code === "ENOENT") return reply.send([]);
-      throw err;
-    }
+  const qrUpload = await QRCode.toDataURL(upload, {
+    width: 224,
+    margin: 1,
+    color: { dark: "#000000", light: "#ffffff" },
+  });
 
-    const videos = await Promise.all(
-      entries
-        .filter((e) => e.isDirectory())
-        .map(async (e) => {
-          const videoid = e.name;
-          const videoDir = path.join(dataDir, videoid, "video");
-          let files;
-          try {
-            files = await readdir(videoDir);
-          } catch {
-            return null;
-          }
-          const mp4 = files.find(
-            (f) => f.endsWith(".mp4") && !f.endsWith(".mp4.json"),
-          );
-          if (!mp4) return null;
+  return reply.send({
+    upload,
+    videoid,
+    qrUpload,
+    authMode: Boolean(DEMO_TOKEN),
+  });
+});
 
-          const mp4Path = path.join(videoDir, mp4);
-          const jsonPath = `${mp4Path}.json`;
-          const [mp4Stat, meta] = await Promise.all([
-            stat(mp4Path).catch(() => null),
-            readFile(jsonPath, "utf8")
-              .then(JSON.parse)
-              .catch(() => null),
-          ]);
-          if (!mp4Stat || mp4Stat.size === 0) return null;
+// List uploaded videos by scanning the on-disk TUS layout: data/<videoid>/video/<videoid>.mp4 + .json sidecar.
+app.get("/videos", async (_req, reply) => {
+  let entries;
+  try {
+    entries = await readdir(dataDir, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === "ENOENT") return reply.send([]);
+    throw err;
+  }
 
-          return {
-            videoid,
-            filename: meta?.metadata?.filename ?? mp4,
-            size: mp4Stat.size,
-            creation_date:
-              meta?.creation_date ?? mp4Stat.birthtime.toISOString(),
-          };
-        }),
-    );
+  const videos = await Promise.all(
+    entries
+      .filter((e) => e.isDirectory())
+      .map(async (e) => {
+        const videoid = e.name;
+        const videoDir = path.join(dataDir, videoid, "video");
+        let files;
+        try {
+          files = await readdir(videoDir);
+        } catch {
+          return null;
+        }
+        const mp4 = files.find((f) => f.endsWith(".mp4") && !f.endsWith(".mp4.json"));
+        if (!mp4) return null;
 
-    return reply.send(
-      videos
-        .filter(Boolean)
-        .sort((a, b) => b.creation_date.localeCompare(a.creation_date)),
-    );
-  },
-);
+        const mp4Path = path.join(videoDir, mp4);
+        const [mp4Stat, meta] = await Promise.all([
+          stat(mp4Path).catch(() => null),
+          readFile(`${mp4Path}.json`, "utf8").then(JSON.parse).catch(() => null),
+        ]);
+        if (!mp4Stat || mp4Stat.size === 0) return null;
 
-// Return a pre-built upload deep link for the pairing page.
-// videoid is generated here so the server is the single source of truth.
-app.get(
-  "/deeplinks",
-  {
-    schema: {
-      tags: ["demo"],
-      summary: "Upload deep link + QR code for RN pairing",
-      description:
-        "Builds a videoid-scoped upload link and encodes it as a data-URL PNG QR code.",
-      response: {
-        200: {
-          description: "Deep link and its QR-code rendering.",
-          type: "object",
-          properties: {
-            upload: { type: "string", format: "uri" },
-            videoid: { type: "string", format: "uuid" },
-            qrUpload: {
-              type: "string",
-              description: "data:image/png;base64 QR for `upload`.",
-            },
-          },
-          required: ["upload", "videoid", "qrUpload"],
-        },
-      },
-    },
-  },
-  async (req, reply) => {
-    const proto = req.headers["x-forwarded-proto"] ?? "http";
-    const host = req.headers["x-forwarded-host"] ?? req.headers.host;
-    const server = `${proto}://${host}`;
-    const videoid = randomUUID();
+        return {
+          videoid,
+          filename: meta?.metadata?.filename ?? mp4,
+          size: mp4Stat.size,
+          creation_date: meta?.creation_date ?? mp4Stat.birthtime.toISOString(),
+        };
+      }),
+  );
 
-    const upload = buildUploadLink({ server, videoid });
+  return reply.send(
+    videos.filter(Boolean).sort((a, b) => b.creation_date.localeCompare(a.creation_date)),
+  );
+});
 
-    const qrOpts = {
-      width: 224,
-      margin: 1,
-      color: { dark: "#000000", light: "#ffffff" },
-    };
-    const qrUpload = await QRCode.toDataURL(upload, qrOpts);
-
-    return reply.send({
-      upload,
-      videoid,
-      qrUpload,
-    });
-  },
-);
-
-// Mount plugin at root prefix so TUS is at POST /upload and video GET is at /:videoid
+// Mount the plugin at root so TUS is at POST /upload and watch is GET /:videoid
 const pulseStorage = createLocalStorage({ workspaceDir: dataDir });
 await app.register(pulseVault, {
   prefix: "",
   storage: pulseStorage,
   maxUploadSize: 5 * 1024 * 1024 * 1024, // 5 GiB
   allowedExtensions: [".mp4"],
-  // Reject anything that doesn't look like an MP4 at the final PATCH.
   validatePayload: createMp4Sniffer(pulseStorage),
+
   /**
-   * Authorization hook — called before every create/patch/resolve/delete.
-   * This demo server has no real auth store and accepts all requests.
+   * authorize hook — the demo's auth proof-of-concept.
    *
-   * TODO: plug real auth here — sessions, JWT, mTLS, etc. Throw to reject,
-   * e.g. `throw { statusCode: 403, message: "Forbidden" }`.
+   * When DEMO_TOKEN is unset (default), this is a no-op and the server accepts
+   * every request. When DEMO_TOKEN is set, every TUS create/patch must carry
+   * `Authorization: Bearer <DEMO_TOKEN>` and every watch must carry
+   * `?token=<DEMO_TOKEN>`. Swap this body with your real auth — sessions, JWT,
+   * mTLS, etc.
    */
-  authorize: async (_request, _ctx) => {
-    // no-op
+  authorize: async (request, ctx) => {
+    if (!DEMO_TOKEN) return;
+
+    const supplied =
+      ctx.phase === "resolve"
+        ? ctx.token
+        : (request.headers.authorization || "").replace(/^Bearer\s+/i, "");
+
+    if (supplied !== DEMO_TOKEN) {
+      throw { statusCode: 403, message: "Forbidden: invalid demo token" };
+    }
   },
 });
 
@@ -256,9 +155,10 @@ const port = Number(process.env.PORT ?? 3000);
 const host = process.env.HOST ?? "0.0.0.0";
 
 await app.listen({ port, host });
-console.log(`\nRN demo server running.`);
-console.log(`Pairing page: http://localhost:${port}/`);
-console.log(`Swagger UI:   http://localhost:${port}/docs`);
-console.log(
-  `From your phone (same WiFi): open http://<your-laptop-ip>:${port}/ in the browser`,
-);
+console.log(`\nPulseVault demo running on http://localhost:${port}/`);
+console.log(`Swagger UI:                   http://localhost:${port}/docs`);
+if (DEMO_TOKEN) {
+  console.log(`Auth demo:                    ON  (DEMO_TOKEN is set)`);
+} else {
+  console.log(`Auth demo:                    off (set DEMO_TOKEN=... to enable)`);
+}


### PR DESCRIPTION
- Drop the /reserve endpoint (dead since deeplinks always carry a videoid) and the per-route Swagger schemas / videoSummarySchema cruft.
- Trim the pairing page to one card: it always represents "scan to upload", matching the new chooser UX in the app.
- Add an opt-in auth demo: set DEMO_TOKEN to enable it. The authorize hook then enforces the token on create/patch (Bearer header) and resolve (?token= query); a status badge on the pairing page reflects current mode.