### PR TITLE
Add S3 / Cloudflare R2 object-storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ type PulseVaultPluginOptions = {
 
 ### `storage`
 
-A `PulseVaultStorage` adapter. Use the built-in `createLocalStorage` for filesystem-backed deployments (the blessed default) or implement the interface for custom backends (S3, GCS, etc.).
+A `PulseVaultStorage` adapter. Use the built-in `createLocalStorage` for filesystem-backed deployments (the blessed default), `createS3Storage` for Cloudflare R2 / AWS S3 (see [Object storage](#object-storage-cloudflare-r2--aws-s3)), or implement the interface for custom backends (GCS, database, etc.).
 
 ### `prefix`
 
@@ -339,6 +339,87 @@ await app.register(pulseVault, {
 
 `@mieweb/artipod` is **not** a dependency of this plugin — install it in your app only if you want it. Any filesystem-native pipeline (ffmpeg, whisper, rsync) works equally well.
 
+## Object storage (Cloudflare R2 / AWS S3)
+
+`createS3Storage` is a built-in adapter that streams uploads into an S3-compatible bucket via S3 multipart upload and serves playback by redirecting the client to a short-lived **presigned URL** (so bytes never flow back through your server). Because Cloudflare R2 speaks the S3 API, the same adapter covers both R2 and AWS S3 — they differ only by endpoint and credentials.
+
+It's **opt-in**: the AWS SDK and `@tus/s3-store` are `optionalDependencies`, loaded lazily only when you call `createS3Storage`. Install them in your app:
+
+```bash
+npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @tus/s3-store
+```
+
+`createS3Storage` is **async** (it lazily imports those packages), so `await` it before registering the plugin.
+
+**Cloudflare R2:**
+
+```ts
+import pulseVault, { createS3Storage, createS3Mp4Sniffer } from "@mieweb/pulsevault";
+
+const storage = await createS3Storage({
+  bucket: "pulse-videos",
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+  accessKeyId: process.env.R2_ACCESS_KEY,
+  secretAccessKey: process.env.R2_SECRET_KEY,
+});
+
+await app.register(pulseVault, {
+  prefix: "/pulsevault",
+  storage,
+  maxUploadSize: 5 * 1024 * 1024 * 1024,
+  validatePayload: createS3Mp4Sniffer(storage), // ranged-read MP4 sniff
+});
+```
+
+**AWS S3** — drop the custom `endpoint` and set `region`:
+
+```ts
+const storage = await createS3Storage({
+  bucket: "pulse-videos",
+  region: "us-east-1",
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+});
+```
+
+Credentials are optional — omit `accessKeyId`/`secretAccessKey` to use the AWS SDK's default credential chain (env vars, IAM role, etc.). **Never hard-code keys; read them from the environment.**
+
+### Object layout
+
+```text
+<bucket>/
+  .pulsevault/<id>.json   # metadata sidecar: { version, ext, filename, status, kind }
+  video/<id><ext>         # finalized video object   (kind="video")
+  project/<id><ext>       # finalized project object (kind="project")
+  <key>.info              # @tus/s3-store multipart bookkeeping (transient)
+```
+
+`resolve()` only returns a presigned URL once the sidecar `status` is `"ready"` (after the final byte lands and `validatePayload` passes), so in-progress or rejected uploads are never served. `getKind(id)` returns the kind without a full resolve.
+
+### Options
+
+| Option | Default | Notes |
+| --- | --- | --- |
+| `bucket` | — | Required. Must already exist. |
+| `endpoint` | — | Custom S3 endpoint (set for R2). Omit for AWS S3. |
+| `region` | `"auto"` when `endpoint` is set | Required for AWS S3. |
+| `accessKeyId` / `secretAccessKey` | SDK default chain | Optional; omit both to use env/IAM credentials. |
+| `sessionToken` | — | Optional STS session token for temporary credentials. |
+| `forcePathStyle` | `true` when `endpoint` is set | R2 and most S3-compatible stores need path-style. |
+| `presignTtlSeconds` | `900` | Lifetime of the playback presigned URL. |
+| `partSize` | computed | Preferred multipart part size (≥ 5 MiB), forwarded to `@tus/s3-store`. |
+| `clientConfig` | — | Advanced: extra `S3ClientConfig` merged into the client. |
+
+> The runnable demo wires these to environment variables — see [`examples/rn-demo/.env.example`](examples/rn-demo/.env.example) for the full list (`STORAGE`, `S3_BUCKET`, `S3_ENDPOINT`, `AWS_REGION`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, …).
+
+### Payload validation on remote storage
+
+The default `createMp4Sniffer` reads a local file path, which doesn't exist for a bucket object. Use **`createS3Mp4Sniffer(storage)`** instead: it fetches the first 12 bytes via a small ranged GET (`storage.readHeader`) and applies the same ISOBMFF `ftyp` check, rejecting non-MP4 uploads with 422 and removing the object — no full download.
+
+### Direct playback & CORS
+
+Because playback is a 302 redirect to a presigned URL, a browser fetching it goes **directly** to R2/S3. If you play back from a web origin, add a bucket CORS rule allowing your origin (`GET`, and `Range` for seeking). Native clients that follow redirects need no CORS.
+
 ## Custom storage adapter
 
 Implement `PulseVaultStorage` to back uploads with any system (S3, GCS, database, etc.):
@@ -423,6 +504,7 @@ Runs a Node `--test` suite against the built plugin. Coverage includes:
 - Legacy sidecars (no `kind` field) default to `"video"` without migration
 - Sidecar corruption recovery
 - `allowedExtensions` object form
+- S3/R2 backend (`createS3Storage`): full resumable upload → presigned-redirect playback, `createS3Mp4Sniffer`, `DELETE`, `kind=project`, run against an in-process [s3rver](https://github.com/jamhall/s3rver) mock (no cloud credentials needed)
 
 ## Accessing storage outside the plugin routes
 

--- a/examples/rn-demo/.env.example
+++ b/examples/rn-demo/.env.example
@@ -1,0 +1,56 @@
+# PulseVault demo server — environment variables.
+#
+# Copy to `.env` and fill in. Load it when starting the server, e.g.:
+#   node --env-file=.env server.mjs
+# (Node 20.6+ supports --env-file.) `.env` is gitignored; never commit secrets.
+
+# ---------------------------------------------------------------------------
+# Demo server
+# ---------------------------------------------------------------------------
+# Port / host the demo listens on.
+PORT=3000
+HOST=0.0.0.0
+# Optional bearer token. When set, every TUS upload must send
+# `Authorization: Bearer <DEMO_TOKEN>` and every watch URL must carry
+# `?token=<DEMO_TOKEN>`. Leave unset for an open demo.
+DEMO_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Storage backend
+# ---------------------------------------------------------------------------
+# "local" (default) stores uploads on disk under ./data.
+# "s3" streams uploads into a Cloudflare R2 / AWS S3 bucket and serves playback
+# via short-lived presigned redirects. S3 mode requires the optional packages:
+#   npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @tus/s3-store
+STORAGE=local
+
+# ---------------------------------------------------------------------------
+# S3 / Cloudflare R2 config (only read when STORAGE=s3)
+# Maps to createS3Storage(...) options in src/storage/s3.ts.
+# ---------------------------------------------------------------------------
+# Target bucket. Required in S3 mode. Must already exist.
+S3_BUCKET=pulse-videos
+
+# Cloudflare R2: set the account endpoint and leave AWS_REGION unset (the
+# adapter defaults region to "auto" when an endpoint is present):
+#   S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com
+# AWS S3: leave S3_ENDPOINT empty and set AWS_REGION instead.
+S3_ENDPOINT=
+AWS_REGION=us-east-1
+
+# Credentials. Optional — omit BOTH to use the AWS SDK default credential chain
+# (standard AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars, IAM role, etc.).
+# Never hard-code real keys.
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+# Optional STS session token for temporary credentials.
+S3_SESSION_TOKEN=
+
+# --- Advanced (all optional) ---
+# Path-style addressing ("true"/"false"). Defaults to true when S3_ENDPOINT is
+# set (R2 and most S3-compatible stores need it).
+S3_FORCE_PATH_STYLE=
+# Lifetime of the playback presigned URL, in seconds. Default 900 (15 min).
+S3_PRESIGN_TTL_SECONDS=900
+# Preferred multipart part size in bytes (must be >= 5 MiB). Default: computed.
+S3_PART_SIZE=

--- a/examples/rn-demo/server.mjs
+++ b/examples/rn-demo/server.mjs
@@ -11,6 +11,8 @@ import QRCode from "qrcode";
 import pulseVault, {
   createLocalStorage,
   createMp4Sniffer,
+  createS3Storage,
+  createS3Mp4Sniffer,
   buildUploadLink,
 } from "@mieweb/pulsevault";
 
@@ -220,16 +222,49 @@ app.get("/deeplinks", async (req, reply) => {
   });
 });
 
+// Storage backend. Defaults to the local filesystem; set STORAGE=s3 to stream
+// uploads into Cloudflare R2 / AWS S3 instead and serve playback via presigned
+// redirects. S3 mode needs the optional packages installed
+// (`@aws-sdk/client-s3 @aws-sdk/s3-request-presigner @tus/s3-store`) and the
+// S3_*/AWS_* env vars below — see `.env.example`. Note: the demo's GET /videos
+// route lists local sidecars only, so it returns [] in S3 mode.
+const useS3 = (process.env.STORAGE || "local").toLowerCase() === "s3";
+const pulseStorage = useS3
+  ? await createS3Storage({
+      bucket: process.env.S3_BUCKET,
+      // Set S3_ENDPOINT for R2 (https://<account>.r2.cloudflarestorage.com);
+      // omit it and set AWS_REGION for AWS S3.
+      endpoint: process.env.S3_ENDPOINT,
+      region: process.env.AWS_REGION,
+      // Credentials are optional — omit both to use the AWS SDK default chain.
+      accessKeyId: process.env.S3_ACCESS_KEY_ID,
+      secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+      sessionToken: process.env.S3_SESSION_TOKEN,
+      // Advanced (all optional): override path-style, presigned URL TTL, part size.
+      ...(process.env.S3_FORCE_PATH_STYLE
+        ? { forcePathStyle: process.env.S3_FORCE_PATH_STYLE === "true" }
+        : {}),
+      ...(process.env.S3_PRESIGN_TTL_SECONDS
+        ? { presignTtlSeconds: Number(process.env.S3_PRESIGN_TTL_SECONDS) }
+        : {}),
+      ...(process.env.S3_PART_SIZE
+        ? { partSize: Number(process.env.S3_PART_SIZE) }
+        : {}),
+    })
+  : createLocalStorage({ workspaceDir: dataDir });
+
 // Mount plugin under /pulsevault so TUS is at POST /pulsevault/upload and video GET is at /pulsevault/:videoid
-const pulseStorage = createLocalStorage({ workspaceDir: dataDir });
 await app.register(pulseVault, {
   prefix: "/pulsevault",
   storage: pulseStorage,
   maxUploadSize: 5 * 1024 * 1024 * 1024, // 5 GiB
   // Accept MP4 videos and Pulse draft bundles (.pulse) + diagnostic zips.
   allowedExtensions: { video: [".mp4"], project: [".pulse", ".zip"] },
-  // Reject non-MP4 bytes on video uploads (magic-byte sniff).
-  validatePayload: createMp4Sniffer(pulseStorage),
+  // Reject non-MP4 bytes on video uploads (magic-byte sniff). The S3 sniffer
+  // does a ranged read of the object; the local one reads the file on disk.
+  validatePayload: useS3
+    ? createS3Mp4Sniffer(pulseStorage)
+    : createMp4Sniffer(pulseStorage),
   // Fired when a project bundle finishes uploading. The bundle is opaque
   // to the plugin — index it, relay it, or leave it for a later request.
   onProjectUploadComplete: async (_req, { videoid, size }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,13 +17,515 @@
       "devDependencies": {
         "@types/node": "^25.6.0",
         "fastify": "^5.8.5",
+        "s3rver": "^3.7.1",
         "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">=18"
       },
+      "optionalDependencies": {
+        "@aws-sdk/client-s3": "^3.1074.0",
+        "@aws-sdk/s3-request-presigner": "^3.1074.0",
+        "@tus/s3-store": "^2.0.4"
+      },
       "peerDependencies": {
         "fastify": "^5.8.5"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.8.tgz",
+      "integrity": "sha512-v0U9S7gBIme3OTgt1LdbAF4RpvavCc+4GK1+1xqAcqtbrHsEhjQo6R45LKcjhs/+WrRJij1Y0Gztw7QPAIeUfA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1074.0.tgz",
+      "integrity": "sha512-NxC62ifhtaDDdJjZ8f8Y49DCOpviGGSwzdE4KO/DA1vui4dJP4CAq+64HQkdAjFw64i5cVZb5mF6off+pZX/pg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.33",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.54",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.974.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.33.tgz",
+      "integrity": "sha512-qMgQSPemQq2/eW/e/0+SpY4kYR5L7dUgBiVdEc5bd+ztHNv07ZMYiI+sTiir3TgKndFfglSw/VFi7oZJ6bZ63g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.54",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.54.tgz",
+      "integrity": "sha512-GDfDQ0gwLFRKN9gWIKcmVrHJ3e7XagnY7N1LLzMVNgnOnuY7f/ALgmy3CuBjosWD95T/Z6e+gs1IeWmLPkyLKQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1074.0.tgz",
+      "integrity": "sha512-cCHgOUZmuJ8h7WhAb5cRfDTENjENkee/XQLr01VQ0ZGPoUnBuUTDfdmXqQGe2sETtSCtALDnwrp7q7i1RhNMaw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz",
+      "integrity": "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@fastify/ajv-compiler": {
@@ -173,6 +675,61 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@koa/router": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/@koa/router/-/router-9.4.0.tgz",
+      "integrity": "sha512-dOOXgzqaDoHu5qqMEPLKEgLz5CeIA7q8+1W62mCvFVCOqeC71UoTGJ4u1xUSOpIl2J1x2pqrNULkFteUeZW3/A==",
+      "deprecated": "**IMPORTANT 10x+ PERFORMANCE UPGRADE**: Please upgrade to v12.0.1+ as we have fixed an issue with debuglog causing 10x slower router benchmark performance, see https://github.com/koajs/router/pull/173",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "http-errors": "^1.7.3",
+        "koa-compose": "^4.1.0",
+        "methods": "^1.1.2",
+        "path-to-regexp": "^6.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/@koa/router/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@koa/router/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@koa/router/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -204,6 +761,157 @@
         "node": ">=14"
       }
     },
+    "node_modules/@shopify/semaphore": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@shopify/semaphore/-/semaphore-3.1.0.tgz",
+      "integrity": "sha512-LxonkiWEu12FbZhuOMhsdocpxCqm7By8C/2U9QgNuEoXUx2iMrlXjJv3p93RwfNC6TrdlNRo17gRer1z1309VQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@tus/file-store": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tus/file-store/-/file-store-2.0.0.tgz",
@@ -218,6 +926,33 @@
       },
       "optionalDependencies": {
         "@redis/client": "^1.6.0"
+      }
+    },
+    "node_modules/@tus/s3-store": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@tus/s3-store/-/s3-store-2.0.4.tgz",
+      "integrity": "sha512-hDksmufDo1U339CwbJI+uhT/nevCCEG220rxoxoZfF9qLaD0V+JKRC6kCQo5dSIQ5X/dLgxW/KBIMWMpHizS/Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.1045.0",
+        "@shopify/semaphore": "^3.1.0",
+        "@tus/utils": "^0.7.0",
+        "debug": "^4.3.4",
+        "multistream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@tus/s3-store/node_modules/@tus/utils": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@tus/utils/-/utils-0.7.0.tgz",
+      "integrity": "sha512-BPom8lVwR4fkk1EynPeQwuN0e5bH2gBphwt69uF5rS4wRD2N7IyHDPqdjcAY0I7gNEWfUitPyDodywbD4r7dEQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@tus/server": {
@@ -258,12 +993,33 @@
         "undici-types": "~7.19.0"
       }
     },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/ajv": {
       "version": "8.18.0",
@@ -300,6 +1056,26 @@
         }
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
@@ -331,6 +1107,95 @@
         "fastq": "^1.17.1"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/busboy": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
+      "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dev": true,
+      "dependencies": {
+        "dicer": "0.3.0"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cache-content-type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cache-content-type/-/cache-content-type-1.0.1.tgz",
+      "integrity": "sha512-IKufZ1o4Ut42YUrZSo8+qnMTrFuKkvyoLXUywKz9GJ5BrhOFGhLdkx9sG4KAnVvbY6kEcSFjLQul+DVmBm2bgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^2.1.18",
+        "ylru": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
@@ -339,6 +1204,127 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
@@ -353,6 +1339,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookies": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/debug": {
@@ -371,6 +1371,20 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/denque": {
       "version": "2.1.0",
@@ -401,11 +1415,116 @@
         "node": ">=6"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dicer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
+      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "0.1.2"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -472,6 +1591,23 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.21.1.tgz",
+      "integrity": "sha512-FTFVjYoBOZTJekiUsawGsSYV9QL0A+zDYCRj7y34IO6Jg+2IMYEtQa+bbictpdpV8dHxXywqU7C0gRDEOFtBFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.4"
+      },
+      "bin": {
+        "xml2js": "cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fastify": {
       "version": "5.8.5",
       "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
@@ -532,6 +1668,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/find-my-way": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
@@ -547,6 +1690,58 @@
         "node": ">=20"
       }
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/generic-pool": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
@@ -555,6 +1750,178 @@
       "optional": true,
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/http-assert": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
+      "integrity": "sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-equal": "~1.0.1",
+        "http-errors": "~1.8.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-assert/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-assert/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/http-errors": {
@@ -576,6 +1943,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/humanize-number": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
+      "integrity": "sha512-un3ZAcNQGI7RzaWGZzQDH47HETM4Wrj6z6E4TId8Yeq9w5ZKUVB1nrT2jwFheTUjEmqcgTjXDc959jum+ai1kQ==",
+      "dev": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -618,6 +1991,58 @@
         "node": ">= 10"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
@@ -642,6 +2067,145 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keygrip": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tsscmp": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa": {
+      "version": "2.16.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+      "integrity": "sha512-3An0GCLDSR34tsCO4H8Tef8Pp2ngtaZDAZnsWJYelqXUK5wyiHvGItgK/xcSkmHLSTn1Jcho1mRQs2ehRzvKKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.9.0",
+        "debug": "^4.3.2",
+        "delegates": "^1.0.0",
+        "depd": "^2.0.0",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
+        "koa-convert": "^2.0.0",
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": "^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4"
+      }
+    },
+    "node_modules/koa-compose": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.1.0.tgz",
+      "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/koa-convert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-2.0.0.tgz",
+      "integrity": "sha512-asOvN6bFlSnxewce2e/DK3p4tltyfC4VM7ZwuTuepI7dEQVcvpyFuBcEARu1+Hxg8DIwytce2n7jrZtRlPrARA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "co": "^4.6.0",
+        "koa-compose": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/koa-logger": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa-logger/-/koa-logger-3.2.1.tgz",
+      "integrity": "sha512-MjlznhLLKy9+kG8nAXKJLM0/ClsQp/Or2vI3a5rbSQmgl8IJBQO0KI5FA70BvW+hqjtxjp49SpH2E7okS6NmHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.0",
+        "chalk": "^2.4.2",
+        "humanize-number": "0.0.2",
+        "passthrough-counter": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 7.6.0"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/http-errors/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "dev": true,
       "license": "MIT"
     },
@@ -684,6 +2248,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.defaults": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
@@ -704,6 +2275,54 @@
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
       "license": "MIT"
     },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mime": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
@@ -716,11 +2335,69 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multistream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-4.1.0.tgz",
+      "integrity": "sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -731,6 +2408,69 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==",
+      "dev": true
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/passthrough-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-1.0.0.tgz",
+      "integrity": "sha512-Wy8PXTLqPAN0oEgBrlnsXPMww3SYJ44tQ8aVrGAI4h4JZYCS0oYqsPqtPR8OhJpv6qFbpbB7XAn0liKV7EXubA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pino": {
       "version": "10.3.1",
@@ -795,6 +2535,21 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -866,6 +2621,71 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/s3rver": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/s3rver/-/s3rver-3.7.1.tgz",
+      "integrity": "sha512-H9KIX6n8NqcfoE4ziFNbQASBQfjcNJgb+3wbT9L5iotEqfOncFO1c38cfJSFSo7xXTu1zM9HA6t2u9xKNlYRaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@koa/router": "^9.0.0",
+        "busboy": "^0.3.1",
+        "commander": "^5.0.0",
+        "fast-xml-parser": "^3.12.19",
+        "fs-extra": "^8.0.0",
+        "he": "^1.2.0",
+        "koa": "^2.7.0",
+        "koa-logger": "^3.2.0",
+        "lodash": "^4.17.5",
+        "statuses": "^2.0.0",
+        "winston": "^3.0.0"
+      },
+      "bin": {
+        "s3rver": "bin/s3rver.js"
+      },
+      "engines": {
+        "node": ">=8.3.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safe-regex2": {
       "version": "5.1.0",
@@ -962,6 +2782,16 @@
         "node": ">= 10.x"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/standard-as-callback": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
@@ -977,6 +2807,58 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/thread-stream": {
       "version": "4.0.0",
@@ -1010,6 +2892,47 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
@@ -1031,12 +2954,94 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/ylru": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ylru/-/ylru-1.4.0.tgz",
+      "integrity": "sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,12 @@
   "devDependencies": {
     "@types/node": "^25.6.0",
     "fastify": "^5.8.5",
+    "s3rver": "^3.7.1",
     "typescript": "^6.0.2"
+  },
+  "optionalDependencies": {
+    "@aws-sdk/client-s3": "^3.1074.0",
+    "@aws-sdk/s3-request-presigner": "^3.1074.0",
+    "@tus/s3-store": "^2.0.4"
   }
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -224,6 +224,8 @@ export default fp(app, {
 
 export { createLocalStorage } from "./storage/local.js";
 export type { LocalStorage, LocalStorageOptions } from "./storage/local.js";
+export { createS3Storage } from "./storage/s3.js";
+export type { S3Storage, S3StorageOptions } from "./storage/s3.js";
 export type {
   PulseVaultResolution,
   PulseVaultStorage,
@@ -236,7 +238,7 @@ export type {
   PulseVaultAuthorizePhase,
 } from "./routes/pulsevault.js";
 export type { PulseVaultOnUploadComplete } from "./lib/pulsevaultTus.js";
-export { sniffMp4, createMp4Sniffer } from "./lib/magic.js";
+export { sniffMp4, createMp4Sniffer, createS3Mp4Sniffer } from "./lib/magic.js";
 export type { PulseVaultValidatePayload } from "./lib/magic.js";
 export { buildUploadLink } from "./lib/deeplinks.js";
 export type { UploadLinkOptions } from "./lib/deeplinks.js";

--- a/src/lib/magic.ts
+++ b/src/lib/magic.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import type { FastifyRequest } from "fastify";
 import type { LocalStorage } from "../storage/local.js";
+import type { S3Storage } from "../storage/s3.js";
 
 /**
  * Optional plugin-level hook: after TUS writes the final byte but before the
@@ -46,19 +47,26 @@ export async function sniffMp4(filePath: string): Promise<boolean> {
     const buf = Buffer.alloc(12);
     const { bytesRead } = await fd.read(buf, 0, 12, 0);
     if (bytesRead < 12) return false;
-    // Bytes 4..7 must spell "ftyp" (ASCII 0x66 0x74 0x79 0x70). The first
-    // four bytes are the box size and the remaining four after "ftyp" are
-    // the brand (e.g. "isom", "mp42", "qt  ") — brand validation is left
-    // to downstream tools.
-    return (
-      buf[4] === 0x66 &&
-      buf[5] === 0x74 &&
-      buf[6] === 0x79 &&
-      buf[7] === 0x70
-    );
+    return hasFtypBox(buf);
   } finally {
     await fd.close();
   }
+}
+
+/**
+ * Whether a buffer's first 12 bytes carry an ISO base media `ftyp` box.
+ * Bytes 4..7 must spell "ftyp" (ASCII 0x66 0x74 0x79 0x70). The first four
+ * bytes are the box size and the four after "ftyp" are the brand (e.g.
+ * "isom", "mp42", "qt  ") — brand validation is left to downstream tools.
+ */
+function hasFtypBox(buf: Buffer): boolean {
+  if (buf.length < 12) return false;
+  return (
+    buf[4] === 0x66 &&
+    buf[5] === 0x74 &&
+    buf[6] === 0x79 &&
+    buf[7] === 0x70
+  );
 }
 
 /**
@@ -92,6 +100,44 @@ export function createMp4Sniffer(
     }
     const ok = await sniffMp4(localPath);
     if (!ok) {
+      throw Object.assign(
+        new Error("Uploaded bytes are not a valid MP4 (missing ftyp header)"),
+        { statusCode: 422 },
+      );
+    }
+  };
+}
+
+/**
+ * `createMp4Sniffer` for the S3 / R2 backend. Instead of opening a local file,
+ * it asks the adapter for the first 12 bytes of the finalized object via a
+ * small ranged GET (`S3Storage.readHeader`) and applies the same `ftyp` check.
+ * Runs in the same lifecycle slot — after `@tus/s3-store` completes the
+ * multipart upload (so the object is readable) but before `markReady` — so a
+ * non-MP4 upload is removed and never served.
+ *
+ * Usage:
+ * ```ts
+ * const storage = await createS3Storage({ ... });
+ * await app.register(pulseVault, {
+ *   storage,
+ *   validatePayload: createS3Mp4Sniffer(storage),
+ *   // ...
+ * });
+ * ```
+ */
+export function createS3Mp4Sniffer(
+  storage: S3Storage,
+): PulseVaultValidatePayload {
+  return async (_request, { videoid }) => {
+    const header = await storage.readHeader(videoid, 12);
+    if (!header) {
+      throw Object.assign(
+        new Error(`Cannot validate upload ${videoid}: no object bytes available`),
+        { statusCode: 500 },
+      );
+    }
+    if (!hasFtypBox(header)) {
       throw Object.assign(
         new Error("Uploaded bytes are not a valid MP4 (missing ftyp header)"),
         { statusCode: 422 },

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -1,0 +1,435 @@
+import type { DataStore } from "@tus/server";
+// Type-only imports: erased at compile time (verbatimModuleSyntax), so loading
+// this module never pulls in the AWS SDK. The real modules are loaded lazily
+// inside `createS3Storage` so a local-filesystem-only consumer never has to
+// install `@aws-sdk/*` or `@tus/s3-store`.
+import type { S3Client, S3ClientConfig } from "@aws-sdk/client-s3";
+import type {
+  PulseVaultResolution,
+  PulseVaultStorage,
+  ReserveUploadParams,
+  UploadKind,
+} from "./types.js";
+
+/**
+ * Per-upload metadata sidecar, stored as a small JSON object in the bucket at
+ * `.pulsevault/<videoid>.json`. This mirrors the local adapter's on-disk
+ * sidecar: it lets `resolve`/`getKind` recover an upload's extension, kind and
+ * completion state from the `videoid` alone (the object key needs both `kind`
+ * and `ext`, which the bare videoid doesn't carry), and survives a restart.
+ */
+type Sidecar = {
+  /** Sidecar schema version. Increment for breaking changes. */
+  version: 1;
+  /** Lowercase extension including the leading dot (e.g. `".mp4"`). */
+  ext: string;
+  /** Original filename from `Upload-Metadata.filename`. */
+  filename: string;
+  /**
+   * `"uploading"` between `reserveUpload` and `markReady`; `"ready"` once every
+   * post-upload validation has passed. `resolve` only serves `"ready"` uploads
+   * so an object that exists but failed validation is never handed out.
+   */
+  status: "uploading" | "ready";
+  /** Artifact kind. Optional for back-compat; absent is read as `"video"`. */
+  kind?: UploadKind;
+};
+
+const SIDECAR_VERSION = 1 as const;
+/** Key prefix inside the bucket that holds the per-upload sidecar objects. */
+const PULSEVAULT_META_PREFIX = ".pulsevault";
+/** Default presigned playback URL lifetime (15 minutes). */
+const DEFAULT_PRESIGN_TTL_SECONDS = 900;
+
+type CachedMeta = { ext: string; ready: boolean; kind: UploadKind };
+
+/** Map a file extension to the `Content-Type` the playback URL should return. */
+function extToContentType(ext: string): string {
+  switch (ext) {
+    case ".mp4": return "video/mp4";
+    case ".zip": return "application/zip";
+    default: return "application/octet-stream";
+  }
+}
+
+export type S3StorageOptions = {
+  /** Target bucket. Must already exist (the integrator provisions it). */
+  bucket: string;
+  /**
+   * Custom S3 endpoint. Set this for Cloudflare R2 or any S3-compatible store
+   * (e.g. `https://<account-id>.r2.cloudflarestorage.com`). Omit for AWS S3.
+   */
+  endpoint?: string;
+  /**
+   * AWS region. Required for AWS S3; for R2 use `"auto"`. When omitted and an
+   * `endpoint` is set this defaults to `"auto"`; otherwise the SDK resolves it
+   * from the environment.
+   */
+  region?: string;
+  /**
+   * Access key id. Optional — when both `accessKeyId` and `secretAccessKey`
+   * are omitted the AWS SDK default credential chain is used (env vars, IAM
+   * role, etc.). Never hard-code keys; read them from env in your app.
+   */
+  accessKeyId?: string;
+  /** Secret access key. See `accessKeyId`. */
+  secretAccessKey?: string;
+  /** Optional STS session token for temporary credentials. */
+  sessionToken?: string;
+  /**
+   * Use path-style addressing (`<endpoint>/<bucket>/<key>`) instead of
+   * virtual-host style. Defaults to `true` whenever a custom `endpoint` is set
+   * (R2 and most S3-compatible stores need it).
+   */
+  forcePathStyle?: boolean;
+  /** Presigned playback URL TTL in seconds. Defaults to 900 (15 minutes). */
+  presignTtlSeconds?: number;
+  /**
+   * Preferred multipart part size in bytes, forwarded to `@tus/s3-store`. Must
+   * be >= 5 MiB. When omitted, `@tus/s3-store` computes an optimal size.
+   */
+  partSize?: number;
+  /**
+   * Advanced escape hatch: extra `S3ClientConfig` fields merged into the
+   * client used for both playback presigning and the underlying TUS datastore
+   * (e.g. checksum flags for S3-compatible stores). Values here win over the
+   * fields derived from the options above.
+   */
+  clientConfig?: Partial<S3ClientConfig>;
+};
+
+/**
+ * S3 / Cloudflare R2 storage adapter. Uploads stream into the bucket via S3
+ * multipart upload (`@tus/s3-store`); playback is served by redirecting the
+ * client to a short-lived presigned GET URL, so bytes never flow back through
+ * the app server.
+ */
+export type S3Storage = PulseVaultStorage & {
+  /** The bucket this adapter writes to. */
+  readonly bucket: string;
+  /**
+   * Ranged GET of the first `n` bytes of a finalized upload, or `null` if the
+   * videoid is unknown. Used by `createS3Mp4Sniffer` to validate the payload
+   * without downloading the whole object.
+   */
+  readHeader(videoid: string, n: number): Promise<Buffer | null>;
+  /** Artifact kind for a known videoid, or `null`. Satisfies `getKind`. */
+  getKind(videoid: string): Promise<UploadKind | null>;
+};
+
+/**
+ * Build an S3/R2-backed storage adapter.
+ *
+ * Async because it lazily imports the optional `@aws-sdk/*` and
+ * `@tus/s3-store` packages — `await` it before registering the plugin:
+ *
+ * ```ts
+ * const storage = await createS3Storage({
+ *   bucket: "pulse-videos",
+ *   endpoint: `https://${ACCOUNT}.r2.cloudflarestorage.com`,
+ *   accessKeyId: process.env.R2_ACCESS_KEY,
+ *   secretAccessKey: process.env.R2_SECRET_KEY,
+ * });
+ * await app.register(pulseVault, { storage, prefix: "/pulsevault", maxUploadSize: Infinity });
+ * ```
+ */
+export async function createS3Storage(
+  opts: S3StorageOptions,
+): Promise<S3Storage> {
+  let s3: typeof import("@aws-sdk/client-s3");
+  let presigner: typeof import("@aws-sdk/s3-request-presigner");
+  let s3store: typeof import("@tus/s3-store");
+  try {
+    [s3, presigner, s3store] = await Promise.all([
+      import("@aws-sdk/client-s3"),
+      import("@aws-sdk/s3-request-presigner"),
+      import("@tus/s3-store"),
+    ]);
+  } catch (err) {
+    throw new Error(
+      "createS3Storage requires the optional packages `@aws-sdk/client-s3`, " +
+        "`@aws-sdk/s3-request-presigner`, and `@tus/s3-store`. Install them with:\n" +
+        "  npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner @tus/s3-store\n" +
+        `(original error: ${err instanceof Error ? err.message : String(err)})`,
+    );
+  }
+  const { S3Client, GetObjectCommand, PutObjectCommand, DeleteObjectCommand } = s3;
+  const { getSignedUrl } = presigner;
+  const { S3Store } = s3store;
+
+  const bucket = opts.bucket;
+  const presignTtl = opts.presignTtlSeconds ?? DEFAULT_PRESIGN_TTL_SECONDS;
+
+  const credentials =
+    opts.accessKeyId && opts.secretAccessKey
+      ? {
+          accessKeyId: opts.accessKeyId,
+          secretAccessKey: opts.secretAccessKey,
+          ...(opts.sessionToken ? { sessionToken: opts.sessionToken } : {}),
+        }
+      : undefined;
+
+  const clientConfig: S3ClientConfig = {
+    region: opts.region ?? (opts.endpoint ? "auto" : undefined),
+    ...(opts.endpoint ? { endpoint: opts.endpoint } : {}),
+    forcePathStyle: opts.forcePathStyle ?? Boolean(opts.endpoint),
+    ...(credentials ? { credentials } : {}),
+    ...opts.clientConfig,
+  };
+
+  // Our own client, used for sidecar I/O, ranged header reads, deletes, and
+  // presigning. The TUS datastore creates its own client from the same config.
+  const client: S3Client = new S3Client(clientConfig);
+  const datastore = new S3Store({
+    ...(opts.partSize ? { partSize: opts.partSize } : {}),
+    s3ClientConfig: { ...clientConfig, bucket },
+  }) as unknown as DataStore;
+
+  // Metadata cache keyed by videoid, mirroring the local adapter: populated
+  // eagerly on reserve and lazily from the sidecar on a cache-miss, so the GET
+  // hot path avoids a per-request round-trip to the bucket.
+  const metaCache = new Map<string, CachedMeta>();
+
+  const sidecarKey = (videoid: string): string =>
+    `${PULSEVAULT_META_PREFIX}/${videoid}.json`;
+  /** Object key for the artifact bytes — also the TUS file id / multipart key. */
+  const artifactKey = (videoid: string, kind: UploadKind, ext: string): string =>
+    `${kind}/${videoid}${ext}`;
+
+  const writeSidecar = async (
+    videoid: string,
+    sidecar: Sidecar,
+  ): Promise<void> => {
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: sidecarKey(videoid),
+        Body: JSON.stringify(sidecar),
+        ContentType: "application/json",
+      }),
+    );
+  };
+
+  const readSidecar = async (videoid: string): Promise<Sidecar | null> => {
+    let raw: string;
+    try {
+      const res = await client.send(
+        new GetObjectCommand({ Bucket: bucket, Key: sidecarKey(videoid) }),
+      );
+      raw = (await bodyToBuffer(res.Body)).toString("utf8");
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+    try {
+      const parsed = JSON.parse(raw) as Partial<Sidecar>;
+      if (typeof parsed.ext !== "string") return null;
+      if (typeof parsed.filename !== "string") return null;
+      const status: Sidecar["status"] =
+        parsed.status === "uploading" ? "uploading" : "ready";
+      const kind: UploadKind = parsed.kind === "project" ? "project" : "video";
+      return {
+        version: SIDECAR_VERSION,
+        ext: parsed.ext,
+        filename: parsed.filename,
+        status,
+        kind,
+      };
+    } catch {
+      // Malformed sidecar — treat as absent; `reserveUpload` rewrites it.
+      return null;
+    }
+  };
+
+  const loadMeta = async (videoid: string): Promise<CachedMeta | null> => {
+    const cached = metaCache.get(videoid);
+    if (cached) return cached;
+    const sidecar = await readSidecar(videoid);
+    if (!sidecar) return null;
+    const meta: CachedMeta = {
+      ext: sidecar.ext,
+      ready: sidecar.status === "ready",
+      kind: sidecar.kind ?? "video",
+    };
+    metaCache.set(videoid, meta);
+    return meta;
+  };
+
+  const reserveUpload = async ({
+    videoid,
+    filename,
+    ext,
+    kind,
+  }: ReserveUploadParams): Promise<string> => {
+    // Collision guard, same contract as the local adapter: refuse a second
+    // upload for a videoid that already has one (in-progress or ready) rather
+    // than letting the datastore silently reset the multipart upload. Surfaces
+    // as HTTP 409 via @tus/server's error path.
+    const meta = await loadMeta(videoid);
+    if (meta) {
+      throw Object.assign(new Error(`videoid ${videoid} already has an upload`), {
+        statusCode: 409,
+        status_code: 409,
+      });
+    }
+
+    await writeSidecar(videoid, {
+      version: SIDECAR_VERSION,
+      ext,
+      filename,
+      status: "uploading",
+      kind,
+    });
+    metaCache.set(videoid, { ext, ready: false, kind });
+    // @tus/s3-store uses this as the object key for the multipart upload, so
+    // the finished object lands at `<kind>/<videoid><ext>`.
+    return artifactKey(videoid, kind, ext);
+  };
+
+  const resolve = async (
+    videoid: string,
+  ): Promise<PulseVaultResolution | null> => {
+    const meta = await loadMeta(videoid);
+    // Only serve ready uploads — an object that exists but is mid-upload or
+    // failed validation stays hidden.
+    if (!meta || !meta.ready) return null;
+    const key = artifactKey(videoid, meta.kind, meta.ext);
+    const url = await getSignedUrl(
+      client,
+      new GetObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        // Force the right Content-Type on the redirected download regardless
+        // of what was stored on the object.
+        ResponseContentType: extToContentType(meta.ext),
+      }),
+      { expiresIn: presignTtl },
+    );
+    return { kind: "redirect", url, statusCode: 302 };
+  };
+
+  const markReady = async (videoid: string): Promise<void> => {
+    const sidecar = await readSidecar(videoid);
+    if (!sidecar) {
+      throw new Error(
+        `markReady: no sidecar for videoid ${videoid} (was reserveUpload called?)`,
+      );
+    }
+    const next: CachedMeta = {
+      ext: sidecar.ext,
+      ready: true,
+      kind: sidecar.kind ?? "video",
+    };
+    if (sidecar.status === "ready") {
+      // Idempotent: already ready, just keep the cache consistent.
+      metaCache.set(videoid, next);
+      return;
+    }
+    await writeSidecar(videoid, { ...sidecar, status: "ready" });
+    metaCache.set(videoid, next);
+  };
+
+  const remove = async (videoid: string): Promise<boolean> => {
+    const meta = await loadMeta(videoid);
+    // Evict before deleting so a racing `resolve` can't hand back a stale key.
+    metaCache.delete(videoid);
+    if (!meta) return false;
+    const key = artifactKey(videoid, meta.kind, meta.ext);
+    // Abort any still-in-progress multipart upload (no-op / best-effort once
+    // the upload has completed) so we never orphan an open multipart session.
+    await Promise.allSettled([
+      (datastore as { remove?: (id: string) => Promise<void> }).remove?.(key),
+    ]);
+    // Delete the finalized object, the @tus/s3-store `.info` sidecar, and our
+    // metadata sidecar. DeleteObject is idempotent, so this is safe whether or
+    // not the multipart abort above already removed some of them.
+    await Promise.all([
+      client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key })),
+      client.send(
+        new DeleteObjectCommand({ Bucket: bucket, Key: `${key}.info` }),
+      ),
+      client.send(
+        new DeleteObjectCommand({ Bucket: bucket, Key: sidecarKey(videoid) }),
+      ),
+    ]);
+    return true;
+  };
+
+  const readHeader = async (
+    videoid: string,
+    n: number,
+  ): Promise<Buffer | null> => {
+    const meta = await loadMeta(videoid);
+    if (!meta) return null;
+    const key = artifactKey(videoid, meta.kind, meta.ext);
+    try {
+      const res = await client.send(
+        new GetObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Range: `bytes=0-${Math.max(0, n - 1)}`,
+        }),
+      );
+      return await bodyToBuffer(res.Body);
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  };
+
+  const getKind = async (videoid: string): Promise<UploadKind | null> => {
+    const meta = await loadMeta(videoid);
+    return meta ? meta.kind : null;
+  };
+
+  const shutdown = async (): Promise<void> => {
+    client.destroy();
+  };
+
+  return {
+    datastore,
+    bucket,
+    reserveUpload,
+    resolve,
+    markReady,
+    remove,
+    readHeader,
+    getKind,
+    shutdown,
+  };
+}
+
+/** Collect an AWS SDK response body into a Buffer. */
+async function bodyToBuffer(body: unknown): Promise<Buffer> {
+  if (
+    body &&
+    typeof (body as { transformToByteArray?: unknown }).transformToByteArray ===
+      "function"
+  ) {
+    const arr = await (
+      body as { transformToByteArray(): Promise<Uint8Array> }
+    ).transformToByteArray();
+    return Buffer.from(arr);
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    chunks.push(Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Whether an AWS SDK error represents a missing key/object (404-ish). */
+function isNotFound(err: unknown): boolean {
+  const e = err as {
+    name?: string;
+    Code?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return (
+    e?.name === "NoSuchKey" ||
+    e?.name === "NotFound" ||
+    e?.Code === "NoSuchKey" ||
+    e?.Code === "NotFound" ||
+    e?.$metadata?.httpStatusCode === 404
+  );
+}

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -1,0 +1,82 @@
+// Shared TUS protocol helpers for the test suites. Backend-agnostic: every
+// helper takes an explicit `baseUrl` + `prefix` so the same code drives the
+// local-filesystem tests and the S3/R2 tests.
+
+import assert from "node:assert/strict";
+
+export function b64(str) {
+  return Buffer.from(str, "utf8").toString("base64");
+}
+
+// Minimal ISOBMFF header: "ftyp" box with brand "isom". Enough bytes for the
+// MP4 sniffers to accept and for realistic-looking upload sizes.
+export const MP4_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, // box size + "ftyp"
+  0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, // brand "isom" + version
+]);
+
+export function makeMp4(size) {
+  if (size < MP4_HEADER.length) {
+    throw new Error(`makeMp4: size ${size} < header ${MP4_HEADER.length}`);
+  }
+  const body = Buffer.alloc(size);
+  MP4_HEADER.copy(body, 0);
+  for (let i = MP4_HEADER.length; i < body.length; i++) {
+    body[i] = i & 0xff;
+  }
+  return body;
+}
+
+export async function tusCreate(baseUrl, prefix, { videoid, filename, size, kind }) {
+  const parts = [`videoid ${b64(videoid)}`, `filename ${b64(filename)}`];
+  if (kind) parts.push(`kind ${b64(kind)}`);
+  return fetch(`${baseUrl}${prefix}/upload`, {
+    method: "POST",
+    headers: {
+      "Tus-Resumable": "1.0.0",
+      "Upload-Length": String(size),
+      "Upload-Metadata": parts.join(","),
+    },
+  });
+}
+
+export async function tusPatch(url, offset, body) {
+  return fetch(url, {
+    method: "PATCH",
+    headers: {
+      "Tus-Resumable": "1.0.0",
+      "Upload-Offset": String(offset),
+      "Content-Type": "application/offset+octet-stream",
+    },
+    body,
+  });
+}
+
+export async function tusHead(url) {
+  return fetch(url, {
+    method: "HEAD",
+    headers: { "Tus-Resumable": "1.0.0" },
+  });
+}
+
+// Create + single-PATCH a complete upload. Defaults to an MP4 video; pass
+// `body`/`filename`/`kind` to upload something else (e.g. a .pulse project).
+export async function uploadFull(
+  baseUrl,
+  prefix,
+  { videoid, filename = "clip.mp4", size = 1024, kind, body } = {},
+) {
+  const payload = body ?? makeMp4(size);
+  const create = await tusCreate(baseUrl, prefix, {
+    videoid,
+    filename,
+    size: payload.length,
+    kind,
+  });
+  assert.equal(create.status, 201, "create");
+  const location = create.headers.get("location");
+  assert.ok(location, "location header");
+  const patch = await tusPatch(location, 0, payload);
+  assert.equal(patch.status, 204, "patch");
+  return { body: payload, location };
+}

--- a/test/plugin.test.mjs
+++ b/test/plugin.test.mjs
@@ -13,6 +13,13 @@ import pulseVault, {
   createLocalStorage,
   createMp4Sniffer,
 } from "../dist/app.js";
+import {
+  makeMp4,
+  tusCreate as tusCreateRaw,
+  tusPatch,
+  tusHead,
+  uploadFull,
+} from "./helpers.mjs";
 
 // Reusable UUIDs. Each test uses its own workspace, so collisions across
 // tests are impossible — these just need to be valid UUIDs.
@@ -24,28 +31,11 @@ const PREFIX = "/pulsevault";
 
 // ---------- helpers ----------
 
-function b64(str) {
-  return Buffer.from(str, "utf8").toString("base64");
-}
-
-// Minimal ISOBMFF header: "ftyp" box with brand "isom". Enough bytes for
-// `sniffMp4` to accept and for realistic-looking upload sizes.
-const MP4_HEADER = Buffer.from([
-  0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, // box size + "ftyp"
-  0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00, // brand "isom" + version
-]);
-
-function makeMp4(size) {
-  if (size < MP4_HEADER.length) {
-    throw new Error(`makeMp4: size ${size} < header ${MP4_HEADER.length}`);
-  }
-  const body = Buffer.alloc(size);
-  MP4_HEADER.copy(body, 0);
-  for (let i = MP4_HEADER.length; i < body.length; i++) {
-    body[i] = i & 0xff;
-  }
-  return body;
-}
+// Prefix-bound wrappers so the test bodies below read the same as before the
+// shared helpers were extracted.
+const tusCreate = (baseUrl, opts) => tusCreateRaw(baseUrl, PREFIX, opts);
+const uploadFullMp4 = (ctx, videoid, size = 1024) =>
+  uploadFull(ctx.baseUrl, PREFIX, { videoid, size });
 
 async function startApp({ pluginOptions = {}, withSniffer = false } = {}) {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-test-"));
@@ -69,55 +59,6 @@ async function startApp({ pluginOptions = {}, withSniffer = false } = {}) {
       await fs.rm(workspaceDir, { recursive: true, force: true });
     },
   };
-}
-
-async function tusCreate(baseUrl, { videoid, filename, size }) {
-  const metadata = [
-    `videoid ${b64(videoid)}`,
-    `filename ${b64(filename)}`,
-  ].join(",");
-  return fetch(`${baseUrl}${PREFIX}/upload`, {
-    method: "POST",
-    headers: {
-      "Tus-Resumable": "1.0.0",
-      "Upload-Length": String(size),
-      "Upload-Metadata": metadata,
-    },
-  });
-}
-
-async function tusPatch(url, offset, body) {
-  return fetch(url, {
-    method: "PATCH",
-    headers: {
-      "Tus-Resumable": "1.0.0",
-      "Upload-Offset": String(offset),
-      "Content-Type": "application/offset+octet-stream",
-    },
-    body,
-  });
-}
-
-async function tusHead(url) {
-  return fetch(url, {
-    method: "HEAD",
-    headers: { "Tus-Resumable": "1.0.0" },
-  });
-}
-
-async function uploadFullMp4(ctx, videoid, size = 1024) {
-  const body = makeMp4(size);
-  const create = await tusCreate(ctx.baseUrl, {
-    videoid,
-    filename: "clip.mp4",
-    size: body.length,
-  });
-  assert.equal(create.status, 201, "create");
-  const location = create.headers.get("location");
-  assert.ok(location, "location header");
-  const patch = await tusPatch(location, 0, body);
-  assert.equal(patch.status, 204, "patch");
-  return { body, location };
 }
 
 // ---------- tests ----------

--- a/test/s3-storage.test.mjs
+++ b/test/s3-storage.test.mjs
@@ -1,0 +1,302 @@
+// S3 / R2 backend suite for @mieweb/pulsevault. Runs against the built
+// `dist/` and an in-process `s3rver` S3 mock, so CI needs no real cloud
+// credentials. A single s3rver is shared across tests; each test uses a fresh
+// videoid (the bucket persists between tests).
+
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import S3rver from "s3rver";
+import Fastify from "fastify";
+import pulseVault, {
+  createS3Storage,
+  createS3Mp4Sniffer,
+} from "../dist/app.js";
+import { makeMp4, tusCreate, tusPatch, tusHead, uploadFull } from "./helpers.mjs";
+import { installListPartsShim } from "./s3rver-listparts.mjs";
+
+const PREFIX = "/pulsevault";
+const BUCKET = "pulse-test";
+
+let s3rverInstance;
+let s3Dir;
+let endpoint;
+
+before(async () => {
+  s3Dir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-s3rver-"));
+  s3rverInstance = new S3rver({
+    address: "127.0.0.1",
+    port: 0,
+    silent: true,
+    directory: s3Dir,
+    // Presigned URLs from the SDK and modern checksum behavior don't always
+    // match s3rver's SigV4 expectations byte-for-byte; accept them.
+    allowMismatchedSignatures: true,
+    configureBuckets: [{ name: BUCKET }],
+  });
+  // s3rver lacks ListParts, which @tus/s3-store needs on every write.
+  installListPartsShim(s3rverInstance);
+  const { port } = await s3rverInstance.run();
+  endpoint = `http://127.0.0.1:${port}`;
+});
+
+after(async () => {
+  if (s3rverInstance) await s3rverInstance.close();
+  if (s3Dir) await fs.rm(s3Dir, { recursive: true, force: true });
+});
+
+async function startApp({ pluginOptions = {}, withSniffer = false } = {}) {
+  const storage = await createS3Storage({
+    bucket: BUCKET,
+    endpoint,
+    region: "us-east-1",
+    accessKeyId: "S3RVER",
+    secretAccessKey: "S3RVER",
+    forcePathStyle: true,
+    // s3rver does not implement the SDK's default integrity checksums.
+    clientConfig: {
+      requestChecksumCalculation: "WHEN_REQUIRED",
+      responseChecksumValidation: "WHEN_REQUIRED",
+    },
+  });
+  const app = Fastify({ logger: false });
+  await app.register(pulseVault, {
+    prefix: PREFIX,
+    storage,
+    maxUploadSize: 10 * 1024 * 1024,
+    ...(withSniffer ? { validatePayload: createS3Mp4Sniffer(storage) } : {}),
+    ...pluginOptions,
+  });
+  const baseUrl = await app.listen({ port: 0, host: "127.0.0.1" });
+  return {
+    app,
+    storage,
+    baseUrl,
+    teardown: async () => {
+      await app.close();
+    },
+  };
+}
+
+// ---------- tests ----------
+
+test("full upload → GET 302-redirects to a presigned URL that serves the bytes", async () => {
+  const ctx = await startApp();
+  const vid = randomUUID();
+  try {
+    const { body } = await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
+
+    // GET returns a redirect, not the bytes.
+    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(get.status, 302, "GET should 302-redirect");
+    const location = get.headers.get("location");
+    assert.ok(location, "Location header present");
+    assert.ok(location.includes(BUCKET), "redirect points at the bucket");
+
+    // Following the presigned URL returns the exact bytes from the bucket.
+    const direct = await fetch(location);
+    assert.equal(direct.status, 200);
+    assert.equal(
+      direct.headers.get("content-type"),
+      "video/mp4",
+      "presigned URL forces the right content-type",
+    );
+    const bytes = Buffer.from(await direct.arrayBuffer());
+    assert.equal(bytes.length, body.length);
+    assert.equal(Buffer.compare(bytes, body), 0);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("GET returns 404 while the upload is still in progress", async () => {
+  const ctx = await startApp();
+  const vid = randomUUID();
+  try {
+    const create = await tusCreate(ctx.baseUrl, PREFIX, {
+      videoid: vid,
+      filename: "clip.mp4",
+      size: 2048,
+    });
+    assert.equal(create.status, 201);
+
+    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(get.status, 404);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("HEAD + resume PATCH completes the multipart upload", async () => {
+  const ctx = await startApp();
+  const vid = randomUUID();
+  try {
+    const body = makeMp4(4096);
+    const create = await tusCreate(ctx.baseUrl, PREFIX, {
+      videoid: vid,
+      filename: "clip.mp4",
+      size: body.length,
+    });
+    const location = create.headers.get("location");
+    const half = body.length / 2;
+
+    const p1 = await tusPatch(location, 0, body.subarray(0, half));
+    assert.equal(p1.status, 204);
+
+    const head = await tusHead(location);
+    assert.equal(head.status, 200);
+    assert.equal(head.headers.get("upload-offset"), String(half));
+
+    // Still in progress → GET must be 404.
+    const midGet = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(midGet.status, 404);
+
+    const p2 = await tusPatch(location, half, body.subarray(half));
+    assert.equal(p2.status, 204);
+
+    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(get.status, 302);
+    const direct = await fetch(get.headers.get("location"));
+    const bytes = Buffer.from(await direct.arrayBuffer());
+    assert.equal(Buffer.compare(bytes, body), 0);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("second reserve for same videoid returns 409", async () => {
+  const ctx = await startApp();
+  const vid = randomUUID();
+  try {
+    const first = await tusCreate(ctx.baseUrl, PREFIX, {
+      videoid: vid,
+      filename: "clip.mp4",
+      size: 1024,
+    });
+    assert.equal(first.status, 201);
+
+    const dup = await tusCreate(ctx.baseUrl, PREFIX, {
+      videoid: vid,
+      filename: "clip.mp4",
+      size: 1024,
+    });
+    assert.equal(dup.status, 409);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("createS3Mp4Sniffer rejects non-MP4 bytes and removes the object", async () => {
+  const ctx = await startApp({ withSniffer: true });
+  const vid = randomUUID();
+  try {
+    // GIF header — deliberately not ISOBMFF.
+    const fake = Buffer.concat([Buffer.from("GIF89a"), Buffer.alloc(2048, 0xff)]);
+    const create = await tusCreate(ctx.baseUrl, PREFIX, {
+      videoid: vid,
+      filename: "fake.mp4",
+      size: fake.length,
+    });
+    assert.equal(create.status, 201);
+    const location = create.headers.get("location");
+
+    const patch = await tusPatch(location, 0, fake);
+    assert.ok(
+      patch.status >= 400 && patch.status < 500,
+      `expected 4xx, got ${patch.status}`,
+    );
+
+    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(get.status, 404, "rejected upload is not served");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("createS3Mp4Sniffer accepts a valid MP4 payload", async () => {
+  const ctx = await startApp({ withSniffer: true });
+  const vid = randomUUID();
+  try {
+    await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
+    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(get.status, 302);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("DELETE removes the object; second DELETE is 404", async () => {
+  const ctx = await startApp();
+  const vid = randomUUID();
+  try {
+    await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
+
+    const pre = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(pre.status, 302);
+
+    const del = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { method: "DELETE" });
+    assert.equal(del.status, 204);
+
+    const post = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(post.status, 404);
+
+    const del2 = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { method: "DELETE" });
+    assert.equal(del2.status, 404);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("kind=project lands under project/ and GET /project/:id 302-redirects", async () => {
+  const ctx = await startApp();
+  const vid = randomUUID();
+  try {
+    // A .pulse bundle is opaque bytes — no MP4 sniffing for projects.
+    const body = Buffer.alloc(2048, 0x42);
+    await uploadFull(ctx.baseUrl, PREFIX, {
+      videoid: vid,
+      filename: "draft.pulse",
+      kind: "project",
+      body,
+    });
+
+    // Video route must not serve a project artifact.
+    const videoGet = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    assert.equal(videoGet.status, 404);
+
+    const get = await fetch(`${ctx.baseUrl}${PREFIX}/project/${vid}`, { redirect: "manual" });
+    assert.equal(get.status, 302);
+    const location = get.headers.get("location");
+    assert.ok(location.includes(`project/${vid}.pulse`), "redirect points at project key");
+
+    const direct = await fetch(location);
+    const bytes = Buffer.from(await direct.arrayBuffer());
+    assert.equal(Buffer.compare(bytes, body), 0);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("onUploadComplete fires once with the right ctx", async () => {
+  const calls = [];
+  const ctx = await startApp({
+    pluginOptions: {
+      onUploadComplete: async (_req, info) => {
+        calls.push(info);
+      },
+    },
+  });
+  const vid = randomUUID();
+  try {
+    const { body } = await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].videoid, vid);
+    assert.equal(calls[0].size, body.length);
+    assert.equal(typeof calls[0].uploadId, "string");
+  } finally {
+    await ctx.teardown();
+  }
+});

--- a/test/s3rver-listparts.mjs
+++ b/test/s3rver-listparts.mjs
@@ -1,0 +1,99 @@
+// s3rver does not implement the S3 `ListParts` operation, but `@tus/s3-store`
+// calls it on every chunk write (to find the next part number / current
+// offset). Without it every PATCH 500s. This shim teaches a running s3rver
+// instance to answer `GET /<bucket>/<key>?uploadId=<id>` by reading the part
+// files s3rver already wrote to disk for that multipart upload.
+//
+// It's test-only and leans on s3rver's on-disk layout, which is stable
+// because s3rver is unmaintained/frozen. Everything else @tus/s3-store needs
+// (CreateMultipartUpload, UploadPart, the incomplete-part PutObject, and
+// CompleteMultipartUpload) is already supported by s3rver natively.
+
+import path from "node:path";
+import { readdir, readFile, stat } from "node:fs/promises";
+
+// s3rver stores multipart parts at:
+//   <rootDirectory>/<bucket>/._S3rver_uploads/<uploadId>/<partNumber>
+// with a sibling `<partNumber>.md5` holding the part's md5 hex (its ETag).
+const UPLOADS_DIR = "._S3rver_uploads";
+
+async function listParts(rootDirectory, bucket, uploadId) {
+  const uploadDir = path.join(rootDirectory, bucket, UPLOADS_DIR, uploadId);
+  let entries;
+  try {
+    entries = await readdir(uploadDir);
+  } catch {
+    // No directory → upload unknown / already completed / aborted: no parts.
+    return [];
+  }
+  const partNumbers = entries
+    .filter((name) => /^\d+$/.test(name))
+    .map(Number)
+    .sort((a, b) => a - b);
+
+  const parts = [];
+  for (const n of partNumbers) {
+    const size = (await stat(path.join(uploadDir, String(n)))).size;
+    let etag = "";
+    try {
+      etag = (await readFile(path.join(uploadDir, `${n}.md5`), "utf8")).trim();
+    } catch {
+      /* leave etag empty — s3rver's CompleteMultipartUpload ignores it */
+    }
+    parts.push({ n, size, etag });
+  }
+  return parts;
+}
+
+function renderListPartsXml(bucket, key, uploadId, parts) {
+  const partsXml = parts
+    .map(
+      (p) =>
+        `<Part><PartNumber>${p.n}</PartNumber>` +
+        `<LastModified>${new Date().toISOString()}</LastModified>` +
+        `<ETag>&quot;${p.etag}&quot;</ETag>` +
+        `<Size>${p.size}</Size></Part>`,
+    )
+    .join("");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>` +
+    `<ListPartsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">` +
+    `<Bucket>${bucket}</Bucket><Key>${key}</Key><UploadId>${uploadId}</UploadId>` +
+    `<PartNumberMarker>0</PartNumberMarker>` +
+    `<NextPartNumberMarker>${parts.length}</NextPartNumberMarker>` +
+    `<MaxParts>1000</MaxParts><IsTruncated>false</IsTruncated>` +
+    partsXml +
+    `</ListPartsResult>`
+  );
+}
+
+/**
+ * Install the ListParts shim on an (un-started) S3rver instance. Must be called
+ * before `instance.run()` so the middleware is composed ahead of s3rver's
+ * router (we unshift it to the front of the Koa onion).
+ */
+export function installListPartsShim(s3rverInstance) {
+  const shim = async (ctx, next) => {
+    // ListParts is `GET /<bucket>/<key>?uploadId=<id>` (no `uploads` param,
+    // which would be the bucket-level ListMultipartUploads).
+    if (
+      ctx.method === "GET" &&
+      ctx.query.uploadId !== undefined &&
+      ctx.query.uploads === undefined
+    ) {
+      const segments = ctx.path.replace(/^\//, "").split("/");
+      const bucket = segments.shift();
+      const key = segments.join("/");
+      const rootDirectory = s3rverInstance.store.rootDirectory;
+      const parts = await listParts(rootDirectory, bucket, ctx.query.uploadId);
+      ctx.type = "application/xml";
+      ctx.status = 200;
+      ctx.body = renderListPartsXml(bucket, key, ctx.query.uploadId, parts);
+      return;
+    }
+    await next();
+  };
+  // Run before s3rver's own router/middleware.
+  s3rverInstance.middleware.unshift(shim);
+  return s3rverInstance;
+}


### PR DESCRIPTION

## Description

Adds an optional `createS3Storage` adapter so PulseVault can persist uploads in S3-compatible object storage instead of only local disk. Since R2 speaks the S3 API, one adapter covers both Cloudflare R2 and AWS S3 - they differ only by endpoint and credentials.

This is **purely additive**: local filesystem remains the zero-config default, and the routes, hooks, and TUS layer are untouched — the new backend just implements the existing `PulseVaultStorage` interface.

## Demo
https://youtube.com/shorts/6LdBiDPBCbo

### What changed
- **`createS3Storage(...)`** ([[src/storage/s3.ts](https://claude.ai/epitaxy/src/storage/s3.ts)](src/storage/s3.ts)) — uploads stream into the bucket via S3 multipart upload (`@tus/s3-store`); playback returns a 302 redirect to a short-lived **presigned URL**, so bytes never flow back through the app server. Mirrors the local adapter's metadata sidecar + ready-gate (`.pulsevault/<id>.json`).
- **`createS3Mp4Sniffer(storage)`** — MP4 magic-byte validation for remote objects via a small ranged GET (no full download), since the local file-path sniffer doesn't apply to bucket objects.
- **Lean by default** — `@aws-sdk/*` and `@tus/s3-store` are `optionalDependencies`, lazily imported only when `createS3Storage` is called; local-only consumers never load the AWS SDK.
- **Docs + demo** — README "Object storage (R2 / S3)" section (config, layout, options, CORS), a `STORAGE=s3` switch in the example server, and a `.env.example`.

### Configuration
Switching a deployment is a config change, not a code change:
```ts
const storage = await createS3Storage({
  bucket: "pulse-videos",
  endpoint: `https://${ACCOUNT}.r2.cloudflarestorage.com`, // omit for AWS S3
  accessKeyId: process.env.R2_ACCESS_KEY,
  secretAccessKey: process.env.R2_SECRET_KEY,
});
```

### Testing
New suite runs the **full resumable upload → presigned-redirect playback** path against an in-process `s3rver` mock — no Docker, no cloud credentials in CI. s3rver lacks `ListParts` (which `@tus/s3-store` needs), so a small test-only shim emulates it from s3rver's on-disk layout. **35/35 tests pass** (26 existing + 9 new), covering upload/resume/delete, validation accept/reject, `kind=project`, and the ready-gate.

### Notes for reviewers
- Public URLs and the TUS protocol are unchanged — the mobile app needs no changes.
- R2 multipart parity against a real bucket is worth a one-time manual check (the demo's `STORAGE=s3` mode makes that a few env vars); s3rver covers adapter logic but not R2-specific quirks.