### PR TITLE
Rework artifact protocol for multi-tenant compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); this project follows
+semantic versioning once it reaches `1.0.0` — pre-1.0, minor bumps may include
+breaking changes, called out explicitly below.
+
+## [Unreleased]
+
+This release reworks the upload contract for genuine multi-tenant use — any
+third party can implement a compatible server from `PROTOCOL.md` alone, not
+just by reading this package's source. It bundles several breaking changes
+into one release rather than spreading them across several; see "Upgrading"
+in `OPERATIONS.md` for the migration path.
+
+### Breaking
+
+- **Renamed `videoid` → `artifactId`** across the storage interface
+  (`ReserveUploadParams`, `PulseVaultStorage` methods), the `authorize`
+  context (`PulseVaultAuthorizeContext`), the `validatePayload`/
+  `onUploadComplete` hook contexts, the `request.pulseVault` TypeScript
+  augmentation (`./augment.ts` — a separate breaking change from the wire
+  rename, since it's the published type surface, not the HTTP contract), and
+  the deep-link query parameter built by `buildUploadLink`. `videoid`/
+  `projectid` remain accepted as legacy aliases in `Upload-Metadata` — only
+  the *primary* name changed, not backward compatibility for existing
+  clients' requests.
+- **Collapsed the per-kind routes into one generic route.** `GET/DELETE
+  /:videoid` and `GET/DELETE /project/:projectid` are gone; replaced by
+  `GET/DELETE /artifacts/:artifactId`, which resolves the kind from storage
+  rather than the URL. This also means `kind=captions` artifacts (new, see
+  below) don't need a third route pair.
+- **`validateProjectPayload`/`onProjectUploadComplete` are deprecated** (not
+  yet removed) in favor of the now-generic `validatePayload`/
+  `onUploadComplete`, which receive `ctx.kind` and run for every artifact
+  kind. Passing either deprecated option now emits a one-time
+  `DeprecationWarning` at plugin registration.
+- **`allowedExtensions` requires a `captions` default to be considered** if
+  you were relying on the exact shape of the normalized object internally
+  (public consumers passing `allowedExtensions` as documented are unaffected
+  — the new key just has a default like `video`/`project` already did).
+
+### Added
+
+- **`kind: "captions"`** artifact type (default extension `.srt`), running
+  through the same generic `validatePayload`/`onUploadComplete` hooks as
+  every other kind.
+- **`relatedTo`** — an optional `Upload-Metadata` key (and matching
+  `ReserveUploadParams`/storage field) linking one artifact to another (e.g.
+  a video's captions, or a beat belonging to a pulse manifest's session).
+  Storage adapters expose it via the new optional `getRelatedTo` method.
+- **`checksum`** — an optional `Upload-Metadata` key (`<algorithm>:<hex
+  digest>`) verified post-upload via the new `createChecksumValidator`
+  (local storage) / `createS3ChecksumValidator` (S3/R2) helpers, chainable
+  with `createMp4Sniffer`. This is at-rest integrity verification on the
+  finished file, not a per-chunk check — `@tus/server`'s installed version
+  doesn't implement the TUS Checksum extension, which would have covered
+  chunks in flight.
+- **`src/lib/capability-token.ts`**: `issueCapabilityToken`,
+  `verifyCapabilityToken`, `createCapabilityAuthorize` — a stateless,
+  HMAC-signed capability-token scheme with `kid` (key rotation with an
+  overlap window), `iat` (clock-skew tolerance), and `issuer` (cross-deployment
+  replay protection) claims. Fully optional — bring your own `authorize` if
+  you have existing auth.
+- **`GET {prefix}/capabilities`** — unauthenticated discovery route reporting
+  `protocolVersion`, `minSupportedVersion`/`maxSupportedVersion`,
+  `uploadUnit`, `kinds`, `allowedExtensions`, `maxUploadSize`, and supported
+  checksum algorithms. Lets independently-versioned deployments and clients
+  detect compatibility before pairing.
+- **`uploadUnit` plugin option** (`"beat" | "merged"`, default `"beat"`) —
+  purely advertised via `/capabilities`; the operator declares which upload
+  strategy this deployment expects, the client branches on it. Not enforced
+  by the plugin.
+- **`onArtifactEvent` plugin option** — one low-frequency hook (authorize
+  rejection, completion, validation rejection — never per chunk) covering
+  both ops metrics and a compliance audit trail from a single integration
+  point.
+- **`Protocol-Version` response header** on every route this plugin mounts.
+- Bounded, LRU-evicting in-memory metadata cache in both storage adapters
+  (`metaCacheLimit` option, default 10,000 entries) — previously unbounded
+  for the life of the process.
+- `S3Storage.readAll` — full-object read, used by `createS3ChecksumValidator`.
+
+### Fixed
+
+- `maxUploadSize` enforcement and the in-progress-upload 404 behavior now
+  have explicit test coverage proving bytes are rejected/hidden at the right
+  point, not just implied by the implementation.
+
+[Unreleased]: https://github.com/mieweb/pulsevault/compare/v0.0.2...HEAD

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,192 @@
+# Operations
+
+Deployment, scaling, and maintenance guidance for running `@mieweb/pulsevault`
+in production. See `README.md` for the quick-start and plugin options, and
+`PROTOCOL.md` for the wire contract.
+
+## Upgrading to this release
+
+This release renames `videoid` → `artifactId` and collapses the per-kind
+routes into one generic route (see `CHANGELOG.md`). **No on-disk data
+migration is required**: the local and S3 storage layouts never stored the
+id as a field inside the sidecar JSON — the id is the filename — so existing
+uploaded artifacts are immediately readable through the new
+`GET /artifacts/:artifactId` route with zero changes to the files on disk.
+
+What *does* need updating:
+
+- Any of your own code calling the old routes directly (`GET/DELETE
+  /:videoid`, `GET/DELETE /project/:projectid`) must move to `GET/DELETE
+  /artifacts/:artifactId` — the old routes return `404`, not a redirect.
+- Any code reading `request.pulseVault.videoid` (if you imported
+  `@mieweb/pulsevault/augment`) must read `.artifactId` instead.
+- If you use `validateProjectPayload`/`onProjectUploadComplete`, you'll see a
+  one-time `DeprecationWarning` at startup. They still work this release —
+  migrate to `validatePayload`/`onUploadComplete` with a `ctx.kind ===
+  "project"` branch when convenient, before a future major version removes
+  the deprecated options.
+- Clients still sending `Upload-Metadata: videoid ...` (instead of
+  `artifactId`) keep working — the alias is accepted indefinitely for
+  protocol version 1 (see `PROTOCOL.md` §4.1) — but new client code should
+  send `artifactId`.
+
+There is no automated migration script because there is nothing on disk to
+migrate. If a future release ever does change the storage layout, that
+release's `OPERATIONS.md` entry will include one.
+
+## Horizontal scaling
+
+**The local storage adapter (`createLocalStorage`) requires either
+sticky-session load-balancer routing or a shared filesystem (NFS/EFS/etc.)
+across instances.** TUS resumable uploads need subsequent `PATCH`/`HEAD`
+requests to reach an instance that can see the partial upload's bytes and
+`@tus/file-store` offset metadata. If you run multiple instances behind a
+load balancer without either of these, a retried `PATCH` that lands on a
+different instance will silently fail to resume — the client's `HEAD` will
+see no offset and effectively restart from byte zero, with no error
+surfaced anywhere.
+
+Two ways to actually support multiple instances:
+
+1. **Sticky sessions**: configure your load balancer to route by client IP
+   or a session cookie so all requests for one upload land on the same
+   instance.
+2. **Shared filesystem**: point every instance's `workspaceDir` at the same
+   NFS/EFS mount. Verify your mount's durability/consistency guarantees
+   under concurrent writes from multiple instances before relying on this in
+   production.
+
+**The S3/R2 adapter (`createS3Storage`) has no such requirement** — every
+instance talks to the same bucket, so it scales horizontally with zero
+additional configuration. Prefer it for any multi-instance deployment unless
+you have a specific reason to use local disk.
+
+## Resource limits and abuse prevention
+
+`pulsevault` does not implement rate limiting or a concurrent-upload cap
+itself — that's left to the operator, consistent with this project's general
+principle that policy decisions belong to the deployment, not the library.
+A minimal example using `@fastify/rate-limit`, scoped to just the upload
+routes:
+
+```ts
+import rateLimit from "@fastify/rate-limit";
+
+await app.register(rateLimit, {
+  max: 20,
+  timeWindow: "1 minute",
+  // Scope to the pulsevault prefix only — don't rate-limit your whole app
+  // with upload-sized limits.
+  allowList: (req) => !req.url.startsWith("/pulsevault/upload"),
+});
+```
+
+## Monitoring and audit logging
+
+Wire `onArtifactEvent` once to get both ops metrics and a compliance audit
+trail from the same hook — it fires at low-frequency, audit-worthy moments
+only (never per chunk): authorize rejection (on `create`/`delete`/`resolve`,
+not `patch`), successful completion, and validation rejection.
+
+**Plain structured logging** (zero new dependencies):
+
+```ts
+onArtifactEvent: (event) => {
+  app.log.info(event, "pulsevault artifact event");
+},
+```
+
+**Prometheus counters**:
+
+```ts
+import { Counter } from "prom-client";
+const artifactEvents = new Counter({
+  name: "pulsevault_artifact_events_total",
+  help: "pulsevault artifact lifecycle events",
+  labelNames: ["phase", "kind"],
+});
+
+onArtifactEvent: (event) => {
+  artifactEvents.inc({ phase: event.phase, kind: event.kind });
+  if (event.phase === "reject" || event.phase === "authorize") {
+    app.log.warn(event, "pulsevault artifact event");
+  }
+},
+```
+
+What to alert on: a sustained rise in `reject`/`authorize`-rejection events
+(misconfigured auth, or an attacker probing), disk usage on the local
+adapter's `workspaceDir` approaching capacity, and any `5xx` rate on the
+upload routes.
+
+## Backup and restore (local storage)
+
+The entire state of the local adapter lives under `workspaceDir`:
+`.pulsevault/` (sidecars), `video/`, `project/`, `captions/` (bytes). Back it
+up as a normal filesystem tree — there's no separate database to keep in
+sync. To restore, copy the tree back and restart; in-progress uploads at
+backup time will resume correctly via the normal TUS `HEAD`-then-resume path
+once the client retries, or will simply sit as abandoned partial uploads
+(see "Retention" below) if the client never retries.
+
+## Retention
+
+`pulsevault` has no built-in retention/expiry feature — this is intentionally
+left to the operator (see `PROTOCOL.md` §1 on lifecycle ownership). A sample
+cron script for the local adapter, deleting artifacts whose sidecar has been
+`"uploading"` for longer than a cutoff (abandoned uploads) or that are older
+than a retention window (compliance-driven deletion):
+
+```ts
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { createLocalStorage } from "@mieweb/pulsevault";
+
+const storage = createLocalStorage({ workspaceDir: "./data" });
+const sidecarDir = path.join(storage.workspaceRoot, ".pulsevault");
+const ABANDONED_AFTER_MS = 24 * 60 * 60 * 1000; // 24h stuck "uploading"
+const RETAIN_FOR_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+for (const file of await readdir(sidecarDir)) {
+  if (!file.endsWith(".json")) continue;
+  const artifactId = file.slice(0, -".json".length);
+  const sidecarPath = path.join(sidecarDir, file);
+  const [sidecar, stats] = await Promise.all([
+    readFile(sidecarPath, "utf8").then(JSON.parse),
+    stat(sidecarPath),
+  ]);
+  const ageMs = Date.now() - stats.mtimeMs;
+  const stuckUploading = sidecar.status === "uploading" && ageMs > ABANDONED_AFTER_MS;
+  const pastRetention = sidecar.status === "ready" && ageMs > RETAIN_FOR_MS;
+  if (stuckUploading || pastRetention) {
+    await storage.remove(artifactId);
+    console.log(`removed ${artifactId} (${stuckUploading ? "abandoned" : "retention"})`);
+  }
+}
+```
+
+Run this on whatever schedule your retention policy requires. For S3/R2
+storage, prefer your bucket provider's native lifecycle-policy feature (S3
+Lifecycle Rules, R2 Object Lifecycle) over a custom script where available.
+
+## Secrets management
+
+If you use `createCapabilityAuthorize`, you supply the HMAC secret(s)
+yourself via `lookupSecret`. For local development, reading from an
+environment variable is fine. For production, read from your organization's
+actual secrets manager instead of a raw env var — e.g.:
+
+```ts
+import { SecretsManagerClient, GetSecretValueCommand } from "@aws-sdk/client-secrets-manager";
+
+const client = new SecretsManagerClient({});
+const keys: Record<string, string> = {};
+async function loadKey(kid: string) {
+  const res = await client.send(new GetSecretValueCommand({ SecretId: `pulsevault/${kid}` }));
+  keys[kid] = res.SecretString!;
+}
+```
+
+Rotate by adding the new `kid` to your lookup table alongside the old one,
+switching issuance to the new `kid`, and removing the old entry only after
+its longest-lived outstanding token has expired.

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,0 +1,249 @@
+# Pulse Upload Protocol
+
+**Version 1**
+
+This document specifies the wire contract between a Pulse client and any
+server that wants to receive uploads from it. It is independent of
+`@mieweb/pulsevault` — a server that implements everything in this document
+is Pulse-compatible whether or not it uses this package. `@mieweb/pulsevault`
+is the reference implementation.
+
+The key words **MUST**, **MUST NOT**, **REQUIRED**, **SHOULD**, **SHOULD
+NOT**, and **MAY** in this document are to be interpreted as described in
+[RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+
+## 1. Overview
+
+A server (the "operator") mints an `artifactId` and a capability `token`,
+then presents them to a Pulse client via a deep link or QR code (§3). The
+client uploads the artifact's bytes to the server using the [TUS v1
+resumable upload protocol](https://tus.io/protocols/resumable-upload) (§4),
+authenticated with the token on every request (§5). The server validates,
+stores, and serves the finished artifact (§6, §7).
+
+No central authority is involved. Any server implementing this document MAY
+be used by any Pulse client. Lifecycle decisions — `artifactId` minting,
+token issuance, expiry policy, secret rotation, revocation — are entirely the
+operator's responsibility (§5.4). This document fixes the wire shape only,
+never the policy behind it.
+
+## 2. Capability discovery
+
+A server MUST expose an unauthenticated `GET {prefix}/capabilities` endpoint.
+The response body MUST be a JSON object with at least the following fields:
+
+```json
+{
+  "protocolVersion": 1,
+  "minSupportedVersion": 1,
+  "maxSupportedVersion": 1,
+  "uploadUnit": "beat",
+  "kinds": ["video", "project", "captions"],
+  "allowedExtensions": { "video": [".mp4"], "project": [".pulse", ".zip"], "captions": [".srt"] },
+  "maxUploadSize": 5368709120,
+  "checksum": { "algorithms": ["sha256"] }
+}
+```
+
+- `protocolVersion` (integer, REQUIRED): the version of this document the
+  server implements.
+- `minSupportedVersion`/`maxSupportedVersion` (integer, REQUIRED): the
+  inclusive range of client protocol versions this server accepts. A client
+  SHOULD refuse to pair if its own version falls outside this range, and
+  SHOULD show the user an actionable message ("update the app" /
+  "this server needs an update") rather than a generic error.
+- `uploadUnit` (`"beat"` or `"merged"`, REQUIRED): which upload strategy this
+  deployment expects (§8). The client MUST read this before doing any
+  merge/upload work and branch accordingly.
+- `kinds` (array of string, REQUIRED): artifact kinds this server accepts.
+- `allowedExtensions` (object, REQUIRED): allowed file extensions per kind.
+- `maxUploadSize` (integer, REQUIRED): maximum artifact size in bytes.
+- `checksum.algorithms` (array of string, OPTIONAL): digest algorithms this
+  server can verify (§6.3). Absent or empty means the server does not
+  support checksum verification.
+
+A server response to this endpoint MUST NOT include any secret. Every other
+response from the server MUST include a `Protocol-Version` header carrying
+the integer from `protocolVersion`.
+
+## 3. Pairing (deep link)
+
+A server presents a pairing link or QR code of the form:
+
+```
+pulsecam://?v=1&artifactId=<uuid>&server=<origin>&token=<opaque>
+```
+
+- `v` (REQUIRED): the deep-link schema version. A client MUST refuse and
+  explain (not silently misparse) a `v` it doesn't recognize.
+- `artifactId` (REQUIRED): a UUID minted by the server. The client uses this
+  directly as the `artifactId` in `Upload-Metadata` (§4) — it MUST NOT
+  perform a separate "reserve" round-trip when an `artifactId` is already
+  present in the link.
+- `server` (REQUIRED): the full **base URL** to upload to — origin plus
+  whatever path prefix the operator mounted the upload routes under (e.g.
+  `https://vault.example.org/pulsevault`), not merely the origin. A client
+  MUST treat every route in §2/§4/§6 as `${server}/<path>` and MUST NOT
+  assume or invent a separate prefix of its own. A client MUST reject any
+  `server` value that is not `https://`, with the sole exception of
+  `http://localhost` or a private IP literal for local development — this
+  exception MUST NOT be silently extended to any other plaintext origin.
+- `token` (OPTIONAL): an opaque credential forwarded on every subsequent
+  request (§5). Servers SHOULD treat this as short-lived and scoped to the
+  `artifactId` (or a session it anchors, §5.4), not a standing general
+  credential — see §5.4 for the recommended (but not required) capability-
+  token shape.
+
+A client SHOULD display the server's origin (and, where feasible, its TLS
+certificate fingerprint) to the user before uploading anything, rather than
+silently proceeding — this is a trust-on-first-use decision the user should
+be able to see and decline.
+
+## 4. Upload transport (TUS)
+
+Upload transport MUST be [TUS v1](https://tus.io/protocols/resumable-upload)
+core protocol (creation + core resumable upload). A server MUST mount:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `{prefix}/upload` | Create a resumable upload |
+| `PATCH` | `{prefix}/upload/<id>` | Append a chunk at `Upload-Offset` |
+| `HEAD` | `{prefix}/upload/<id>` | Query the current offset |
+| `DELETE` | `{prefix}/upload/<id>` | Cancel an in-flight upload |
+
+`PATCH` bodies MUST be the raw bytes for that offset
+(`Content-Type: application/offset+octet-stream`) — never base64-encoded or
+wrapped in another envelope.
+
+### 4.1 `Upload-Metadata`
+
+The TUS `Upload-Metadata` header (comma-separated `<key> <base64(value)>`
+pairs) MUST be parsed for at least:
+
+| Key | Required | Description |
+|---|---|---|
+| `artifactId` | Yes (or a legacy `videoid`/`projectid` alias) | UUID for this artifact. |
+| `filename` | Yes | Original filename; extension validated against `kind`'s allowed list. |
+| `kind` | No, defaults to `video` | `video`, `project`, or `captions`. |
+| `relatedTo` | No | UUID of another artifact this one belongs to (§8). |
+| `checksum` | No | `<algorithm>:<hex digest>` of the finished file (§6.3). |
+
+A client MUST always send `artifactId` (not only the legacy aliases) on new
+uploads. A server MUST continue accepting `videoid`/`projectid` as aliases
+for `artifactId` for back-compat with clients built against protocol
+version 1 before this alias was the only spelling — this alias requirement
+holds for the lifetime of protocol version 1.
+
+### 4.2 Resumption
+
+A client MUST always issue a `HEAD` request to learn the authoritative
+offset before resuming an interrupted upload — it MUST NOT trust a locally
+cached byte count, which can be stale (server restart, a partial write that
+never committed, clock differences between client and a previous session).
+
+## 5. Authentication
+
+### 5.1 Token transport
+
+A client MUST send the pairing token as `Authorization: Bearer <token>` on
+every `POST`/`PATCH`/`DELETE` request to `{prefix}/upload*`, and SHOULD also
+send it as `?token=` on `GET` requests to a watch/playback URL (some servers
+validate playback links without requiring a header, e.g. for browser
+playback).
+
+### 5.2 Server-side verification
+
+A server MAY implement authentication however it chooses — this document
+does not mandate a scheme. A server MUST reject requests it cannot authorize
+with `403` (or `401` if no credential was presented at all), and SHOULD do
+so before any bytes are accepted for a new upload.
+
+### 5.3 Rejection responses
+
+Error responses MUST be JSON of the shape `{ "ok": false, "error": string }`.
+
+### 5.4 Recommended capability-token shape (non-normative)
+
+Servers that don't already have an auth scheme are encouraged (not required)
+to use a stateless, HMAC-signed token with at least:
+
+```json
+{ "artifactId": "<uuid>", "iat": 1234567890, "exp": 1234569690, "kid": "2026-06", "issuer": "https://vault.example.org" }
+```
+
+`kid` lets a secret rotate with an overlap window instead of instantly
+invalidating every outstanding token. `iat` (signed alongside `exp`) closes a
+clock-skew gap where signing only expiry would let a slow clock accept an
+expired token. `issuer` prevents a token minted by one deployment from being
+replayed against a different one that happens to share a secret. A token MAY
+authorize an artifact other than the one it names if that artifact declares
+the token's `artifactId` as its `relatedTo` (§8) — this lets one token cover
+an entire upload session (a video, its captions, and every beat + manifest
+under `uploadUnit: "beat"`) rather than requiring one token per artifact.
+
+This shape is exactly what `@mieweb/pulsevault`'s `issueCapabilityToken`/
+`verifyCapabilityToken`/`createCapabilityAuthorize` implement, but any server
+is free to use its own scheme entirely — only §5.1–§5.3 are normative.
+
+## 6. Storage and validation
+
+### 6.1 Readiness
+
+A server MUST NOT serve (via `GET`) an artifact's bytes until the upload is
+fully written and any payload validation has passed. An in-progress or
+rejected upload MUST return `404` from the serving route, not partial or
+corrupt bytes.
+
+### 6.2 Serving
+
+A server MUST expose `GET {prefix}/artifacts/<artifactId>` returning either
+the bytes directly or a redirect to a URL serving them (e.g. a presigned
+object-storage URL). The kind is resolved server-side; it is not encoded in
+this URL. A server MUST also expose `DELETE {prefix}/artifacts/<artifactId>`.
+
+### 6.3 Checksum (optional)
+
+If a server supports checksum verification (advertised via `/capabilities`),
+it SHOULD verify the client-supplied `checksum` metadata against the
+finished file before marking the upload ready, and MUST reject a mismatch
+with `422` and remove the rejected bytes. This is at-rest integrity
+verification on the finished artifact — it does not substitute for
+in-transit (TLS) integrity, and does not verify individual chunks as they
+arrive.
+
+## 7. Versioning
+
+A server MUST report `protocolVersion`, `minSupportedVersion`, and
+`maxSupportedVersion` via `/capabilities` (§2) and `Protocol-Version` on
+every response. A client encountering a server whose supported range
+excludes its own version MUST NOT attempt to pair, and SHOULD surface a
+clear, specific message rather than a generic failure.
+
+## 8. Artifact relationships (`relatedTo`) and `uploadUnit`
+
+A pulse (a short composed of one or more beats) MAY be uploaded as a single
+pre-merged video (`uploadUnit: "merged"`) or as individual per-beat artifacts
+plus a manifest (`uploadUnit: "beat"`) — the operator declares which via
+`/capabilities` (§2); this document does not prefer one over the other.
+
+Under `uploadUnit: "beat"`, a client uploads each beat under its own
+`artifactId`, plus one manifest artifact (`kind: "project"`, a JSON document
+listing the ordered beat `artifactId`s) and, optionally, per-beat captions
+(`kind: "captions"`). Every non-primary artifact in the session SHOULD
+declare `relatedTo` pointing at the session's anchor `artifactId` (the one
+named in the pairing link) so a single capability token can authorize the
+whole session (§5.4).
+
+The relational graph of replies between beats/pulses (who replied to what,
+rendering a thread) is explicitly **out of scope** for this document. That
+graph is a query/relational concern for the operator's own systems, built
+from `relatedTo` and whatever additional metadata the operator chooses to
+record — not something a Pulse-compatible server is required to implement.
+
+## 9. Compatibility notes
+
+A client or server MAY support additional, non-normative extensions to this
+contract (additional `Upload-Metadata` keys, additional kinds, additional
+`/capabilities` fields) as long as doing so does not break a client/server
+that only implements what's written here. New REQUIRED fields MUST NOT be
+added to a response without a `protocolVersion` bump.

--- a/README.md
+++ b/README.md
@@ -2,37 +2,28 @@
 
 Fastify plugin for resumable video uploads via the [TUS protocol](https://tus.io/), with filesystem-first local storage and deep link helpers for the [Pulse](https://github.com/mieweb/pulse) mobile app.
 
-```text
-    Pulse app                   Your Fastify app
-    ─────────                   ────────────────
+**Licensing note**: this package is currently Source Available (free for non-commercial use; see [License](#license)) — a move to a fully OSI-approved open source license is planned but not yet landed. If you're evaluating this for adoption, read [License](#license) before investing evaluation time.
 
-   ┌───────────┐    pair +    ┌────────────────────────────────┐
-   │ iOS / web │ ─── TUS ───► │  Pulsevault plugin             │
-   └───────────┘              │  POST  /pulsevault/upload      │
-                              │  PATCH /pulsevault/upload/:id  │
-                              │  GET   /pulsevault/:videoid    │
-                              └────────────────┬───────────────┘
-                                         │
-                                         ▼
-                              ┌──────────────────────┐
-                              │  Your hooks          │
-                              │  • authorize         │
-                              │  • validatePayload   │
-                              │  • onUploadComplete  │
-                              └──┬─────────────────┬─┘
-                                 │                 │
-                                 ▼                 ▼
-                          ┌──────────────┐  ┌──────────────┐
-                          │   Storage    │  │ Your systems │
-                          │   adapter    │  │  DB · SSO ·  │
-                          │ local / S3 / │  │  audit logs  │
-                          │ GCS / custom │  │  pipelines   │
-                          └──────────────┘  └──────────────┘
-```
+See also: [`PROTOCOL.md`](PROTOCOL.md) (the wire contract, independent of this implementation — read this if you're building a Pulse-compatible server *without* this package) and [`OPERATIONS.md`](OPERATIONS.md) (scaling, secrets, retention, monitoring).
 
 Self-hosted video capture for places that can't ship recordings to a vendor. Pulse records the walkthrough on the phone; Pulsevault receives it inside the Fastify app you already run, behind your auth, on your storage. Pair a device by QR code and upload over TUS so two-minute captures from the floor survive signal drops and device restarts.
 
-Hook in at `authorize`, `validatePayload`, or `onUploadComplete` to bolt on whatever your institution already runs — SSO, audit logs, transcoding queues, AI pipelines. The plugin mounts three routes; the rest stays yours.
+Hook in at `authorize`, `validatePayload`, or `onUploadComplete` to bolt on whatever your institution already runs — SSO, audit logs, transcoding queues, AI pipelines. The plugin mounts a handful of routes; the rest stays yours. **Every deployment of this plugin is fully independent** — there's no central Pulse-run service anywhere in this picture:
+
+```mermaid
+graph LR
+    subgraph "Org A — fully independent"
+        A1["Org A's Fastify server"] -->|registers| A2["@mieweb/pulsevault"]
+        A1 -->|owns| A3["artifactId minting, token issuance,\nTTL policy, secret rotation, revocation"]
+    end
+    subgraph "Org B — fully independent, no pulsevault"
+        B1["Org B's own server"] -->|implements from spec only| B2["PROTOCOL.md"]
+        B1 -->|owns| B3["its own auth scheme entirely"]
+    end
+    P["Pulse mobile app\nmulti-tenant client"] -->|pairs + uploads via open contract| A1
+    P -->|pairs + uploads via open contract| B1
+    P -.->|no dependency on either| X[("No central Pulse service")]
+```
 
 The local storage adapter writes to a stable on-disk layout (see [Local storage](#local-storage)) so you can layer post-processing — transcription, thumbnails, AI analysis — directly against the files from an `onUploadComplete` hook.
 
@@ -62,30 +53,57 @@ await app.register(pulseVault, {
   maxUploadSize: 5 * 1024 * 1024 * 1024, // 5 GiB
 });
 
-// Your server owns videoid creation — attach auth, DB records, quotas here.
+// Your server owns artifactId creation — attach auth, DB records, quotas here.
 app.post("/reserve", async (_req, reply) => {
-  return reply.send({ videoid: randomUUID() });
+  return reply.send({ artifactId: randomUUID() });
 });
 
 await app.listen({ port: 3030 });
+```
+
+This is the minimal setup with no authentication — fine for local development,
+not for production. See [`authorize`](#authorize) and [Capability tokens](#capability-tokens)
+for a secure-by-default option, and `OPERATIONS.md` for the full production checklist.
+
+## How a pairing + upload session flows
+
+```mermaid
+sequenceDiagram
+    participant Org as Your server
+    participant User
+    participant Pulse as Pulse app
+
+    Org->>Org: mint artifactId + issue a token
+    Org->>User: show QR / deep link
+    User->>Pulse: open link
+    Pulse->>Pulse: validate link, show pairing screen
+    User->>Pulse: confirm and choose draft
+    Pulse->>Org: POST upload, Bearer token, kind video, checksum
+    Org->>Pulse: 201 Location
+    Pulse->>Org: PATCH chunks, HEAD before resume
+    Org->>Org: validatePayload, markReady, onUploadComplete
+    Pulse->>Org: POST upload, kind captions, same session
+    Org->>Org: validatePayload, markReady, onUploadComplete
+    Org->>Pulse: ready for playback and captions fetch
 ```
 
 ## Routes
 
 The plugin mounts the following routes under `prefix`:
 
-| Method                         | Path                      | Description                                      |
-| ------------------------------ | ------------------------- | ------------------------------------------------ |
-| `POST`                         | `/pulsevault/upload`      | Create a TUS upload session                      |
-| `PATCH` / `HEAD` / `DELETE` \* | `/pulsevault/upload/:id`  | Upload chunks, probe offset, cancel upload (TUS) |
-| `GET`                          | `/pulsevault/:videoid`    | Stream or redirect to the uploaded video         |
-| `DELETE`                       | `/pulsevault/:videoid`    | Delete a finalized upload (bytes + sidecar)      |
+| Method | Path | Description |
+| --- | --- | --- |
+| `GET` | `/pulsevault/capabilities` | Unauthenticated discovery: protocol version, `uploadUnit`, allowed extensions, limits |
+| `POST` | `/pulsevault/upload` | Create a TUS upload session |
+| `PATCH` / `HEAD` / `DELETE` \* | `/pulsevault/upload/:id` | Upload chunks, probe offset, cancel upload (TUS) |
+| `GET` | `/pulsevault/artifacts/:artifactId` | Stream or redirect to the uploaded artifact (any kind) |
+| `DELETE` | `/pulsevault/artifacts/:artifactId` | Delete a finalized upload (bytes + sidecar) |
 
-\* `DELETE /pulsevault/upload/:id` is TUS's own "cancel in-flight upload" — distinct from `DELETE /pulsevault/:videoid`, which removes a finalized video.
+\* `DELETE /pulsevault/upload/:id` is TUS's own "cancel in-flight upload" — distinct from `DELETE /pulsevault/artifacts/:artifactId`, which removes a finalized artifact.
 
-> `POST /reserve` is **not** part of the plugin. Your server implements it so you control auth, ownership, and any business logic tied to video creation.
+> `POST /reserve` is **not** part of the plugin. Your server implements it so you control auth, ownership, and any business logic tied to artifact creation.
 
-`GET /pulsevault/:videoid` only serves uploads whose adapter has been told to mark them ready. With the built-in local adapter, that means the final PATCH has landed _and_ `validatePayload` (if configured) accepted the bytes. In-progress uploads return 404.
+`GET /pulsevault/artifacts/:artifactId` only serves uploads whose adapter has been told to mark them ready. With the built-in local adapter, that means the final PATCH has landed _and_ `validatePayload` (if configured) accepted the bytes. In-progress uploads return 404. The artifact's kind (`video`/`project`/`captions`) is resolved from storage, not the URL — there's one route for every kind.
 
 ## Plugin options
 
@@ -94,17 +112,21 @@ type PulseVaultPluginOptions = {
   storage: PulseVaultStorage;
   prefix: string;
   maxUploadSize: number;
-  decoratorName?: string; // default: "pulseVault"
+  uploadUnit?: "beat" | "merged";              // default: "beat" — see "Upload unit"
+  decoratorName?: string;                      // default: "pulseVault"
   allowedExtensions?:
-    | string[]                                    // legacy — treated as video-only
-    | { video?: string[]; project?: string[] };   // per-kind (recommended)
-  // defaults: { video: [".mp4"], project: [".pulse", ".zip"] }
+    | string[]                                                          // legacy — treated as video-only
+    | { video?: string[]; project?: string[]; captions?: string[] };    // per-kind (recommended)
+  // defaults: { video: [".mp4"], project: [".pulse", ".zip"], captions: [".srt"] }
   cache?: PulseVaultCacheOptions;
   authorize?: PulseVaultAuthorize;
-  validatePayload?: PulseVaultValidatePayload;          // video uploads only
-  validateProjectPayload?: PulseVaultValidatePayload;   // project uploads only
-  onUploadComplete?: PulseVaultOnUploadComplete;        // video uploads only
-  onProjectUploadComplete?: PulseVaultOnUploadComplete; // project uploads only
+  validatePayload?: PulseVaultValidatePayload;          // runs for every kind; branch on ctx.kind
+  onUploadComplete?: PulseVaultOnUploadComplete;        // runs for every kind; branch on ctx.kind
+  onArtifactEvent?: PulseVaultOnArtifactEvent;          // low-frequency hook for metrics + audit logging
+  /** @deprecated use validatePayload + ctx.kind === "project" */
+  validateProjectPayload?: PulseVaultValidatePayload;
+  /** @deprecated use onUploadComplete + ctx.kind === "project" */
+  onProjectUploadComplete?: PulseVaultOnUploadComplete;
 };
 ```
 
@@ -122,6 +144,15 @@ URL prefix for all plugin routes. Set to `"/pulsevault"` for the standard namesp
 
 Maximum upload size in bytes. Use `Infinity` for no cap.
 
+### Upload unit
+
+`uploadUnit: "beat" | "merged"` — purely advertised via `GET /pulsevault/capabilities`; **the plugin doesn't enforce either.** It tells the client which upload strategy this deployment expects:
+
+- `"beat"` (default): the client uploads each clip individually (no merge/re-encode pass), plus a `kind=project` manifest artifact for ordering. Lower client-side cost, finer-grained resumability.
+- `"merged"`: the client pre-merges a pulse's clips into one video before uploading. Simpler server-side mental model (one artifact per pulse), more client-side work.
+
+A client reads this at pairing time, before doing any merge or upload work, and branches accordingly. See `PROTOCOL.md` §8 for the full contract.
+
 ### `decoratorName`
 
 Name of the Fastify decorator that exposes the storage adapter on the instance. Defaults to `"pulseVault"`. Override when registering the plugin more than once in the same process.
@@ -137,21 +168,21 @@ import "@mieweb/pulsevault/augment";
 File extensions accepted per artifact kind. Three accepted forms:
 
 ```ts
-// 1. Omit entirely — uses both defaults:
-//    video: [".mp4"]   project: [".pulse", ".zip"]
+// 1. Omit entirely — uses all three defaults:
+//    video: [".mp4"]   project: [".pulse", ".zip"]   captions: [".srt"]
 
-// 2. Flat array (legacy) — video-only; project defaults to [".pulse", ".zip"]:
+// 2. Flat array (legacy) — video-only; project/captions keep their defaults:
 allowedExtensions: [".mp4"]
 
 // 3. Per-kind object — unset keys fall back to their defaults:
-allowedExtensions: { video: [".mp4"], project: [".pulse"] }
+allowedExtensions: { video: [".mp4"], project: [".pulse"], captions: [".srt"] }
 ```
 
 All extensions must include the leading dot and are matched case-insensitively. The `kind` field in `Upload-Metadata` determines which list is checked.
 
 ### `cache`
 
-Cache-control options for the `GET /:videoid` route, forwarded to `@fastify/send`:
+Cache-control options for the `GET /artifacts/:artifactId` route, forwarded to `@fastify/send`:
 
 ```ts
 type PulseVaultCacheOptions = {
@@ -172,9 +203,10 @@ type PulseVaultAuthorize = (
   request: FastifyRequest,
   ctx: {
     phase: "create" | "patch" | "resolve" | "delete";
-    videoid: string;
-    kind: "video" | "project";  // artifact kind; always present
+    artifactId: string;
+    kind: "video" | "project" | "captions";  // artifact kind; always present
     token?: string;             // only on "resolve" phase
+    relatedTo?: string;         // the session-anchor artifact this one belongs to, if any
   },
 ) => void | Promise<void>;
 ```
@@ -182,38 +214,44 @@ type PulseVaultAuthorize = (
 ```ts
 await app.register(pulseVault, {
   // ...
-  authorize: async (request, { phase, videoid, kind }) => {
+  authorize: async (request, { phase, artifactId, kind }) => {
     const token = request.headers.authorization?.replace("Bearer ", "");
-    if (!isValid(token, videoid)) {
+    if (!isValid(token, artifactId)) {
       throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
     }
   },
 });
 ```
 
+Don't want to write your own auth from scratch? See [Capability tokens](#capability-tokens) for a secure-by-default option.
+
 ### `validatePayload`
 
-Optional async hook that runs _after_ TUS writes the final byte but _before_ the upload is marked ready or `onUploadComplete` fires — **for `kind=video` uploads only**. Throw to reject — the plugin calls `storage.remove` to free the bytes and returns a 4xx (default 422) to the client. The sidecar never flips to `"ready"`, so the file is never served.
+Optional async hook that runs _after_ TUS writes the final byte but _before_ the upload is marked ready or `onUploadComplete` fires — **for every artifact kind**, with `ctx.kind` telling you which. Throw to reject — the plugin calls `storage.remove` to free the bytes and returns a 4xx (default 422) to the client. The sidecar never flips to `"ready"`, so the artifact is never served.
 
 ```ts
 type PulseVaultValidatePayload = (
   request: FastifyRequest,
   ctx: {
-    videoid: string;
+    artifactId: string;
     size: number;
     uploadId: string;
+    kind: "video" | "project" | "captions";
     /** Absolute path to finalized bytes for adapters that expose `getLocalPath`. */
     localPath: string | null;
+    /** Client-supplied `<algorithm>:<hex>` digest, if `Upload-Metadata.checksum` was sent. */
+    checksum?: string;
   },
 ) => void | Promise<void>;
 ```
 
-Use for magic-byte sniffing, virus scanning, size re-checks — anything that needs the final bytes. A ready-made helper ships with the package:
+Use for magic-byte sniffing, checksum verification, virus scanning, size re-checks — anything that needs the final bytes. Ready-made helpers ship with the package:
 
 ```ts
 import pulseVault, {
   createLocalStorage,
   createMp4Sniffer,
+  createChecksumValidator,
 } from "@mieweb/pulsevault";
 
 const storage = createLocalStorage({ workspaceDir: "./data" });
@@ -221,48 +259,124 @@ const storage = createLocalStorage({ workspaceDir: "./data" });
 await app.register(pulseVault, {
   // ...
   storage,
-  validatePayload: createMp4Sniffer(storage),
+  // Chain validators: checksum runs first, then the MP4 sniff.
+  validatePayload: createChecksumValidator(createMp4Sniffer(storage)),
 });
 ```
 
-`createMp4Sniffer` reads the first 12 bytes and verifies the ISOBMFF `ftyp` header (MP4, MOV, M4V, 3GP). Uploads that pass the extension check but contain non-video bytes are rejected with 422 and the disk is cleaned up.
+`createMp4Sniffer` reads the first 12 bytes and verifies the ISOBMFF `ftyp` header (MP4, MOV, M4V, 3GP). Uploads that pass the extension check but contain non-video bytes are rejected with 422 and the disk is cleaned up. The lower-level `sniffMp4(path)` is also exported if you want to drive your own validator.
 
-The lower-level `sniffMp4(path)` is also exported if you want to drive your own validator.
+`createMp4Sniffer`/`createChecksumValidator` only make sense for `kind=video`/general payloads — they run unconditionally for every kind your hook receives, so branch on `ctx.kind` yourself if you only want them applied to one kind, or compose differently per kind:
+
+```ts
+validatePayload: async (request, ctx) => {
+  if (ctx.kind === "video") return createMp4Sniffer(storage)(request, ctx);
+  // project/captions: no byte-level check, or your own.
+},
+```
 
 ### `onUploadComplete`
 
-Optional async hook fired once the final byte is written, `validatePayload` has passed, and the sidecar has been marked ready — **for `kind=video` uploads only**. Use it to update a database row, enqueue a job, or write an audit log. Throwing returns a `500` to the client. The video is ready at this point — if you want all-or-nothing semantics, call `storage.remove` before throwing.
+Optional async hook fired once the final byte is written, `validatePayload` has passed, and the sidecar has been marked ready — **for every artifact kind**, with `ctx.kind` telling you which. Use it to update a database row, enqueue a job, or write an audit log. Throwing returns a `500` to the client. The artifact is ready at this point — if you want all-or-nothing semantics, call `storage.remove` before throwing.
 
 ```ts
 type PulseVaultOnUploadComplete = (
   request: FastifyRequest,
-  ctx: { videoid: string; size: number; uploadId: string },
+  ctx: { artifactId: string; kind: "video" | "project" | "captions"; size: number; uploadId: string },
 ) => void | Promise<void>;
 ```
 
-### `validateProjectPayload`
+### `onArtifactEvent`
 
-Same lifecycle and signature as `validatePayload`, but fires only for `kind=project` uploads (`.pulse`, `.zip`, etc.). Use this to inspect the bundle before it is marked ready.
+Optional low-frequency hook — fired on authorize rejection (`create`/`delete`/`resolve` phases only, never per-chunk `patch`), upload completion, and payload-validation rejection. One hook covers both ops metrics and a compliance audit trail instead of hand-wiring both from the lower-level hooks above:
 
-### `onProjectUploadComplete`
+```ts
+type PulseVaultArtifactEvent = {
+  phase: "authorize" | "complete" | "reject";
+  artifactId: string;
+  kind: "video" | "project" | "captions";
+  size?: number;
+  reason?: string; // present for "authorize" and "reject"
+};
 
-Same lifecycle and signature as `onUploadComplete`, but fires only for `kind=project` uploads. Use this to index a draft, enable cross-device editing, relay a diagnostic bundle to an issue tracker, etc. The bundle bytes are opaque to PulseVault — the consumer decides what to do with them.
+onArtifactEvent: (event) => {
+  app.log.info(event, "pulsevault artifact event"); // or push to a metrics/audit sink
+},
+```
+
+See `OPERATIONS.md` for a Prometheus-counter example and what to alert on.
+
+### `validateProjectPayload` / `onProjectUploadComplete` (deprecated)
+
+Same lifecycle as `validatePayload`/`onUploadComplete`, but only fired for `kind=project` uploads. **Deprecated** — use the generic `validatePayload`/`onUploadComplete` with a `ctx.kind === "project"` branch instead. Still honored this release (passing either emits a one-time `DeprecationWarning` at registration); will be removed in a future major version.
 
 ### Upload-complete sequencing
 
-When the final PATCH lands the plugin runs the following steps in order. Any step failing short-circuits the rest.
+When the final PATCH lands the plugin runs the following steps in order, for every kind. Any step failing short-circuits the rest.
 
-**For `kind=video`:**
+1. **`validatePayload`** (optional, runs for every kind) — throws → `storage.remove(artifactId)`, HTTP 4xx (default 422).
+2. **`storage.markReady(artifactId)`** — flips the sidecar so `resolve()` will serve the bytes.
+3. **`onUploadComplete`** (optional, runs for every kind) — throws → HTTP 500; bytes remain ready unless the consumer removes them.
 
-1. **`validatePayload`** (optional) — throws → `storage.remove(videoid)`, HTTP 4xx (default 422).
-2. **`storage.markReady(videoid)`** — flips the sidecar so `resolve()` will serve the bytes.
-3. **`onUploadComplete`** (optional) — throws → HTTP 500; bytes remain ready unless the consumer removes them.
+(`validateProjectPayload`/`onProjectUploadComplete`, if passed, run instead of the generic hooks specifically for `kind=project` — see the deprecation note above.)
 
-**For `kind=project`:**
+## Capabilities discovery
 
-1. **`validateProjectPayload`** (optional) — same semantics; throws → `storage.remove(videoid)`, HTTP 4xx.
-2. **`storage.markReady(videoid)`** — flips the sidecar.
-3. **`onProjectUploadComplete`** (optional) — throws → HTTP 500.
+`GET {prefix}/capabilities` is unauthenticated (no secrets in the response) and lets a client detect protocol compatibility and this deployment's configuration before pairing:
+
+```json
+{
+  "protocolVersion": 1,
+  "minSupportedVersion": 1,
+  "maxSupportedVersion": 1,
+  "uploadUnit": "beat",
+  "kinds": ["video", "project", "captions"],
+  "allowedExtensions": { "video": [".mp4"], "project": [".pulse", ".zip"], "captions": [".srt"] },
+  "maxUploadSize": 5368709120,
+  "checksum": { "algorithms": ["sha256", "sha1", "md5"] }
+}
+```
+
+See `PROTOCOL.md` §2 for the full normative shape.
+
+## Capability tokens
+
+Don't want to write your own auth scheme? `issueCapabilityToken`/`verifyCapabilityToken`/`createCapabilityAuthorize` implement a stateless, HMAC-signed token — no server-side session table, so you can rotate secrets, change TTL policy, or revoke at the artifact level entirely on your own schedule.
+
+```ts
+import pulseVault, {
+  createLocalStorage,
+  createCapabilityAuthorize,
+  issueCapabilityToken,
+  buildUploadLink,
+} from "@mieweb/pulsevault";
+import { randomUUID } from "node:crypto";
+
+const keys = { "2026-06": process.env.PULSEVAULT_KEY_2026_06! }; // add the previous key during rotation
+const issuer = "https://vault.example.org"; // identity claim — no path, just who issued the token
+const prefix = "/pulsevault";
+
+await app.register(pulseVault, {
+  prefix,
+  storage: createLocalStorage({ workspaceDir: "./data" }),
+  maxUploadSize: 5 * 1024 * 1024 * 1024,
+  authorize: createCapabilityAuthorize((kid) => keys[kid] ?? null, { issuer }),
+});
+
+app.post("/pair", async (_req, reply) => {
+  const artifactId = randomUUID();
+  const token = issueCapabilityToken(artifactId, keys["2026-06"], {
+    keyId: "2026-06",
+    issuer,
+    expirySeconds: 1800, // 30 minutes — long enough for one upload session
+  });
+  // `server` is the full base URL the client uploads to — origin *plus* the
+  // plugin's prefix — not just `issuer`'s bare origin.
+  return reply.send({ link: buildUploadLink({ server: `${issuer}${prefix}`, artifactId, token }) });
+});
+```
+
+A token authorizes either the artifact it names, or any artifact that declares that one as its `relatedTo` — so one token issued for a video also covers its captions and (under `uploadUnit: "beat"`) every beat and the manifest in the same session, without minting a token per artifact. See `PROTOCOL.md` §5.4 for the full claim shape (`kid`/`iat`/`exp`/`issuer`/`artifactId`) and rationale.
 
 ## Upload-Metadata protocol
 
@@ -270,15 +384,17 @@ The TUS `Upload-Metadata` header is a comma-separated list of `<key> <base64>` p
 
 | Key | Required | Description |
 |---|---|---|
-| `videoid` | Yes (or `projectid`) | Server-generated UUID for this upload. |
-| `projectid` | Alias for `videoid` | Accepted as a synonym. Use `videoid` for new code. |
+| `artifactId` | Yes (or `videoid`/`projectid`) | Server-generated UUID for this upload. |
+| `videoid` / `projectid` | Legacy aliases for `artifactId` | Accepted as synonyms indefinitely (protocol v1). Use `artifactId` for new code. |
 | `filename` | Yes | Original filename. The extension is validated against the kind's allowed list. |
-| `kind` | No | `video` (default) or `project`. Determines the storage subdir and which hooks fire. |
+| `kind` | No | `video` (default), `project`, or `captions`. Determines the storage subdir and which hooks fire. |
+| `relatedTo` | No | UUID of another artifact this one belongs to (e.g. a video's captions). Lets one capability token authorize a whole session. |
+| `checksum` | No | `<algorithm>:<hex digest>` of the finished file, verified by `createChecksumValidator`/`createS3ChecksumValidator` if configured. |
 
-Example (`kind=project`):
+Example (`kind=captions`, linked to a video):
 
 ```
-Upload-Metadata: videoid <base64(uuid)>, filename <base64("draft.pulse")>, kind <base64("project")>
+Upload-Metadata: artifactId <base64(uuid)>, filename <base64("clip.srt")>, kind <base64("captions")>, relatedTo <base64(videoArtifactId)>
 ```
 
 ## Local storage
@@ -287,7 +403,8 @@ Upload-Metadata: videoid <base64(uuid)>, filename <base64("draft.pulse")>, kind 
 import { createLocalStorage } from "@mieweb/pulsevault";
 
 const storage = createLocalStorage({
-  workspaceDir: "./data", // directory for uploads; created if absent
+  workspaceDir: "./data",   // directory for uploads; created if absent
+  metaCacheLimit: 10_000,   // optional — bounds the in-memory metadata cache
 });
 ```
 
@@ -297,16 +414,20 @@ The local adapter writes uploads into flat kind-scoped subdirectories. Downstrea
 
 ```text
 <workspaceRoot>/
-  .pulsevault/<id>.json           # sidecar: { version, ext, filename, status, kind }
-  video/<id><ext>                 # video upload bytes  (kind="video")
+  .pulsevault/<id>.json           # sidecar: { version, ext, filename, status, kind, relatedTo, checksum }
+  video/<id><ext>                 # video upload bytes    (kind="video")
   video/<id><ext>.json            # @tus/file-store offset/metadata sidecar
-  project/<id><ext>               # project bundle bytes (kind="project")
+  project/<id><ext>               # project bundle bytes  (kind="project")
   project/<id><ext>.json          # @tus/file-store offset/metadata sidecar
+  captions/<id><ext>              # captions bytes        (kind="captions")
+  captions/<id><ext>.json         # @tus/file-store offset/metadata sidecar
 ```
 
-`status` is `"uploading"` between `reserveUpload` and the successful final PATCH; `"ready"` thereafter. `GET /:id` only serves `"ready"` uploads. `kind` defaults to `"video"` when absent (back-compat with pre-kind sidecars).
+`status` is `"uploading"` between `reserveUpload` and the successful final PATCH; `"ready"` thereafter. `GET /artifacts/:id` only serves `"ready"` uploads. `kind` defaults to `"video"` when absent (back-compat with pre-kind sidecars).
 
-The adapter exposes `storage.workspaceRoot` (absolute, resolved from `workspaceDir`) so consumers can compute per-resource paths without re-implementing the layout. `storage.getKind(id)` returns `"video" | "project" | null` for a lightweight kind check without a full `resolve()` call.
+The adapter exposes `storage.workspaceRoot` (absolute, resolved from `workspaceDir`) so consumers can compute per-resource paths without re-implementing the layout. `storage.getKind(id)` returns `"video" | "project" | "captions" | null`; `storage.getRelatedTo(id)` and `storage.getChecksum(id)` return the corresponding sidecar fields, each `null` if absent/unknown.
+
+**Horizontal scaling**: this adapter requires sticky-session routing or a shared filesystem across instances — see `OPERATIONS.md`.
 
 ### Post-processing (transcription, thumbnails, AI)
 
@@ -323,9 +444,10 @@ await app.register(pulseVault, {
   prefix: "/pulsevault",
   storage,
   maxUploadSize: 5 * 1024 * 1024 * 1024,
-  onUploadComplete: async (_req, { videoid }) => {
+  onUploadComplete: async (_req, { artifactId, kind }) => {
+    if (kind !== "video") return;
     const videoDir = path.join(storage.workspaceRoot, "video");
-    const pod = new ArtiPod({ id: videoid, useMainMount: false });
+    const pod = new ArtiPod({ id: artifactId, useMainMount: false });
     pod.addMount(new ArtiMount("video", videoDir));
     // Create these lazily as your pipeline produces artifacts:
     // pod.addMount(new ArtiMount("transcripts", path.join(root, "transcripts")));
@@ -341,7 +463,7 @@ await app.register(pulseVault, {
 
 ## Object storage (Cloudflare R2 / AWS S3)
 
-`createS3Storage` is a built-in adapter that streams uploads into an S3-compatible bucket via S3 multipart upload and serves playback by redirecting the client to a short-lived **presigned URL** (so bytes never flow back through your server). Because Cloudflare R2 speaks the S3 API, the same adapter covers both R2 and AWS S3 — they differ only by endpoint and credentials.
+`createS3Storage` is a built-in adapter that streams uploads into an S3-compatible bucket via S3 multipart upload and serves playback by redirecting the client to a short-lived **presigned URL** (so bytes never flow back through your server). Because Cloudflare R2 speaks the S3 API, the same adapter covers both R2 and AWS S3 — they differ only by endpoint and credentials. It has no horizontal-scaling caveat — every instance talks to the same bucket.
 
 It's **opt-in**: the AWS SDK and `@tus/s3-store` are `optionalDependencies`, loaded lazily only when you call `createS3Storage`. Install them in your app:
 
@@ -382,19 +504,20 @@ const storage = await createS3Storage({
 });
 ```
 
-Credentials are optional — omit `accessKeyId`/`secretAccessKey` to use the AWS SDK's default credential chain (env vars, IAM role, etc.). **Never hard-code keys; read them from the environment.**
+Credentials are optional — omit `accessKeyId`/`secretAccessKey` to use the AWS SDK's default credential chain (env vars, IAM role, etc.). **Never hard-code keys; read them from the environment** — see `OPERATIONS.md` for a secrets-manager example.
 
 ### Object layout
 
 ```text
 <bucket>/
-  .pulsevault/<id>.json   # metadata sidecar: { version, ext, filename, status, kind }
-  video/<id><ext>         # finalized video object   (kind="video")
-  project/<id><ext>       # finalized project object (kind="project")
+  .pulsevault/<id>.json   # metadata sidecar: { version, ext, filename, status, kind, relatedTo, checksum }
+  video/<id><ext>         # finalized video object    (kind="video")
+  project/<id><ext>       # finalized project object  (kind="project")
+  captions/<id><ext>      # finalized captions object (kind="captions")
   <key>.info              # @tus/s3-store multipart bookkeeping (transient)
 ```
 
-`resolve()` only returns a presigned URL once the sidecar `status` is `"ready"` (after the final byte lands and `validatePayload` passes), so in-progress or rejected uploads are never served. `getKind(id)` returns the kind without a full resolve.
+`resolve()` only returns a presigned URL once the sidecar `status` is `"ready"` (after the final byte lands and `validatePayload` passes), so in-progress or rejected uploads are never served. `getKind(id)` returns the kind without a full resolve; `getRelatedTo(id)`/`getChecksum(id)` mirror the local adapter.
 
 ### Options
 
@@ -408,13 +531,14 @@ Credentials are optional — omit `accessKeyId`/`secretAccessKey` to use the AWS
 | `forcePathStyle` | `true` when `endpoint` is set | R2 and most S3-compatible stores need path-style. |
 | `presignTtlSeconds` | `900` | Lifetime of the playback presigned URL. |
 | `partSize` | computed | Preferred multipart part size (≥ 5 MiB), forwarded to `@tus/s3-store`. |
+| `metaCacheLimit` | `10000` | Caps the in-memory metadata cache before evicting the oldest entry. |
 | `clientConfig` | — | Advanced: extra `S3ClientConfig` merged into the client. |
 
 > The runnable demo wires these to environment variables — see [`examples/rn-demo/.env.example`](examples/rn-demo/.env.example) for the full list (`STORAGE`, `S3_BUCKET`, `S3_ENDPOINT`, `AWS_REGION`, `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, …).
 
 ### Payload validation on remote storage
 
-The default `createMp4Sniffer` reads a local file path, which doesn't exist for a bucket object. Use **`createS3Mp4Sniffer(storage)`** instead: it fetches the first 12 bytes via a small ranged GET (`storage.readHeader`) and applies the same ISOBMFF `ftyp` check, rejecting non-MP4 uploads with 422 and removing the object — no full download.
+The default `createMp4Sniffer`/`createChecksumValidator` read a local file path, which doesn't exist for a bucket object. Use **`createS3Mp4Sniffer(storage)`**/**`createS3ChecksumValidator(storage)`** instead: they fetch the bytes they need via the adapter (a small ranged GET for the MP4 sniff; a full object read for the checksum, since a digest needs every byte) rather than assuming a local path.
 
 ### Direct playback & CORS
 
@@ -438,32 +562,36 @@ const storage: PulseVaultStorage = {
   async shutdown() {
     /* optional teardown */
   },
-  async reserveUpload({ videoid, filename, ext }) {
+  async reserveUpload({ artifactId, filename, ext, kind, relatedTo, checksum }) {
     // Called by the TUS naming function. Return the file id for the datastore.
-    await db.createVideo({ videoid, filename, status: "uploading" });
-    return `${videoid}${ext}`;
+    await db.createArtifact({ artifactId, filename, kind, relatedTo, checksum, status: "uploading" });
+    return `${kind}/${artifactId}${ext}`;
   },
-  async resolve(videoid): Promise<PulseVaultResolution | null> {
-    const video = await db.findVideo(videoid);
-    if (!video || video.status !== "ready") return null;
+  async resolve(artifactId): Promise<PulseVaultResolution | null> {
+    const artifact = await db.findArtifact(artifactId);
+    if (!artifact || artifact.status !== "ready") return null;
     // Stream from local disk:
-    return { kind: "stream", root: "/uploads", filename: video.filename };
+    return { kind: "stream", root: "/uploads", filename: artifact.filename };
     // Or redirect to a CDN / presigned URL:
-    // return { kind: "redirect", url: video.signedUrl, statusCode: 302 };
+    // return { kind: "redirect", url: artifact.signedUrl, statusCode: 302 };
   },
-  async markReady(videoid) {
+  async markReady(artifactId) {
     // Called after `validatePayload` (if any) accepts the bytes. Flip your
     // state so `resolve` starts returning non-null. Omit this method if
     // your backend can't distinguish in-progress from finalized uploads.
-    await db.updateVideo(videoid, { status: "ready" });
+    await db.updateArtifact(artifactId, { status: "ready" });
   },
-  async remove(videoid) {
-    // Called from DELETE /:videoid and from the plugin's cleanup path when
-    // `validatePayload` rejects an upload. Return false if the videoid was
-    // already absent.
-    const result = await db.deleteVideo(videoid);
+  async remove(artifactId) {
+    // Called from DELETE /artifacts/:artifactId and from the plugin's
+    // cleanup path when `validatePayload` rejects an upload. Return false if
+    // the artifactId was already absent.
+    const result = await db.deleteArtifact(artifactId);
     return result.deleted;
   },
+  // Optional — only needed if you use relatedTo/checksum-aware hooks/validators:
+  async getKind(artifactId) { return (await db.findArtifact(artifactId))?.kind ?? null; },
+  async getRelatedTo(artifactId) { return (await db.findArtifact(artifactId))?.relatedTo ?? null; },
+  async getChecksum(artifactId) { return (await db.findArtifact(artifactId))?.checksum ?? null; },
 };
 ```
 
@@ -475,12 +603,15 @@ Use this to generate a `pulsecam://` deep link for pairing the Pulse mobile app 
 import { buildUploadLink } from "@mieweb/pulsevault";
 import { randomUUID } from "node:crypto";
 
-// Opens the app directly on the upload screen for a specific video.
+// Opens the app directly on the upload screen for a specific artifact.
+// `server` must include your `prefix` — e.g. "https://example.com/pulsevault",
+// not just the bare origin — the client has no separate notion of a prefix.
 const uploadLink = buildUploadLink({
-  server: "https://example.com",
-  videoid: randomUUID(), // generate server-side; skip POST /reserve on the app
-  token: "secret", // optional — forwarded to your authorize hook
+  server: "https://example.com/pulsevault",
+  artifactId: randomUUID(), // generate server-side; skip POST /reserve on the app
+  token: "secret", // optional — forwarded to your authorize hook; see Capability tokens
 });
+// pulsecam://?v=1&artifactId=...&server=https%3A%2F%2Fexample.com&token=secret
 ```
 
 ## Tests
@@ -493,18 +624,20 @@ Runs a Node `--test` suite against the built plugin. Coverage includes:
 
 - TUS create/HEAD/PATCH resume, collision handling, extension rejection, range GETs
 - Ready-gate (`GET` returns 404 while uploading)
-- `DELETE /:id`
-- `authorize` rejection on every phase; `kind` in authorize context
-- `validatePayload` + `createMp4Sniffer` for video; `validateProjectPayload` for projects
-- `onUploadComplete` and `onProjectUploadComplete` dispatch
-- `kind=project` happy paths (`.pulse`, `.zip`) — correct subdir, `Content-Type`, sidecar
+- The generic `GET/DELETE /artifacts/:artifactId` route, and that the old per-kind routes are gone (not kept as a parallel API)
+- `authorize` rejection on every phase; `kind`/`relatedTo` in the authorize context
+- `validatePayload`/`onUploadComplete` running for every kind via `ctx.kind`, plus the deprecated `validateProjectPayload`/`onProjectUploadComplete` aliases
+- `kind=project` and `kind=captions` happy paths — correct subdir, `Content-Type`, sidecar, `relatedTo` linking
 - Extension mismatch rejections in both directions
-- `projectid` metadata alias
-- `getKind()` storage method
-- Legacy sidecars (no `kind` field) default to `"video"` without migration
+- `artifactId`/`videoid`/`projectid` metadata aliases
+- `getKind()`/`getRelatedTo()`/`getChecksum()` storage methods
+- Legacy sidecars (no `kind` field) default to `"video"`, readable through the new generic route with no data migration
 - Sidecar corruption recovery
 - `allowedExtensions` object form
-- S3/R2 backend (`createS3Storage`): full resumable upload → presigned-redirect playback, `createS3Mp4Sniffer`, `DELETE`, `kind=project`, run against an in-process [s3rver](https://github.com/jamhall/s3rver) mock (no cloud credentials needed)
+- `createChecksumValidator`/`createS3ChecksumValidator`: matching digest accepted, mismatch rejected with cleanup
+- `issueCapabilityToken`/`verifyCapabilityToken`/`createCapabilityAuthorize`: round-trip, tampered signature/payload, expiry + clock tolerance, unknown `kid`, issuer mismatch, key-rotation overlap, `relatedTo`-based session authorization — both as fast unit tests (no server) and wired into real HTTP requests
+- `GET /capabilities`
+- S3/R2 backend (`createS3Storage`): full resumable upload → presigned-redirect playback, `createS3Mp4Sniffer`, `createS3ChecksumValidator`, `DELETE`, `kind=project`/`captions`, run against an in-process [s3rver](https://github.com/jamhall/s3rver) mock (no cloud credentials needed)
 
 ## Accessing storage outside the plugin routes
 
@@ -513,7 +646,7 @@ The storage adapter is exposed as a Fastify decorator, so you can use it in your
 ```ts
 import "@mieweb/pulsevault/augment"; // once, for TypeScript types
 
-app.get("/admin/video/:id", async (req, reply) => {
+app.get("/admin/artifact/:id", async (req, reply) => {
   const resolved = await app.pulseVault.resolve(req.params.id);
   if (!resolved) return reply.code(404).send();
   // custom logic...
@@ -523,5 +656,7 @@ app.get("/admin/video/:id", async (req, reply) => {
 ## License
 
 Source Available — free for non-commercial use under the terms in [LICENSE](LICENSE), which also requires that redistributions be published under an OSI-approved open source license. Commercial use requires a separate license from Medical Informatics Engineering, LLC — contact [helpdesk@mieweb.com](mailto:helpdesk@mieweb.com) or [mieweb.com](https://www.mieweb.com).
+
+A move to a fully OSI-approved open source license for this package itself is planned, to remove this friction for adopters entirely — tracked as a follow-up, not yet decided which license.
 
 Copyright © 2026 Medical Informatics Engineering, LLC. All rights reserved.

--- a/examples/rn-demo/package-lock.json
+++ b/examples/rn-demo/package-lock.json
@@ -15,7 +15,7 @@
     },
     "../..": {
       "name": "@mieweb/pulsevault",
-      "version": "0.0.2",
+      "version": "0.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@fastify/send": "^4.1.0",
@@ -26,10 +26,16 @@
       "devDependencies": {
         "@types/node": "^25.6.0",
         "fastify": "^5.8.5",
+        "s3rver": "^3.7.1",
         "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@aws-sdk/client-s3": "^3.1074.0",
+        "@aws-sdk/s3-request-presigner": "^3.1074.0",
+        "@tus/s3-store": "^2.0.4"
       },
       "peerDependencies": {
         "fastify": "^5.8.5"

--- a/examples/rn-demo/public/index.html
+++ b/examples/rn-demo/public/index.html
@@ -45,8 +45,8 @@
       <label>Server</label>
       <p class="mono" id="serverUrl"></p>
 
-      <label>Video ID</label>
-      <p class="mono" id="uploadVideoid"></p>
+      <label>Artifact ID</label>
+      <p class="mono" id="uploadArtifactId"></p>
 
       <label>Deep link</label>
       <p class="mono" id="deeplinkUpload"></p>
@@ -78,7 +78,7 @@
         const data = await fetch("/deeplinks").then((r) => r.json());
 
         document.getElementById("serverUrl").textContent = window.location.origin;
-        document.getElementById("uploadVideoid").textContent = data.videoid;
+        document.getElementById("uploadArtifactId").textContent = data.artifactId;
         document.getElementById("deeplinkUpload").textContent = data.upload;
         document.getElementById("openBtnUpload").href = data.upload;
         document.getElementById("qrUpload").src = data.qrUpload;
@@ -105,10 +105,10 @@
         }
         list.innerHTML = videos.map((v) => `
           <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #30363d;">
-            <video src="/${v.videoid}" controls preload="metadata" style="width: 100%; max-height: 26rem; border-radius: 6px; background: #000; display: block; object-fit: contain;"></video>
+            <video src="/pulsevault/artifacts/${v.artifactId}" controls preload="metadata" style="width: 100%; max-height: 26rem; border-radius: 6px; background: #000; display: block; object-fit: contain;"></video>
             <p class="mono" style="margin: 0.4rem 0 0;">${v.filename}</p>
             <p class="mono" style="margin: 0.15rem 0 0; color: #6e7681;">${formatSize(v.size)} • ${new Date(v.creation_date).toLocaleString()}</p>
-            <p class="mono" style="margin: 0.15rem 0 0; color: #6e7681;">${v.videoid}</p>
+            <p class="mono" style="margin: 0.15rem 0 0; color: #6e7681;">${v.artifactId}</p>
           </div>
         `).join("");
       }

--- a/examples/rn-demo/server.mjs
+++ b/examples/rn-demo/server.mjs
@@ -55,7 +55,7 @@ await app.register(fastifySwaggerUI, {
   uiConfig: { docExpansion: "list", deepLinking: false },
 });
 
-// Serve pairing page before the plugin so it isn't swallowed by /:videoid
+// Serve pairing page before the plugin so it isn't swallowed by /pulsevault/artifacts/:artifactId
 app.get(
   "/",
   {
@@ -75,47 +75,47 @@ app.get(
   (_req, reply) => reply.type("text/html").send(html),
 );
 
-// Reserve a videoid for an upload. The server owns ID generation so it can
-// later attach auth tokens, quotas, or other server-side state here.
+// Reserve an artifactId for an upload. The server owns ID generation so it
+// can later attach auth tokens, quotas, or other server-side state here.
 app.post(
   "/reserve",
   {
     schema: {
       tags: ["demo"],
-      summary: "Reserve a new videoid",
+      summary: "Reserve a new artifactId",
       description:
-        "Generates a fresh UUID for the client to use as the `videoid` metadata entry on its TUS upload.",
+        "Generates a fresh UUID for the client to use as the `artifactId` metadata entry on its TUS upload.",
       response: {
         200: {
-          description: "A newly minted videoid.",
+          description: "A newly minted artifactId.",
           type: "object",
           properties: {
-            videoid: { type: "string", format: "uuid" },
+            artifactId: { type: "string", format: "uuid" },
           },
-          required: ["videoid"],
+          required: ["artifactId"],
         },
       },
     },
   },
   async (_req, reply) => {
-    const videoid = randomUUID();
-    return reply.send({ videoid });
+    const artifactId = randomUUID();
+    return reply.send({ artifactId });
   },
 );
 
 // List all uploads under dataDir. Reads each upload's sidecar to determine
-// kind and subdir rather than hard-coding "video/" — handles video + project.
+// kind and subdir rather than hard-coding "video/" — handles video/project/captions.
 const uploadSummarySchema = {
   type: "object",
   properties: {
-    videoid: { type: "string", format: "uuid" },
-    kind: { type: "string", enum: ["video", "project"], description: "Artifact kind." },
+    artifactId: { type: "string", format: "uuid" },
+    kind: { type: "string", enum: ["video", "project", "captions"], description: "Artifact kind." },
     filename: { type: "string" },
     ext: { type: "string" },
     size: { type: "integer", minimum: 0 },
     creation_date: { type: "string", format: "date-time" },
   },
-  required: ["videoid", "kind", "filename", "ext", "size", "creation_date"],
+  required: ["artifactId", "kind", "filename", "ext", "size", "creation_date"],
 };
 
 app.get(
@@ -149,7 +149,7 @@ app.get(
       entries
         .filter((e) => e.isFile() && e.name.endsWith(".json") && !e.name.endsWith(".tmp"))
         .map(async (e) => {
-          const videoid = e.name.slice(0, -".json".length);
+          const artifactId = e.name.slice(0, -".json".length);
           const sidecarFilePath = path.join(pulsevaultMetaDir, e.name);
           let sidecar;
           try {
@@ -162,7 +162,7 @@ app.get(
 
           const kind = sidecar.kind ?? "video";
           const ext = sidecar.ext ?? ".mp4";
-          const artifactFile = `${videoid}${ext}`;
+          const artifactFile = `${artifactId}${ext}`;
           const artifactPath = path.join(dataDir, kind, artifactFile);
           const tusJsonPath = `${artifactPath}.json`;
 
@@ -175,7 +175,7 @@ app.get(
           if (!artifactStat || artifactStat.size === 0) return null;
 
           return {
-            videoid,
+            artifactId,
             kind,
             filename: sidecar.filename ?? tusMeta?.metadata?.filename ?? artifactFile,
             ext,
@@ -194,17 +194,19 @@ app.get(
   },
 );
 
-// One deeplink + matching QR per request. videoid is generated server-side so
-// it stays the source of truth.
+// One deeplink + matching QR per request. artifactId is generated server-side
+// so it stays the source of truth. `server` must include the plugin's
+// `prefix` ("/pulsevault") — the client builds every request as
+// `${server}/<path>` with no prefix concept of its own.
 app.get("/deeplinks", async (req, reply) => {
   const proto = req.headers["x-forwarded-proto"] ?? "http";
   const host = req.headers["x-forwarded-host"] ?? req.headers.host;
-  const server = `${proto}://${host}`;
-  const videoid = randomUUID();
+  const server = `${proto}://${host}/pulsevault`;
+  const artifactId = randomUUID();
 
   const upload = buildUploadLink({
     server,
-    videoid,
+    artifactId,
     ...(DEMO_TOKEN && { token: DEMO_TOKEN }),
   });
 
@@ -216,7 +218,7 @@ app.get("/deeplinks", async (req, reply) => {
 
   return reply.send({
     upload,
-    videoid,
+    artifactId,
     qrUpload,
     authMode: Boolean(DEMO_TOKEN),
   });
@@ -253,22 +255,29 @@ const pulseStorage = useS3
     })
   : createLocalStorage({ workspaceDir: dataDir });
 
-// Mount plugin under /pulsevault so TUS is at POST /pulsevault/upload and video GET is at /pulsevault/:videoid
+// Mount plugin under /pulsevault so TUS is at POST /pulsevault/upload and
+// artifact GET is at /pulsevault/artifacts/:artifactId.
 await app.register(pulseVault, {
   prefix: "/pulsevault",
   storage: pulseStorage,
   maxUploadSize: 5 * 1024 * 1024 * 1024, // 5 GiB
-  // Accept MP4 videos and Pulse draft bundles (.pulse) + diagnostic zips.
-  allowedExtensions: { video: [".mp4"], project: [".pulse", ".zip"] },
-  // Reject non-MP4 bytes on video uploads (magic-byte sniff). The S3 sniffer
-  // does a ranged read of the object; the local one reads the file on disk.
-  validatePayload: useS3
-    ? createS3Mp4Sniffer(pulseStorage)
-    : createMp4Sniffer(pulseStorage),
-  // Fired when a project bundle finishes uploading. The bundle is opaque
-  // to the plugin — index it, relay it, or leave it for a later request.
-  onProjectUploadComplete: async (_req, { videoid, size }) => {
-    app.log.info({ videoid, size }, "pulsevault project upload complete");
+  // Accept MP4 videos, Pulse draft bundles (.pulse) + diagnostic zips, and SRT captions.
+  allowedExtensions: { video: [".mp4"], project: [".pulse", ".zip"], captions: [".srt"] },
+  // validatePayload now runs for every kind, with ctx.kind telling you which
+  // — only apply the MP4 magic-byte sniff to actual videos, since project
+  // bundles and SRT captions never start with an ISOBMFF ftyp box. The S3
+  // sniffer does a ranged read of the object; the local one reads the file
+  // on disk.
+  validatePayload: async (request, ctx) => {
+    if (ctx.kind !== "video") return;
+    const sniff = useS3 ? createS3Mp4Sniffer(pulseStorage) : createMp4Sniffer(pulseStorage);
+    await sniff(request, ctx);
+  },
+  // Fired once any artifact (video, project bundle, or captions) finishes
+  // uploading. The bytes are opaque to the plugin — index them, relay them,
+  // or leave them for a later request.
+  onUploadComplete: async (_req, { artifactId, kind, size }) => {
+    app.log.info({ artifactId, kind, size }, "pulsevault upload complete");
   },
   /**
    * authorize hook — the demo's auth proof-of-concept.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mieweb/pulsevault",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Fastify plugin for resumable video uploads via TUS, with a pluggable storage adapter and a filesystem-first local-storage default.",
   "type": "module",
   "main": "./dist/app.js",
@@ -20,13 +20,17 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "CHANGELOG.md",
+    "PROTOCOL.md",
+    "OPERATIONS.md"
   ],
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
     "pretest": "npm run build",
-    "test": "node --test test/*.test.mjs"
+    "test": "node --test test/*.test.mjs",
+    "e2e": "npm run build && node scripts/e2e-tus.mjs"
   },
   "keywords": [
     "fastify",

--- a/scripts/e2e-tus.mjs
+++ b/scripts/e2e-tus.mjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+// Scripted end-to-end smoke test: boots the rn-demo reference server, then
+// drives a real TUS upload against it with a plain Node script — no mobile
+// app or simulator required. Catches contract drift between this package and
+// its own demo automatically, in CI, rather than only by a human noticing on
+// a simulator. Run with `npm run e2e` (see package.json).
+//
+// Exits non-zero (and prints what failed) on any assertion failure.
+
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const demoDir = path.join(__dirname, "..", "examples", "rn-demo");
+
+const PORT = 4173;
+const BASE = `http://127.0.0.1:${PORT}`;
+const PREFIX = `${BASE}/pulsevault`;
+const DEMO_TOKEN = "e2e-smoke-test-token";
+
+function b64(str) {
+  return Buffer.from(str, "utf8").toString("base64");
+}
+
+const MP4_HEADER = Buffer.from([
+  0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70, 0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+]);
+function makeMp4(size) {
+  const body = Buffer.alloc(size);
+  MP4_HEADER.copy(body, 0);
+  return body;
+}
+
+async function waitForReady(child, timeoutMs = 15_000) {
+  let buffer = "";
+  const onData = (chunk) => {
+    buffer += chunk.toString();
+  };
+  child.stdout.on("data", onData);
+  child.stderr.on("data", onData);
+  const deadline = Date.now() + timeoutMs;
+  while (!buffer.includes("PulseVault demo running")) {
+    if (Date.now() > deadline) {
+      throw new Error(`Server did not start within ${timeoutMs}ms. Output so far:\n${buffer}`);
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  child.stdout.off("data", onData);
+  child.stderr.off("data", onData);
+}
+
+async function main() {
+  console.log("Starting rn-demo server...");
+  const child = spawn(process.execPath, ["server.mjs"], {
+    cwd: demoDir,
+    env: { ...process.env, PORT: String(PORT), HOST: "127.0.0.1", DEMO_TOKEN, STORAGE: "local" },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let exitedEarly = false;
+  child.once("exit", (code) => {
+    if (!main.done) {
+      exitedEarly = true;
+      console.error(`rn-demo server exited early with code ${code}`);
+    }
+  });
+
+  try {
+    await waitForReady(child);
+    console.log("Server ready. Running checks...");
+
+    // 1. Capabilities discovery — unauthenticated, reports protocol version range.
+    const capsRes = await fetch(`${PREFIX}/capabilities`);
+    assert.equal(capsRes.status, 200, "GET /capabilities should be 200");
+    const caps = await capsRes.json();
+    assert.equal(typeof caps.protocolVersion, "number");
+    assert.ok(caps.minSupportedVersion <= caps.protocolVersion);
+    assert.ok(caps.protocolVersion <= caps.maxSupportedVersion);
+    assert.ok(["beat", "merged"].includes(caps.uploadUnit));
+    console.log(`  ✓ /capabilities reports protocolVersion=${caps.protocolVersion}, uploadUnit=${caps.uploadUnit}`);
+
+    // 2. Pairing — mints an artifactId + deep link carrying the demo token.
+    const linkRes = await fetch(`${BASE}/deeplinks`);
+    assert.equal(linkRes.status, 200, "GET /deeplinks should be 200");
+    const { artifactId, upload: deepLink } = await linkRes.json();
+    assert.ok(artifactId, "deeplinks response should include an artifactId");
+    assert.ok(deepLink.startsWith("pulsecam://"), "deep link should use the pulsecam scheme");
+    console.log(`  ✓ /deeplinks minted artifactId=${artifactId}`);
+
+    // 3. Full chunked TUS upload, authorized with the demo bearer token.
+    const body = makeMp4(2 * 1024 * 1024);
+    const digest = createHash("sha256").update(body).digest("hex");
+    const metadata = [
+      `artifactId ${b64(artifactId)}`,
+      `filename ${b64("clip.mp4")}`,
+      `checksum ${b64(`sha256:${digest}`)}`,
+    ].join(",");
+
+    const create = await fetch(`${PREFIX}/upload`, {
+      method: "POST",
+      headers: {
+        "Tus-Resumable": "1.0.0",
+        "Upload-Length": String(body.length),
+        "Upload-Metadata": metadata,
+        Authorization: `Bearer ${DEMO_TOKEN}`,
+      },
+    });
+    assert.equal(create.status, 201, `create should be 201, got ${create.status}`);
+    const location = create.headers.get("location");
+    assert.ok(location, "create response should include a Location header");
+    console.log("  ✓ TUS create succeeded");
+
+    const half = body.length / 2;
+    const patch1 = await fetch(location, {
+      method: "PATCH",
+      headers: {
+        "Tus-Resumable": "1.0.0",
+        "Upload-Offset": "0",
+        "Content-Type": "application/offset+octet-stream",
+        Authorization: `Bearer ${DEMO_TOKEN}`,
+      },
+      body: body.subarray(0, half),
+    });
+    assert.equal(patch1.status, 204, `first PATCH should be 204, got ${patch1.status}`);
+
+    // Resume via HEAD before the second chunk — never trust a cached offset.
+    const head = await fetch(location, {
+      method: "HEAD",
+      headers: { "Tus-Resumable": "1.0.0", Authorization: `Bearer ${DEMO_TOKEN}` },
+    });
+    assert.equal(Number(head.headers.get("upload-offset")), half, "HEAD should report the offset after chunk 1");
+
+    const patch2 = await fetch(location, {
+      method: "PATCH",
+      headers: {
+        "Tus-Resumable": "1.0.0",
+        "Upload-Offset": String(half),
+        "Content-Type": "application/offset+octet-stream",
+        Authorization: `Bearer ${DEMO_TOKEN}`,
+      },
+      body: body.subarray(half),
+    });
+    assert.equal(patch2.status, 204, `second PATCH should be 204, got ${patch2.status}`);
+    console.log("  ✓ chunked PATCH + HEAD-based resume succeeded, checksum accepted");
+
+    // 4. Verify the artifact is actually retrievable and byte-identical. The
+    // demo's authorize hook reads the resolve-phase token from `?token=`
+    // (forwarded from the watch URL), not the Authorization header — that's
+    // the documented contract for the "resolve" phase specifically.
+    const get = await fetch(`${PREFIX}/artifacts/${artifactId}?token=${DEMO_TOKEN}`);
+    assert.equal(get.status, 200, `GET /artifacts/:id should be 200, got ${get.status}`);
+    const got = Buffer.from(await get.arrayBuffer());
+    assert.equal(Buffer.compare(got, body), 0, "downloaded bytes should match what was uploaded");
+    console.log("  ✓ GET /artifacts/:artifactId serves the exact uploaded bytes");
+
+    // 5. A request with no/wrong token must be rejected, not silently accepted.
+    const unauthorized = await fetch(`${PREFIX}/artifacts/${artifactId}`);
+    assert.equal(unauthorized.status, 403, "unauthenticated GET should be rejected");
+    console.log("  ✓ request with no token is rejected (403)");
+
+    console.log("\nAll e2e checks passed.");
+  } finally {
+    main.done = true;
+    if (!exitedEarly) child.kill();
+    await once(child, "exit").catch(() => {});
+  }
+}
+
+main().catch((err) => {
+  console.error("\ne2e smoke test FAILED:", err);
+  process.exitCode = 1;
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,11 +1,7 @@
 import type { FastifyPluginAsync } from "fastify";
 import fp from "fastify-plugin";
-import pulseVaultRoutes, {
-  type PulseVaultAuthorize,
-  type PulseVaultAuthorizeContext,
-  type PulseVaultAuthorizePhase,
-} from "./routes/pulsevault.js";
-import type { PulseVaultOnUploadComplete } from "./lib/pulsevaultTus.js";
+import pulseVaultRoutes, { type PulseVaultAuthorize } from "./routes/pulsevault.js";
+import type { PulseVaultOnUploadComplete, PulseVaultOnArtifactEvent } from "./lib/pulsevaultTus.js";
 import type { PulseVaultValidatePayload } from "./lib/magic.js";
 import type { PulseVaultStorage } from "./storage/types.js";
 import type { UploadKind } from "./storage/types.js";
@@ -48,6 +44,14 @@ export type PulseVaultPluginOptions = {
    */
   maxUploadSize: number;
   /**
+   * Which upload strategy this deployment expects: `"beat"` uploads each
+   * clip individually (no client-side merge/re-encode pass) plus a manifest
+   * artifact for ordering, while `"merged"` expects one pre-merged video per
+   * pulse. Purely advertised via `GET /capabilities` for the client to branch
+   * on — `pulsevault` doesn't enforce either. Defaults to `"beat"`.
+   */
+  uploadUnit?: "beat" | "merged";
+  /**
    * Fastify instance decorator name under which the storage adapter is
    * exposed. Defaults to `"pulseVault"`. Override when registering this
    * plugin more than once in the same process so the decorators don't
@@ -62,15 +66,18 @@ export type PulseVaultPluginOptions = {
   decoratorName?: string;
   /**
    * File extensions allowed per artifact kind. Accepts:
-   * - A flat array (`[".mp4"]`) — treated as video-only; project defaults to
-   *   `[".pulse", ".zip"]`. This is the legacy form for back-compat.
-   * - An object with optional `video` and/or `project` keys; unset keys fall
-   *   back to their defaults.
-   * - Omitted entirely — defaults to `{ video: [".mp4"], project: [".pulse", ".zip"] }`.
+   * - A flat array (`[".mp4"]`) — treated as video-only; project/captions
+   *   default. This is the legacy form for back-compat.
+   * - An object with optional `video`/`project`/`captions` keys; unset keys
+   *   fall back to their defaults.
+   * - Omitted entirely — defaults to
+   *   `{ video: [".mp4"], project: [".pulse", ".zip"], captions: [".srt"] }`.
    *
    * All extensions must include the leading dot and are matched case-insensitively.
    */
-  allowedExtensions?: readonly string[] | { video?: readonly string[]; project?: readonly string[] };
+  allowedExtensions?:
+    | readonly string[]
+    | { video?: readonly string[]; project?: readonly string[]; captions?: readonly string[] };
   /**
    * Cache-control options forwarded to `@fastify/send` for the GET route.
    * When omitted, `@fastify/send`'s defaults apply (`Cache-Control: public,
@@ -84,45 +91,60 @@ export type PulseVaultPluginOptions = {
    *
    * The hook is called with the `FastifyRequest`, so consumers can look up
    * sessions, API keys, JWTs, etc. using whatever auth system they have
-   * registered higher up in the Fastify tree.
+   * registered higher up in the Fastify tree. Use `createCapabilityAuthorize`
+   * (from `./lib/capability-token.js`) for a secure-by-default option that
+   * doesn't require writing your own.
    *
    * When omitted, the plugin performs no authorization. For production
    * deployments you almost certainly want to set this — register your auth
    * plugin on the parent scope and let the hook verify ownership of the
-   * `videoid` before any bytes are written.
+   * `artifactId` before any bytes are written.
    */
   authorize?: PulseVaultAuthorize;
   /**
-   * Optional payload-validation hook. Runs *after* TUS writes the final byte
-   * but *before* the upload is marked ready or `onUploadComplete` fires.
-   * Throw to reject — the plugin will call `storage.remove` to free the
-   * bytes and return a 4xx (default 422) to the client. The sidecar never
-   * flips to `"ready"`, so the video is never served.
+   * Optional payload-validation hook, called for every artifact kind with
+   * `ctx.kind` set accordingly. Runs *after* TUS writes the final byte but
+   * *before* the upload is marked ready or `onUploadComplete` fires. Throw to
+   * reject — the plugin will call `storage.remove` to free the bytes and
+   * return a 4xx (default 422) to the client. The sidecar never flips to
+   * `"ready"`, so the artifact is never served.
    *
-   * Use this for magic-byte sniffing, virus scanning, or any check that
-   * needs the final bytes. Ship-ready helpers are exported from this
-   * package — see `createMp4Sniffer`.
+   * Use this for magic-byte sniffing, checksum verification, virus scanning,
+   * or any check that needs the final bytes. Ship-ready helpers are exported
+   * from this package — see `createMp4Sniffer`, `createChecksumValidator`.
    */
   validatePayload?: PulseVaultValidatePayload;
   /**
-   * Optional post-upload hook. Fires once TUS writes the final byte *and*
+   * Optional post-upload hook, fired once TUS writes the final byte *and*
    * any `validatePayload` has passed, and after the adapter's `markReady`
-   * has run. Use this to flip consumer state (DB row, queue job, audit
-   * log). Throwing turns the upload into a 500 response; the video is
-   * marked ready at this point, so consumers that want all-or-nothing
-   * semantics should `storage.remove` before throwing.
+   * has run — for every artifact kind, with `ctx.kind` set accordingly. Use
+   * this to flip consumer state (DB row, queue job, audit log). Throwing
+   * turns the upload into a 500 response; the artifact is marked ready at
+   * this point, so consumers that want all-or-nothing semantics should
+   * `storage.remove` before throwing.
    */
   onUploadComplete?: PulseVaultOnUploadComplete;
   /**
-   * Optional payload-validation hook for `kind=project` uploads. Same
-   * lifecycle as `validatePayload` but only fires for project artifacts
-   * (`.pulse`, `.zip`, etc.). Throwing causes `storage.remove` + 4xx.
+   * Optional low-frequency event hook — fired on authorize rejection (create
+   * phase and delete/resolve, never per-chunk patch), upload completion, and
+   * payload-validation rejection. One hook covers both ops metrics and a
+   * compliance audit trail; see `OPERATIONS.md` for wiring examples.
+   */
+  onArtifactEvent?: PulseVaultOnArtifactEvent;
+  /**
+   * @deprecated Use `validatePayload` instead — it now receives `ctx.kind`
+   * and runs for every artifact kind, including `"project"`. Still honored
+   * this release (mapped onto `validatePayload` when `kind === "project"`),
+   * but will be removed in a future major version. Passing this triggers a
+   * one-time `DeprecationWarning` at registration.
    */
   validateProjectPayload?: PulseVaultValidatePayload;
   /**
-   * Optional post-upload hook for `kind=project` uploads. Fires after
-   * `validateProjectPayload` passes and `markReady` runs. Use this to
-   * index the draft, enable cross-device editing, etc.
+   * @deprecated Use `onUploadComplete` instead — it now receives `ctx.kind`
+   * and runs for every artifact kind, including `"project"`. Still honored
+   * this release (mapped onto `onUploadComplete` when `kind === "project"`),
+   * but will be removed in a future major version. Passing this triggers a
+   * one-time `DeprecationWarning` at registration.
    */
   onProjectUploadComplete?: PulseVaultOnUploadComplete;
 };
@@ -130,29 +152,41 @@ export type PulseVaultPluginOptions = {
 const DEFAULT_DECORATOR_NAME = "pulseVault";
 const DEFAULT_VIDEO_EXTENSIONS: readonly string[] = [".mp4"];
 const DEFAULT_PROJECT_EXTENSIONS: readonly string[] = [".pulse", ".zip"];
+const DEFAULT_CAPTIONS_EXTENSIONS: readonly string[] = [".srt"];
 const EXTENSION_REGEX = /^\.[^.\s/\\]+$/;
 
 /**
  * Normalize the consumer's `allowedExtensions` option (legacy array or per-kind
- * object) into the canonical `{ video, project }` shape the route layer expects.
+ * object) into the canonical `{ video, project, captions }` shape the route
+ * layer expects.
  */
 function normalizeAllowedExtensions(
   raw: PulseVaultPluginOptions["allowedExtensions"],
-): { video: readonly string[]; project: readonly string[] } {
+): { video: readonly string[]; project: readonly string[]; captions: readonly string[] } {
   if (!raw) {
-    return { video: DEFAULT_VIDEO_EXTENSIONS, project: DEFAULT_PROJECT_EXTENSIONS };
+    return {
+      video: DEFAULT_VIDEO_EXTENSIONS,
+      project: DEFAULT_PROJECT_EXTENSIONS,
+      captions: DEFAULT_CAPTIONS_EXTENSIONS,
+    };
   }
   if (Array.isArray(raw)) {
-    // Legacy flat array: treat as video-only, project keeps its default.
+    // Legacy flat array: treat as video-only, project/captions keep their defaults.
     return {
       video: (raw as readonly string[]).map((e) => e.toLowerCase()),
       project: DEFAULT_PROJECT_EXTENSIONS,
+      captions: DEFAULT_CAPTIONS_EXTENSIONS,
     };
   }
-  const obj = raw as { video?: readonly string[]; project?: readonly string[] };
+  const obj = raw as {
+    video?: readonly string[];
+    project?: readonly string[];
+    captions?: readonly string[];
+  };
   return {
     video: (obj.video ?? DEFAULT_VIDEO_EXTENSIONS).map((e) => e.toLowerCase()),
     project: (obj.project ?? DEFAULT_PROJECT_EXTENSIONS).map((e) => e.toLowerCase()),
+    captions: (obj.captions ?? DEFAULT_CAPTIONS_EXTENSIONS).map((e) => e.toLowerCase()),
   };
 }
 
@@ -167,12 +201,16 @@ function validateOptions(opts: PulseVaultPluginOptions): void {
       "`maxUploadSize` must be a positive number (use Infinity for no cap)",
     );
   }
+  if (opts.uploadUnit && opts.uploadUnit !== "beat" && opts.uploadUnit !== "merged") {
+    throw new TypeError('`uploadUnit` must be "beat" or "merged"');
+  }
   if (opts.allowedExtensions) {
     const exts = Array.isArray(opts.allowedExtensions)
       ? (opts.allowedExtensions as readonly string[])
       : [
           ...((opts.allowedExtensions as { video?: readonly string[] }).video ?? []),
           ...((opts.allowedExtensions as { project?: readonly string[] }).project ?? []),
+          ...((opts.allowedExtensions as { captions?: readonly string[] }).captions ?? []),
         ];
     for (const ext of exts) {
       if (!EXTENSION_REGEX.test(ext)) {
@@ -184,11 +222,62 @@ function validateOptions(opts: PulseVaultPluginOptions): void {
   }
 }
 
+/**
+ * One-time (not per-request) warning for the now-deprecated per-kind project
+ * hooks, so consumers notice the migration need instead of it being silently
+ * aliased away until a future major version removes it outright.
+ */
+function warnIfUsingDeprecatedProjectHooks(opts: PulseVaultPluginOptions): void {
+  if (opts.validateProjectPayload) {
+    process.emitWarning(
+      "pulsevault: `validateProjectPayload` is deprecated — use `validatePayload` and branch on `ctx.kind === \"project\"` instead. Still honored this release.",
+      "DeprecationWarning",
+    );
+  }
+  if (opts.onProjectUploadComplete) {
+    process.emitWarning(
+      "pulsevault: `onProjectUploadComplete` is deprecated — use `onUploadComplete` and branch on `ctx.kind === \"project\"` instead. Still honored this release.",
+      "DeprecationWarning",
+    );
+  }
+}
+
+/** Compose the legacy per-kind hook (if any) with the generic hook, mapped onto the `"project"` kind only. */
+function composeValidatePayload(
+  generic: PulseVaultValidatePayload | undefined,
+  legacyProject: PulseVaultValidatePayload | undefined,
+): PulseVaultValidatePayload | undefined {
+  if (!legacyProject) return generic;
+  return async (request, ctx) => {
+    const kind = (ctx as typeof ctx & { kind?: UploadKind }).kind;
+    if (kind === "project") {
+      await legacyProject(request, ctx);
+      return;
+    }
+    if (generic) await generic(request, ctx);
+  };
+}
+
+function composeOnUploadComplete(
+  generic: PulseVaultOnUploadComplete | undefined,
+  legacyProject: PulseVaultOnUploadComplete | undefined,
+): PulseVaultOnUploadComplete | undefined {
+  if (!legacyProject) return generic;
+  return async (request, ctx) => {
+    if (ctx.kind === "project") {
+      await legacyProject(request, ctx);
+      return;
+    }
+    if (generic) await generic(request, ctx);
+  };
+}
+
 const app: FastifyPluginAsync<PulseVaultPluginOptions> = async (
   fastify,
   opts,
 ) => {
   validateOptions(opts);
+  warnIfUsingDeprecatedProjectHooks(opts);
 
   // Register the shutdown hook *before* awaiting initialize() so any partial
   // state the adapter allocates mid-init still gets cleaned up if Fastify
@@ -207,13 +296,13 @@ const app: FastifyPluginAsync<PulseVaultPluginOptions> = async (
     prefix: opts.prefix,
     storage: opts.storage,
     maxUploadSize: opts.maxUploadSize,
+    uploadUnit: opts.uploadUnit ?? "beat",
     allowedExtensions,
     cache: opts.cache,
     authorize: opts.authorize,
-    validatePayload: opts.validatePayload,
-    validateProjectPayload: opts.validateProjectPayload,
-    onUploadComplete: opts.onUploadComplete,
-    onProjectUploadComplete: opts.onProjectUploadComplete,
+    validatePayload: composeValidatePayload(opts.validatePayload, opts.validateProjectPayload),
+    onUploadComplete: composeOnUploadComplete(opts.onUploadComplete, opts.onProjectUploadComplete),
+    onArtifactEvent: opts.onArtifactEvent,
   });
 };
 
@@ -237,8 +326,29 @@ export type {
   PulseVaultAuthorizeContext,
   PulseVaultAuthorizePhase,
 } from "./routes/pulsevault.js";
-export type { PulseVaultOnUploadComplete } from "./lib/pulsevaultTus.js";
+export type {
+  PulseVaultOnUploadComplete,
+  PulseVaultOnArtifactEvent,
+  PulseVaultArtifactEvent,
+} from "./lib/pulsevaultTus.js";
 export { sniffMp4, createMp4Sniffer, createS3Mp4Sniffer } from "./lib/magic.js";
 export type { PulseVaultValidatePayload } from "./lib/magic.js";
 export { buildUploadLink } from "./lib/deeplinks.js";
 export type { UploadLinkOptions } from "./lib/deeplinks.js";
+export {
+  issueCapabilityToken,
+  verifyCapabilityToken,
+  createCapabilityAuthorize,
+} from "./lib/capability-token.js";
+export type {
+  CapabilityTokenClaims,
+  IssueCapabilityTokenOptions,
+  VerifyCapabilityTokenOptions,
+  LookupSecret,
+} from "./lib/capability-token.js";
+export {
+  createChecksumValidator,
+  createS3ChecksumValidator,
+  parseChecksumMetadata,
+} from "./lib/checksum.js";
+export type { ChecksumAlgorithm, ParsedChecksum } from "./lib/checksum.js";

--- a/src/augment.ts
+++ b/src/augment.ts
@@ -4,8 +4,8 @@ import type { UploadKind } from "./storage/types.js";
 /**
  * Opt-in TypeScript augmentation for the default `pulseVault` decorator and
  * the per-request `request.pulseVault` context that the plugin sets when it
- * recognizes a videoid on the incoming request. Import for side effects in
- * one place in your app when you register the plugin with the default
+ * recognizes an artifactId on the incoming request. Import for side effects
+ * in one place in your app when you register the plugin with the default
  * `decoratorName`:
  *
  * ```ts
@@ -21,10 +21,15 @@ import type { UploadKind } from "./storage/types.js";
  *     myCustomName: PulseVaultStorage;
  *   }
  *   interface FastifyRequest {
- *     pulseVault?: { videoid: string };
+ *     pulseVault?: { artifactId: string };
  *   }
  * }
  * ```
+ *
+ * **Breaking change**: this field was named `videoid` before this release.
+ * It's renamed to `artifactId` here as a deliberate, separate breaking change
+ * from the wire-format rename — update any code reading
+ * `request.pulseVault.videoid` to `request.pulseVault.artifactId`.
  */
 declare module "fastify" {
   interface FastifyInstance {
@@ -32,13 +37,13 @@ declare module "fastify" {
   }
   interface FastifyRequest {
     /**
-     * Populated by the plugin when it can extract a videoid from the
+     * Populated by the plugin when it can extract an artifactId from the
      * incoming request (from `Upload-Metadata` on POST, the URL id on
      * PATCH/HEAD/DELETE, or the route param on GET). Present on every
      * request the plugin routes serve that refer to a valid UUID — use it
      * from your own `preHandler` / auth hooks to avoid re-parsing.
      */
-    pulseVault?: { videoid: string; kind: UploadKind };
+    pulseVault?: { artifactId: string; kind: UploadKind; relatedTo?: string };
   }
 }
 

--- a/src/lib/capability-token.ts
+++ b/src/lib/capability-token.ts
@@ -1,0 +1,187 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { FastifyRequest } from "fastify";
+import type { PulseVaultAuthorize, PulseVaultAuthorizeContext } from "../routes/pulsevault.js";
+
+/**
+ * Claims signed into a capability token. `kid` lets a secret be rotated with
+ * an overlap window (old + new key both verify) instead of instantly
+ * invalidating every outstanding token; `iat` closes a clock-skew gap where
+ * signing only `exp` would let a slow server clock accept an already-expired
+ * token; `issuer` binds the token to the issuing deployment's identity so a
+ * secret accidentally shared between two independent orgs can't be replayed
+ * across them.
+ */
+export type CapabilityTokenClaims = {
+  /** The artifact (or session-anchor artifact — see `relatedTo`) this token authorizes. */
+  artifactId: string;
+  /** Issued-at, seconds since epoch. */
+  iat: number;
+  /** Expiry, seconds since epoch. */
+  exp: number;
+  /** Key id, looked up via `lookupSecret` at verify time. */
+  kid: string;
+  /** Issuing deployment's identity, e.g. `"https://vault.acme-hospital.org"`. */
+  issuer: string;
+};
+
+const DEFAULT_EXPIRY_SECONDS = 1800; // 30 minutes — long enough for one upload session.
+const DEFAULT_CLOCK_TOLERANCE_SECONDS = 30;
+
+function base64urlEncode(input: string): string {
+  return Buffer.from(input, "utf8").toString("base64url");
+}
+
+function sign(payload: string, secret: string): string {
+  return createHmac("sha256", secret).update(payload).digest("base64url");
+}
+
+/** Constant-time string comparison, tolerant of mismatched lengths (returns `false` rather than throwing). */
+function timingSafeEqualStrings(a: string, b: string): boolean {
+  const bufA = Buffer.from(a, "utf8");
+  const bufB = Buffer.from(b, "utf8");
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+export type IssueCapabilityTokenOptions = {
+  /** Key id this token is signed under. Required so rotation has an explicit overlap window. */
+  keyId: string;
+  /** Issuing deployment's identity. Required so cross-issuer replay can be rejected at verify time. */
+  issuer: string;
+  /** Token lifetime in seconds. Defaults to 1800 (30 minutes). */
+  expirySeconds?: number;
+};
+
+/**
+ * Mint a stateless, HMAC-signed capability token scoped to one artifact (or
+ * session-anchor artifact). No server-side session table — verification is a
+ * pure function of `(token, secret)`, so the issuing deployment can rotate
+ * keys, change its TTL policy, or revoke at the artifact level entirely on
+ * its own schedule. See `createCapabilityAuthorize` to use this as the
+ * plugin's `authorize` hook directly.
+ */
+export function issueCapabilityToken(
+  artifactId: string,
+  secret: string,
+  opts: IssueCapabilityTokenOptions,
+): string {
+  const now = Math.floor(Date.now() / 1000);
+  const claims: CapabilityTokenClaims = {
+    artifactId,
+    iat: now,
+    exp: now + (opts.expirySeconds ?? DEFAULT_EXPIRY_SECONDS),
+    kid: opts.keyId,
+    issuer: opts.issuer,
+  };
+  const payload = base64urlEncode(JSON.stringify(claims));
+  return `${payload}.${sign(payload, secret)}`;
+}
+
+/** Look up the signing secret for a given key id. Return `null`/`undefined` for an unrecognized `kid`. */
+export type LookupSecret = (keyId: string) => string | null | undefined;
+
+export type VerifyCapabilityTokenOptions = {
+  /** Must match the token's `issuer` claim exactly. */
+  issuer: string;
+  /** Clock-skew tolerance in seconds applied to both `iat` and `exp` checks. Defaults to 30. */
+  clockToleranceSeconds?: number;
+};
+
+/**
+ * Verify a token minted by `issueCapabilityToken`. Returns the authorized
+ * `artifactId` on success, or `null` for any failure (malformed token,
+ * unknown `kid`, bad signature, expired, issued too far in the future, or
+ * issuer mismatch) — deliberately collapsed to one failure shape so callers
+ * can't accidentally branch on *why* a token failed and leak which part was
+ * wrong to an attacker.
+ */
+export function verifyCapabilityToken(
+  token: string,
+  lookupSecret: LookupSecret,
+  opts: VerifyCapabilityTokenOptions,
+): { artifactId: string } | null {
+  const dot = token.indexOf(".");
+  if (dot < 0) return null;
+  const payload = token.slice(0, dot);
+  const signature = token.slice(dot + 1);
+  if (!payload || !signature) return null;
+
+  let claims: Partial<CapabilityTokenClaims>;
+  try {
+    claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+  } catch {
+    return null;
+  }
+  if (
+    typeof claims.artifactId !== "string" ||
+    typeof claims.iat !== "number" ||
+    typeof claims.exp !== "number" ||
+    typeof claims.kid !== "string" ||
+    typeof claims.issuer !== "string"
+  ) {
+    return null;
+  }
+
+  const secret = lookupSecret(claims.kid);
+  if (!secret) return null;
+  if (!timingSafeEqualStrings(signature, sign(payload, secret))) return null;
+
+  const tolerance = opts.clockToleranceSeconds ?? DEFAULT_CLOCK_TOLERANCE_SECONDS;
+  const now = Math.floor(Date.now() / 1000);
+  if (claims.iat > now + tolerance) return null;
+  if (claims.exp < now - tolerance) return null;
+  if (claims.issuer !== opts.issuer) return null;
+
+  return { artifactId: claims.artifactId };
+}
+
+/** Pull a bearer token from the `Authorization` header, falling back to `ctx.token` (the `resolve`-phase query-string forward). */
+function extractToken(
+  request: FastifyRequest,
+  ctx: Pick<PulseVaultAuthorizeContext, "token">,
+): string | undefined {
+  const header = request.headers.authorization;
+  if (typeof header === "string" && header.startsWith("Bearer ")) {
+    return header.slice("Bearer ".length);
+  }
+  return ctx.token;
+}
+
+/**
+ * Ready-made `authorize` hook backed by `verifyCapabilityToken`. Pass this
+ * directly as the plugin's `authorize` option for a secure-by-default setup
+ * with no custom auth code:
+ *
+ * ```ts
+ * await app.register(pulseVault, {
+ *   // ...
+ *   authorize: createCapabilityAuthorize((kid) => keys[kid] ?? null, {
+ *     issuer: "https://vault.acme-hospital.org",
+ *   }),
+ * });
+ * ```
+ *
+ * Authorizes the request if the token's `artifactId` matches either the
+ * artifact being acted on, or that artifact's `relatedTo` session anchor —
+ * so one token issued for a video also covers its captions and (under
+ * `uploadUnit: "beat"`) every beat and the pulse manifest uploaded in the
+ * same session, without minting a token per artifact.
+ */
+export function createCapabilityAuthorize(
+  lookupSecret: LookupSecret,
+  opts: VerifyCapabilityTokenOptions,
+): PulseVaultAuthorize {
+  return async (request, ctx) => {
+    const token = extractToken(request, ctx);
+    if (!token) {
+      throw Object.assign(new Error("Missing capability token"), { statusCode: 401 });
+    }
+    const verified = verifyCapabilityToken(token, lookupSecret, opts);
+    if (!verified) {
+      throw Object.assign(new Error("Invalid or expired capability token"), { statusCode: 403 });
+    }
+    if (ctx.artifactId !== verified.artifactId && ctx.relatedTo !== verified.artifactId) {
+      throw Object.assign(new Error("Token does not authorize this artifact"), { statusCode: 403 });
+    }
+  };
+}

--- a/src/lib/checksum.ts
+++ b/src/lib/checksum.ts
@@ -1,0 +1,119 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import type { S3Storage } from "../storage/s3.js";
+import type { PulseVaultValidatePayload } from "./magic.js";
+
+export type ChecksumAlgorithm = "sha256" | "sha1" | "md5";
+const SUPPORTED_ALGORITHMS: readonly ChecksumAlgorithm[] = ["sha256", "sha1", "md5"];
+
+export type ParsedChecksum = { algorithm: ChecksumAlgorithm; digest: string };
+
+/**
+ * Parse the client-supplied `Upload-Metadata.checksum` value, format
+ * `<algorithm>:<hex digest>` (e.g. `sha256:9f86d0...`). Returns `null` for a
+ * missing or malformed value — checksum verification is opt-in per upload,
+ * not required, unless the caller treats a `null` parse as a rejection.
+ */
+export function parseChecksumMetadata(raw: string | undefined | null): ParsedChecksum | null {
+  if (!raw) return null;
+  const sep = raw.indexOf(":");
+  if (sep < 0) return null;
+  const algorithm = raw.slice(0, sep).toLowerCase();
+  const digest = raw.slice(sep + 1).toLowerCase();
+  if (!isSupportedAlgorithm(algorithm)) return null;
+  if (!/^[0-9a-f]+$/.test(digest) || digest.length === 0) return null;
+  return { algorithm, digest };
+}
+
+function isSupportedAlgorithm(value: string): value is ChecksumAlgorithm {
+  return (SUPPORTED_ALGORITHMS as readonly string[]).includes(value);
+}
+
+function digestBuffer(buf: Buffer, algorithm: ChecksumAlgorithm): string {
+  return createHash(algorithm).update(buf).digest("hex");
+}
+
+async function digestLocalFile(path: string, algorithm: ChecksumAlgorithm): Promise<string> {
+  return digestBuffer(await fs.readFile(path), algorithm);
+}
+
+function checksumError(message: string): Error {
+  return Object.assign(new Error(message), { statusCode: 422 });
+}
+
+/**
+ * Build a `validatePayload` (or `validateCaptionsPayload`/`validateProjectPayload`)
+ * hook that verifies a client-supplied checksum against the finalized bytes
+ * before the upload is marked ready — for adapters that expose `localPath`
+ * (the built-in local adapter does; see `createS3ChecksumValidator` for S3/R2).
+ *
+ * This is at-rest corruption/tampering detection on the *finished* file, not
+ * a per-chunk integrity check — the TUS protocol's Checksum extension would
+ * cover chunks in flight, but the `@tus/server` version in use doesn't
+ * implement it. This fills the same gap for the finished artifact instead.
+ *
+ * Uploads with no `checksum` metadata are passed through unchanged (the
+ * client opted out); a checksum that's present but doesn't match is rejected
+ * with 422 and the bytes are removed, same semantics as `createMp4Sniffer`.
+ * Chain with another validator (e.g. `createMp4Sniffer`) via `next`:
+ *
+ * ```ts
+ * validatePayload: createChecksumValidator(createMp4Sniffer(storage)),
+ * ```
+ */
+export function createChecksumValidator(
+  next?: PulseVaultValidatePayload,
+): PulseVaultValidatePayload {
+  return async (request, ctx) => {
+    const checksum = parseChecksumMetadata(
+      (ctx as typeof ctx & { checksum?: string }).checksum,
+    );
+    if (checksum) {
+      if (!ctx.localPath) {
+        throw checksumError(
+          "Checksum verification requested but this storage adapter has no local path — use createS3ChecksumValidator for S3/R2 storage",
+        );
+      }
+      const actual = await digestLocalFile(ctx.localPath, checksum.algorithm);
+      if (actual !== checksum.digest) {
+        throw checksumError(
+          `Checksum mismatch: expected ${checksum.algorithm}:${checksum.digest}, got ${checksum.algorithm}:${actual}`,
+        );
+      }
+    }
+    if (next) await next(request, ctx);
+  };
+}
+
+/**
+ * `createChecksumValidator` for the S3/R2 backend — downloads the whole
+ * finalized object (via `S3Storage.readAll`) to compute the digest, since
+ * S3 has no local path to hash directly. Only worth using when checksum
+ * verification is explicitly wanted; it's a full extra download per upload.
+ */
+export function createS3ChecksumValidator(
+  storage: S3Storage,
+  next?: PulseVaultValidatePayload,
+): PulseVaultValidatePayload {
+  return async (request, ctx) => {
+    const checksum = parseChecksumMetadata(
+      (ctx as typeof ctx & { checksum?: string }).checksum,
+    );
+    if (checksum) {
+      const bytes = await storage.readAll(ctx.artifactId);
+      if (!bytes) {
+        throw Object.assign(
+          new Error(`Cannot validate upload ${ctx.artifactId}: no object bytes available`),
+          { statusCode: 500 },
+        );
+      }
+      const actual = digestBuffer(bytes, checksum.algorithm);
+      if (actual !== checksum.digest) {
+        throw checksumError(
+          `Checksum mismatch: expected ${checksum.algorithm}:${checksum.digest}, got ${checksum.algorithm}:${actual}`,
+        );
+      }
+    }
+    if (next) await next(request, ctx);
+  };
+}

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -1,22 +1,40 @@
 export type UploadLinkOptions = {
-  /** Full origin of the PulseVault server. */
+  /**
+   * Full base URL the client should upload to — origin *plus* whatever
+   * `prefix` you registered the plugin under (e.g.
+   * `https://vault.example.org/pulsevault`, not just `https://vault.example.org`).
+   * The client builds every request as `${server}/<path>` with no separate
+   * prefix concept of its own. Must be `https://` (or `http://localhost`/a
+   * private IP for local dev).
+   */
   server: string;
-  /** Opaque token forwarded to the server's `authorize` hook. Omit for unauthenticated servers. */
+  /** Opaque token forwarded to the server's `authorize` hook — typically minted with `issueCapabilityToken`. Omit for unauthenticated servers. */
   token?: string;
   /**
-   * Server-side video UUID. Used as both the app's local draft key and the
-   * `videoid` in `Upload-Metadata`, so the app skips `POST /reserve`.
-   * Generate with `crypto.randomUUID()`.
+   * Server-side artifact UUID. Used as both the app's local draft key and the
+   * `artifactId` in `Upload-Metadata`, so the app skips a separate reserve
+   * step. Generate with `crypto.randomUUID()`.
    */
-  videoid: string;
+  artifactId: string;
 };
+
+/** Deep-link wire format version. Bump when the param shape changes incompatibly. */
+const LINK_VERSION = "1";
 
 /**
  * Build a `pulsecam://` deep link that opens the Pulse app directly on the
- * upload screen for a specific draft, pointed at this server.
+ * upload screen for a specific artifact, pointed at this server.
+ *
+ * No `mode` param — there's only one mode, so it was always redundant. `v`
+ * lets the app refuse/explain a future incompatible link shape instead of
+ * misparsing it.
  */
 export function buildUploadLink(opts: UploadLinkOptions): string {
-  const params = new URLSearchParams({ mode: "upload", videoid: opts.videoid, server: opts.server });
+  const params = new URLSearchParams({
+    v: LINK_VERSION,
+    artifactId: opts.artifactId,
+    server: opts.server,
+  });
   if (opts.token) params.set("token", opts.token);
   return `pulsecam://?${params.toString()}`;
 }

--- a/src/lib/magic.ts
+++ b/src/lib/magic.ts
@@ -18,7 +18,7 @@ import type { S3Storage } from "../storage/s3.js";
 export type PulseVaultValidatePayload = (
   request: FastifyRequest,
   ctx: {
-    videoid: string;
+    artifactId: string;
     size: number;
     uploadId: string;
     /** Absolute local path to the finalized bytes, or `null` if unavailable. */
@@ -88,12 +88,12 @@ function hasFtypBox(buf: Buffer): boolean {
 export function createMp4Sniffer(
   storage: LocalStorage,
 ): PulseVaultValidatePayload {
-  return async (_request, { videoid }) => {
-    const localPath = await storage.getLocalPath(videoid);
+  return async (_request, { artifactId }) => {
+    const localPath = await storage.getLocalPath(artifactId);
     if (!localPath) {
       throw Object.assign(
         new Error(
-          `Cannot validate upload ${videoid}: no local path available`,
+          `Cannot validate upload ${artifactId}: no local path available`,
         ),
         { statusCode: 500 },
       );
@@ -129,11 +129,11 @@ export function createMp4Sniffer(
 export function createS3Mp4Sniffer(
   storage: S3Storage,
 ): PulseVaultValidatePayload {
-  return async (_request, { videoid }) => {
-    const header = await storage.readHeader(videoid, 12);
+  return async (_request, { artifactId }) => {
+    const header = await storage.readHeader(artifactId, 12);
     if (!header) {
       throw Object.assign(
-        new Error(`Cannot validate upload ${videoid}: no object bytes available`),
+        new Error(`Cannot validate upload ${artifactId}: no object bytes available`),
         { statusCode: 500 },
       );
     }

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -14,16 +14,36 @@ import type { UploadKind } from "../storage/types.js";
  */
 export type PulseVaultTusContext = {
   request: FastifyRequest;
-  videoid?: string;
+  artifactId?: string;
   /** Kind resolved during TUS create; available on the same request only. */
   kind?: UploadKind;
+  /** `relatedTo` resolved during TUS create; available on the same request only. */
+  relatedTo?: string;
+  /** Raw `checksum` metadata value (`<algorithm>:<hex>`), if the client sent one. */
+  checksum?: string;
 };
 
 export const pulseVaultTusContext = new AsyncLocalStorage<PulseVaultTusContext>();
 
 export type PulseVaultOnUploadComplete = (
   request: FastifyRequest,
-  ctx: { videoid: string; size: number; uploadId: string },
+  ctx: { artifactId: string; kind: UploadKind; size: number; uploadId: string },
+) => void | Promise<void>;
+
+/**
+ * Fired at low-frequency, audit-worthy moments — never per chunk — so an
+ * operator can wire one hook to get both ops metrics and a compliance audit
+ * trail without hand-rolling both from the lower-level hooks.
+ */
+export type PulseVaultArtifactEvent = {
+  phase: "authorize" | "complete" | "reject";
+  artifactId: string;
+  kind: UploadKind;
+  size?: number;
+  reason?: string;
+};
+export type PulseVaultOnArtifactEvent = (
+  event: PulseVaultArtifactEvent,
 ) => void | Promise<void>;
 
 export type PulsevaultTusOptions = {
@@ -36,28 +56,18 @@ export type PulsevaultTusOptions = {
    * Allowed extensions per kind. Must be pre-normalized to lowercase and
    * include the leading dot.
    */
-  allowedExtensions: { video: readonly string[]; project: readonly string[] };
+  allowedExtensions: { video: readonly string[]; project: readonly string[]; captions: readonly string[] };
   /**
-   * Optional payload-validation hook for `kind=video` uploads. Runs after
-   * TUS writes the final byte but before `markReady` and `onUploadComplete`.
-   * Throwing causes `storage.remove?.(videoid)` and a 4xx (default 422).
+   * Optional payload-validation hook, called for every kind with `ctx.kind`
+   * set accordingly. Runs after TUS writes the final byte but before
+   * `markReady` and `onUploadComplete`. Throwing causes
+   * `storage.remove?.(artifactId)` and a 4xx (default 422).
    */
   validatePayload?: PulseVaultValidatePayload;
-  /**
-   * Optional payload-validation hook for `kind=project` uploads. Same
-   * lifecycle as `validatePayload` but only fires for project artifacts.
-   */
-  validateProjectPayload?: PulseVaultValidatePayload;
-  /**
-   * Fired once the final byte of a `kind=video` upload has been written and
-   * any `validatePayload` has passed.
-   */
+  /** Fired once the final byte has been written and any `validatePayload` has passed, for every kind. */
   onUploadComplete?: PulseVaultOnUploadComplete;
-  /**
-   * Fired once the final byte of a `kind=project` upload has been written
-   * and any `validateProjectPayload` has passed.
-   */
-  onProjectUploadComplete?: PulseVaultOnUploadComplete;
+  /** See `PulseVaultOnArtifactEvent`. */
+  onArtifactEvent?: PulseVaultOnArtifactEvent;
 };
 
 /**
@@ -74,8 +84,8 @@ export function tusError(status: number, body: string): Error {
   });
 }
 
-/** Parse the videoid UUID from a tus upload id of the form `<kind>/<videoid><ext>`. */
-function videoidFromUploadId(id: string): string | undefined {
+/** Parse the artifactId UUID from a tus upload id of the form `<kind>/<artifactId><ext>`. */
+function artifactIdFromUploadId(id: string): string | undefined {
   const [, nameWithExt] = id.split("/");
   if (!nameWithExt) return undefined;
   const ext = path.extname(nameWithExt);
@@ -101,9 +111,8 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
     maxSize,
     allowedExtensions,
     validatePayload,
-    validateProjectPayload,
     onUploadComplete,
-    onProjectUploadComplete,
+    onArtifactEvent,
   } = options;
 
   return new Server({
@@ -111,20 +120,25 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
     datastore: storage.datastore,
     maxSize,
     namingFunction: async (_req, metadata) => {
-      // Accept both `videoid` and `projectid` as the UUID key (alias for
-      // back-compat with the Pulse mobile client).
-      const videoid =
-        (metadata?.videoid ?? metadata?.projectid ?? "").trim();
+      // Accept `artifactId` plus the legacy `videoid`/`projectid` aliases for
+      // back-compat with pre-`artifactId` clients.
+      const artifactId = (
+        metadata?.artifactId ?? metadata?.videoid ?? metadata?.projectid ?? ""
+      ).trim();
       const filename = (metadata?.filename ?? "").trim();
       // `kind` defaults to `"video"` so existing clients that don't send
       // the field continue to work without any changes.
       const rawKind = (metadata?.kind ?? "").trim().toLowerCase();
-      const kind: UploadKind = rawKind === "project" ? "project" : "video";
+      const kind: UploadKind =
+        rawKind === "project" ? "project" : rawKind === "captions" ? "captions" : "video";
+      const rawRelatedTo = (metadata?.relatedTo ?? "").trim();
+      const relatedTo = isUuid(rawRelatedTo) ? rawRelatedTo : undefined;
+      const checksum = (metadata?.checksum ?? "").trim() || undefined;
 
-      if (!isUuid(videoid)) {
+      if (!isUuid(artifactId)) {
         throw tusError(
           400,
-          "Upload-Metadata must include a valid `videoid` (or `projectid`) UUID.\n",
+          "Upload-Metadata must include a valid `artifactId` UUID.\n",
         );
       }
 
@@ -137,15 +151,17 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
         );
       }
 
-      // Store kind in the AsyncLocalStorage context so the authorize hook
-      // (already running) and onUploadFinish (same-request uploads) can
-      // read it without a storage round-trip.
+      // Store kind/relatedTo/checksum in the AsyncLocalStorage context so the
+      // authorize hook (already running) and onUploadFinish (same-request
+      // uploads) can read them without a storage round-trip.
       const store = pulseVaultTusContext.getStore();
       if (store) {
         store.kind = kind;
+        store.relatedTo = relatedTo;
+        store.checksum = checksum;
       }
 
-      return storage.reserveUpload({ videoid, filename, ext, kind });
+      return storage.reserveUpload({ artifactId, filename, ext, kind, relatedTo, checksum });
     },
     generateUrl(_req, { proto, host, path: tusBasePath, id }) {
       const encoded = Buffer.from(id, "utf8").toString("base64url");
@@ -167,54 +183,60 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
         // before calling into tus. Bail quietly rather than crash.
         return {};
       }
-      const videoid = videoidFromUploadId(upload.id);
-      if (!videoid) {
+      const artifactId = artifactIdFromUploadId(upload.id);
+      if (!artifactId) {
         return {};
       }
       const size = upload.size ?? 0;
       const uploadId = upload.id;
 
-      // Resolve the kind: prefer the context value (set during the same
-      // request's namingFunction for single-request uploads), fall back to
-      // a storage lookup (cheap in-memory cache hit for chunked uploads).
-      const kind: UploadKind = store.kind ?? (await resolveKind(storage, videoid));
+      // Resolve kind/checksum: prefer the context value (set during the same
+      // request's namingFunction for single-request uploads), fall back to a
+      // storage lookup (cheap in-memory cache hit) for chunked uploads, or —
+      // just as commonly — a single-PATCH upload sent as two separate HTTP
+      // requests (create, then patch), where `onUploadFinish` runs on the
+      // PATCH request's own fresh context, not the one `namingFunction`
+      // populated during the earlier POST.
+      const kind: UploadKind = store.kind ?? (await resolveKind(storage, artifactId));
+      const checksum = store.checksum ?? (await resolveChecksum(storage, artifactId));
 
-      // Pick the right validate and complete hooks based on kind.
-      const effectiveValidate = kind === "project" ? validateProjectPayload : validatePayload;
-      const effectiveComplete = kind === "project" ? onProjectUploadComplete : onUploadComplete;
-
-      // 1. Validate payload (magic bytes, virus scan, etc.). If this throws
-      //    we wipe the bytes from storage — the client gets a 4xx, the
-      //    sidecar is gone, and they can safely retry with a corrected file.
-      if (effectiveValidate) {
+      // 1. Validate payload (magic bytes, checksum, virus scan, etc.). If
+      //    this throws we wipe the bytes from storage — the client gets a
+      //    4xx, the sidecar is gone, and they can safely retry with a
+      //    corrected file. The same hook runs for every kind; consumers that
+      //    want kind-specific behavior branch on `ctx.kind` themselves.
+      if (validatePayload) {
         try {
-          await effectiveValidate(store.request, {
-            videoid,
+          await validatePayload(store.request, {
+            artifactId,
             size,
             uploadId,
-            localPath: await resolveLocalPath(storage, videoid),
-          });
+            localPath: await resolveLocalPath(storage, artifactId),
+            ...(checksum ? { checksum } : {}),
+            kind,
+          } as Parameters<PulseVaultValidatePayload>[1] & { kind: UploadKind; checksum?: string });
         } catch (err) {
           const status = statusCodeOf(err, 422);
           const message =
             err instanceof Error ? err.message : "Payload validation failed";
           try {
-            await storage.remove?.(videoid);
+            await storage.remove?.(artifactId);
           } catch (rmErr) {
             store.request.log.error(
-              { err: rmErr, videoid },
+              { err: rmErr, artifactId },
               "pulsevault failed to remove rejected upload",
             );
           }
+          await onArtifactEvent?.({ phase: "reject", artifactId, kind, size, reason: message });
           throw tusError(status, `${message}\n`);
         }
       }
 
       // 2. Flip the sidecar to "ready" so `resolve` will serve the bytes.
       //    Done *before* the consumer hook so a downstream service that
-      //    reacts to `onUploadComplete` can immediately GET the video.
+      //    reacts to `onUploadComplete` can immediately GET the artifact.
       try {
-        await storage.markReady?.(videoid);
+        await storage.markReady?.(artifactId);
       } catch (err) {
         const message =
           err instanceof Error ? err.message : "markReady failed";
@@ -222,13 +244,13 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
       }
 
       // 3. Consumer hook — business logic (DB writes, queue jobs).
-      if (effectiveComplete) {
+      if (onUploadComplete) {
         try {
-          await effectiveComplete(store.request, { videoid, size, uploadId });
+          await onUploadComplete(store.request, { artifactId, kind, size, uploadId });
         } catch (err) {
           // Propagate as a tus error so the client sees a non-2xx and can
           // distinguish "bytes stored but completion hook failed" from
-          // success. The video is marked ready at this point — consumers
+          // success. The artifact is marked ready at this point — consumers
           // who want "all-or-nothing" should `storage.remove` before
           // throwing.
           const message =
@@ -237,41 +259,59 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
         }
       }
 
+      await onArtifactEvent?.({ phase: "complete", artifactId, kind, size });
+
       return {};
     },
   });
 }
 
 /**
- * Resolve the artifact kind from storage for a known videoid. Used by
+ * Resolve the artifact kind from storage for a known artifactId. Used by
  * `onUploadFinish` for chunked uploads where the kind is not in the current
  * request's context. Defaults to `"video"` for adapters that don't implement
- * `getKind` or when the videoid is not found.
+ * `getKind` or when the artifactId is not found.
  */
 async function resolveKind(
   storage: PulseVaultStorage,
-  videoid: string,
+  artifactId: string,
 ): Promise<UploadKind> {
   const candidate = (storage as { getKind?: unknown }).getKind;
   if (typeof candidate !== "function") return "video";
-  const result = await (candidate as (id: string) => Promise<UploadKind | null>)(videoid);
+  const result = await (candidate as (id: string) => Promise<UploadKind | null>)(artifactId);
   return result ?? "video";
 }
 
 /**
+ * Resolve the `checksum` metadata from storage for a known artifactId. Same
+ * rationale as `resolveKind` — `namingFunction`'s in-memory context doesn't
+ * survive past the request it ran on, so completion (which may run on a
+ * later, separate request) needs a storage-backed fallback.
+ */
+async function resolveChecksum(
+  storage: PulseVaultStorage,
+  artifactId: string,
+): Promise<string | undefined> {
+  const candidate = (storage as { getChecksum?: unknown }).getChecksum;
+  if (typeof candidate !== "function") return undefined;
+  const result = await (candidate as (id: string) => Promise<string | null>)(artifactId);
+  return result ?? undefined;
+}
+
+/**
  * If the adapter exposes `getLocalPath` (the built-in local adapter does),
- * resolve the videoid to an absolute disk path for `validatePayload`. For
+ * resolve the artifactId to an absolute disk path for `validatePayload`. For
  * other adapters, returns `null` and the validator is expected to fetch
  * bytes through whatever API it knows about.
  */
 async function resolveLocalPath(
   storage: PulseVaultStorage,
-  videoid: string,
+  artifactId: string,
 ): Promise<string | null> {
   const candidate = (storage as { getLocalPath?: unknown }).getLocalPath;
   if (typeof candidate !== "function") return null;
   const result = await (candidate as (id: string) => Promise<string | null>)(
-    videoid,
+    artifactId,
   );
   return typeof result === "string" ? result : null;
 }

--- a/src/routes/pulsevault.ts
+++ b/src/routes/pulsevault.ts
@@ -11,6 +11,7 @@ import {
   createPulsevaultTusServer,
   pulseVaultTusContext,
   type PulseVaultOnUploadComplete,
+  type PulseVaultOnArtifactEvent,
 } from "../lib/pulsevaultTus.js";
 import type { PulseVaultValidatePayload } from "../lib/magic.js";
 import { pulseVaultError } from "../lib/errors.js";
@@ -18,13 +19,18 @@ import { isUuid } from "../lib/uuid.js";
 import type { PulseVaultStorage } from "../storage/types.js";
 import type { UploadKind } from "../storage/types.js";
 
+/** Wire protocol version this release implements. See `/capabilities` and `PROTOCOL.md`. */
+export const PROTOCOL_VERSION = 1;
+const MIN_SUPPORTED_PROTOCOL_VERSION = 1;
+const MAX_SUPPORTED_PROTOCOL_VERSION = 1;
+
 // Internal augmentation — mirrored in the opt-in `./augment.ts` re-export so
 // consumers can `import "@mieweb/pulsevault/augment"` and get the
 // same typing. Kept here as well so the plugin itself typechecks regardless
 // of whether the consumer ever imports the augment module.
 declare module "fastify" {
   interface FastifyRequest {
-    pulseVault?: { videoid: string; kind: UploadKind };
+    pulseVault?: { artifactId: string; kind: UploadKind; relatedTo?: string };
   }
 }
 
@@ -36,11 +42,17 @@ export type PulseVaultAuthorizePhase =
 
 export type PulseVaultAuthorizeContext = {
   phase: PulseVaultAuthorizePhase;
-  videoid: string;
-  /** Artifact kind: `"video"` for MP4 uploads, `"project"` for `.pulse`/`.zip` bundles. */
+  artifactId: string;
+  /** Artifact kind: `"video"`, `"project"`, or `"captions"`. Always present. */
   kind: UploadKind;
   /** Bearer / query-string token forwarded from the watch URL, if present. Only populated during the `"resolve"` phase. */
   token?: string;
+  /**
+   * The session-anchor artifact this one declared via `Upload-Metadata.relatedTo`,
+   * if any. Lets `createCapabilityAuthorize` authorize an artifact against a
+   * token scoped to the session it belongs to rather than its own id.
+   */
+  relatedTo?: string;
 };
 
 export type PulseVaultAuthorize = (
@@ -51,25 +63,28 @@ export type PulseVaultAuthorize = (
 export type PulseVaultRoutesOptions = {
   storage: PulseVaultStorage;
   maxUploadSize: number;
-  allowedExtensions: { video: readonly string[]; project: readonly string[] };
+  allowedExtensions: { video: readonly string[]; project: readonly string[]; captions: readonly string[] };
+  /** Advertised via `GET /capabilities` so the client knows which upload strategy this server expects. */
+  uploadUnit: "beat" | "merged";
   cache?: PulseVaultCacheOptions;
   authorize?: PulseVaultAuthorize;
   validatePayload?: PulseVaultValidatePayload;
-  validateProjectPayload?: PulseVaultValidatePayload;
   onUploadComplete?: PulseVaultOnUploadComplete;
-  onProjectUploadComplete?: PulseVaultOnUploadComplete;
+  onArtifactEvent?: PulseVaultOnArtifactEvent;
 } & FastifyPluginOptions;
 
 /**
- * Pull `videoid` (or `projectid` alias) and `kind` out of a raw
- * `Upload-Metadata` header. Format is a comma-separated list of
- * `<key> <base64-value>` pairs (tus v1 creation extension).
+ * Pull `artifactId` (or the legacy `videoid`/`projectid` aliases), `kind`,
+ * and `relatedTo` out of a raw `Upload-Metadata` header. Format is a
+ * comma-separated list of `<key> <base64-value>` pairs (tus v1 creation
+ * extension).
  */
 function parseUploadMetadata(
   header: string,
-): { videoid: string | undefined; kind: UploadKind } {
-  let videoid: string | undefined;
+): { artifactId: string | undefined; kind: UploadKind; relatedTo: string | undefined } {
+  let artifactId: string | undefined;
   let kind: UploadKind = "video";
+  let relatedTo: string | undefined;
   for (const pair of header.split(",")) {
     const trimmed = pair.trim();
     if (!trimmed) continue;
@@ -80,24 +95,27 @@ function parseUploadMetadata(
     if (!value) continue;
     try {
       const decoded = Buffer.from(value, "base64").toString("utf8");
-      if ((key === "videoid" || key === "projectid") && !videoid) {
-        videoid = isUuid(decoded) ? decoded : undefined;
+      if ((key === "artifactId" || key === "videoid" || key === "projectid") && !artifactId) {
+        artifactId = isUuid(decoded) ? decoded : undefined;
       } else if (key === "kind") {
-        kind = decoded.trim().toLowerCase() === "project" ? "project" : "video";
+        const lower = decoded.trim().toLowerCase();
+        kind = lower === "project" ? "project" : lower === "captions" ? "captions" : "video";
+      } else if (key === "relatedTo" && !relatedTo) {
+        relatedTo = isUuid(decoded) ? decoded : undefined;
       }
     } catch {
       // ignore malformed base64
     }
   }
-  return { videoid, kind };
+  return { artifactId, kind, relatedTo };
 }
 
 /**
  * Decode the last URL segment of a tus PATCH/HEAD/DELETE (base64url-encoded
  * id) and extract the first path component, which the plugin always shapes as
- * the videoid (see `pulseVaultTus.ts`).
+ * the artifactId (see `pulseVaultTus.ts`).
  */
-function videoidFromTusUrl(url: string): string | undefined {
+function artifactIdFromTusUrl(url: string): string | undefined {
   const match = url.match(/\/upload\/([^/?#]+)/);
   if (!match?.[1]) return undefined;
   let decoded: string;
@@ -111,17 +129,28 @@ function videoidFromTusUrl(url: string): string | undefined {
 }
 
 /**
- * Resolve the artifact kind for a videoid from storage. Duck-typed so it
+ * Resolve the artifact kind for an artifactId from storage. Duck-typed so it
  * works with any adapter (those without `getKind` return `"video"`).
  */
 async function resolveStorageKind(
   storage: PulseVaultStorage,
-  videoid: string,
+  artifactId: string,
 ): Promise<UploadKind> {
   const candidate = (storage as { getKind?: unknown }).getKind;
   if (typeof candidate !== "function") return "video";
-  const result = await (candidate as (id: string) => Promise<UploadKind | null>)(videoid);
+  const result = await (candidate as (id: string) => Promise<UploadKind | null>)(artifactId);
   return result ?? "video";
+}
+
+/** Resolve the `relatedTo` artifact for an artifactId from storage, if the adapter supports it. */
+async function resolveStorageRelatedTo(
+  storage: PulseVaultStorage,
+  artifactId: string,
+): Promise<string | undefined> {
+  const candidate = (storage as { getRelatedTo?: unknown }).getRelatedTo;
+  if (typeof candidate !== "function") return undefined;
+  const result = await (candidate as (id: string) => Promise<string | null>)(artifactId);
+  return result ?? undefined;
 }
 
 function extractAuthzStatus(err: unknown): number {
@@ -161,9 +190,11 @@ const tusRouteSchema: OpenApiRouteSchema = {
   description:
     "TUS v1 resumable upload protocol.\n\n" +
     "- `POST` creates a new upload. The `Upload-Metadata` header must include base64-encoded key/value pairs:\n" +
-    "  - `videoid` (or `projectid` alias) — a UUID generated by your server.\n" +
+    "  - `artifactId` (or the legacy `videoid`/`projectid` aliases) — a UUID generated by your server.\n" +
     "  - `filename` — original filename; the extension must match the kind's allowed list.\n" +
-    "  - `kind` — `video` (default) or `project`. Determines the storage subdir and which completion hooks fire.\n" +
+    "  - `kind` — `video` (default), `project`, or `captions`. Determines the storage subdir and which completion hooks fire.\n" +
+    "  - `relatedTo` — optional UUID of another artifact this one belongs to (e.g. a video's captions, or a beat belonging to a pulse manifest's session).\n" +
+    "  - `checksum` — optional `<algorithm>:<hex digest>` of the finished file, verified post-upload if a checksum validator is configured.\n" +
     "- `PATCH` appends a chunk at the offset given by `Upload-Offset`, with `Content-Type: application/offset+octet-stream`.\n" +
     "- `HEAD` returns the current offset for a resumable upload.\n" +
     "- `DELETE` cancels an in-flight upload.\n\n" +
@@ -177,32 +208,32 @@ const tusRouteSchema: OpenApiRouteSchema = {
   },
 };
 
-const videoDeleteSchema: OpenApiRouteSchema = {
+const artifactDeleteSchema: OpenApiRouteSchema = {
   tags: ["pulsevault"],
-  summary: "Delete an uploaded video",
+  summary: "Delete an uploaded artifact",
   description:
-    "Deletes all storage for a videoid (bytes + sidecar metadata). Only deletes `kind=video` uploads — returns 404 for project artifacts (use `DELETE /project/:projectid` instead). Runs the `authorize` hook with `phase: \"delete\"` before the adapter's `remove` is called. Returns 204 on success, 404 if the videoid was unknown, 501 if the adapter does not implement `remove`.",
+    "Deletes all storage for an artifactId (bytes + sidecar metadata), regardless of kind. Runs the `authorize` hook with `phase: \"delete\"` before the adapter's `remove` is called. Returns 204 on success, 404 if the artifactId was unknown, 501 if the adapter does not implement `remove`.",
   params: {
     type: "object",
     properties: {
-      videoid: {
+      artifactId: {
         type: "string",
         format: "uuid",
         description: "UUID of the upload to delete.",
       },
     },
-    required: ["videoid"],
+    required: ["artifactId"],
   },
   response: {
     400: {
-      description: "`videoid` is not a valid UUID.",
+      description: "`artifactId` is not a valid UUID.",
       ...pulseVaultErrorResponse,
     },
     403: {
       description: "Authorize hook rejected the request.",
       ...pulseVaultErrorResponse,
     },
-    404: { description: "Video not found.", ...pulseVaultErrorResponse },
+    404: { description: "Artifact not found.", ...pulseVaultErrorResponse },
     501: {
       description: "Storage adapter does not implement delete.",
       ...pulseVaultErrorResponse,
@@ -210,21 +241,21 @@ const videoDeleteSchema: OpenApiRouteSchema = {
   },
 };
 
-const videoGetSchema: OpenApiRouteSchema = {
+const artifactGetSchema: OpenApiRouteSchema = {
   tags: ["pulsevault"],
-  summary: "Serve a previously uploaded video",
+  summary: "Serve a previously uploaded artifact",
   description:
-    "Resolves the `videoid` through the configured storage adapter and either streams the bytes or redirects (for CDN-backed adapters). Only serves `kind=video` uploads — returns 404 for project artifacts (use `GET /project/:projectid` instead). Runs the `authorize` hook before resolve.",
+    "Resolves the `artifactId` through the configured storage adapter and either streams the bytes or redirects (for CDN-backed adapters). The artifact's kind (video, project, or captions) is resolved from storage, not the URL. Runs the `authorize` hook before resolve.",
   params: {
     type: "object",
     properties: {
-      videoid: {
+      artifactId: {
         type: "string",
         format: "uuid",
-        description: "UUID returned from the reserve/TUS-create flow.",
+        description: "UUID returned from the upload flow.",
       },
     },
-    required: ["videoid"],
+    required: ["artifactId"],
   },
   querystring: {
     type: "object",
@@ -238,85 +269,45 @@ const videoGetSchema: OpenApiRouteSchema = {
   },
   response: {
     400: {
-      description: "`videoid` is not a valid UUID.",
+      description: "`artifactId` is not a valid UUID.",
       ...pulseVaultErrorResponse,
     },
     403: {
       description: "Authorize hook rejected the request.",
       ...pulseVaultErrorResponse,
     },
-    404: { description: "Video not found.", ...pulseVaultErrorResponse },
+    404: { description: "Artifact not found.", ...pulseVaultErrorResponse },
   },
 };
 
-const projectGetSchema: OpenApiRouteSchema = {
+const capabilitiesSchema: OpenApiRouteSchema = {
   tags: ["pulsevault"],
-  summary: "Serve a previously uploaded project artifact",
+  summary: "Discover this deployment's protocol version and configuration",
   description:
-    "Resolves the `projectid` through the configured storage adapter and streams the bytes. Only serves `kind=project` uploads — returns 404 for video artifacts. Runs the `authorize` hook before resolve.",
-  params: {
-    type: "object",
-    properties: {
-      projectid: {
-        type: "string",
-        format: "uuid",
-        description: "UUID of the project upload.",
-      },
-    },
-    required: ["projectid"],
-  },
-  querystring: {
-    type: "object",
-    properties: {
-      token: {
-        type: "string",
-        description:
-          "Optional bearer token for pre-authenticated watch links. Forwarded to the `authorize` hook as `ctx.token`.",
-      },
-    },
-  },
+    "Unauthenticated — the response carries no secrets. Lets a client detect protocol compatibility before pairing, and which upload strategy (`uploadUnit`) this server expects.",
   response: {
-    400: {
-      description: "`projectid` is not a valid UUID.",
-      ...pulseVaultErrorResponse,
-    },
-    403: {
-      description: "Authorize hook rejected the request.",
-      ...pulseVaultErrorResponse,
-    },
-    404: { description: "Project not found.", ...pulseVaultErrorResponse },
-  },
-};
-
-const projectDeleteSchema: OpenApiRouteSchema = {
-  tags: ["pulsevault"],
-  summary: "Delete an uploaded project artifact",
-  description:
-    "Deletes all storage for a projectid (bytes + sidecar metadata). Only deletes `kind=project` uploads — returns 404 for video artifacts. Runs the `authorize` hook with `phase: \"delete\"` before the adapter's `remove` is called.",
-  params: {
-    type: "object",
-    properties: {
-      projectid: {
-        type: "string",
-        format: "uuid",
-        description: "UUID of the project upload to delete.",
+    200: {
+      type: "object",
+      properties: {
+        protocolVersion: { type: "number" },
+        minSupportedVersion: { type: "number" },
+        maxSupportedVersion: { type: "number" },
+        uploadUnit: { type: "string", enum: ["beat", "merged"] },
+        kinds: { type: "array", items: { type: "string" } },
+        allowedExtensions: {
+          type: "object",
+          properties: {
+            video: { type: "array", items: { type: "string" } },
+            project: { type: "array", items: { type: "string" } },
+            captions: { type: "array", items: { type: "string" } },
+          },
+        },
+        maxUploadSize: { type: "number" },
+        checksum: {
+          type: "object",
+          properties: { algorithms: { type: "array", items: { type: "string" } } },
+        },
       },
-    },
-    required: ["projectid"],
-  },
-  response: {
-    400: {
-      description: "`projectid` is not a valid UUID.",
-      ...pulseVaultErrorResponse,
-    },
-    403: {
-      description: "Authorize hook rejected the request.",
-      ...pulseVaultErrorResponse,
-    },
-    404: { description: "Project not found.", ...pulseVaultErrorResponse },
-    501: {
-      description: "Storage adapter does not implement delete.",
-      ...pulseVaultErrorResponse,
     },
   },
 };
@@ -329,12 +320,12 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
     storage,
     maxUploadSize,
     allowedExtensions,
+    uploadUnit,
     cache,
     authorize,
     validatePayload,
-    validateProjectPayload,
     onUploadComplete,
-    onProjectUploadComplete,
+    onArtifactEvent,
   } = opts;
   // `fastify.prefix` is `""` when the plugin is mounted at the root.
   const tusPath = `${fastify.prefix}/upload`;
@@ -345,9 +336,8 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
     maxSize: maxUploadSize,
     allowedExtensions,
     validatePayload,
-    validateProjectPayload,
     onUploadComplete,
-    onProjectUploadComplete,
+    onArtifactEvent,
   });
 
   fastify.addContentTypeParser(
@@ -356,6 +346,13 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
       done(null);
     },
   );
+
+  // Every response from this plugin carries the wire protocol version it
+  // implements, so a client can detect "this server is too old/new for me"
+  // without a dedicated round-trip.
+  fastify.addHook("onSend", async (_request, reply) => {
+    reply.header("Protocol-Version", String(PROTOCOL_VERSION));
+  });
 
   /**
    * Run the consumer's `authorize` hook (if any) for a TUS request. Returns
@@ -366,46 +363,56 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
     request: FastifyRequest,
     reply: FastifyReply,
     phase: "create" | "patch",
-  ): Promise<{ ok: true; videoid: string | undefined; kind: UploadKind } | { ok: false }> => {
-    let videoid: string | undefined;
+  ): Promise<
+    | { ok: true; artifactId: string | undefined; kind: UploadKind; relatedTo?: string }
+    | { ok: false }
+  > => {
+    let artifactId: string | undefined;
     let kind: UploadKind = "video";
+    let relatedTo: string | undefined;
     if (phase === "create") {
       const meta = request.headers["upload-metadata"];
       if (typeof meta === "string") {
-        ({ videoid, kind } = parseUploadMetadata(meta));
+        ({ artifactId, kind, relatedTo } = parseUploadMetadata(meta));
       }
     } else {
-      videoid = videoidFromTusUrl(request.url);
-      // For PATCH/HEAD, resolve kind from storage (cache hit after reserve).
-      if (videoid) {
-        kind = await resolveStorageKind(storage, videoid);
+      artifactId = artifactIdFromTusUrl(request.url);
+      // For PATCH/HEAD, resolve kind/relatedTo from storage (cache hit after reserve).
+      if (artifactId) {
+        kind = await resolveStorageKind(storage, artifactId);
+        relatedTo = await resolveStorageRelatedTo(storage, artifactId);
       }
     }
 
-    if (videoid) {
-      request.pulseVault = { videoid, kind };
+    if (artifactId) {
+      request.pulseVault = { artifactId, kind, relatedTo };
     }
 
     if (!authorize) {
-      return { ok: true, videoid, kind };
+      return { ok: true, artifactId, kind, relatedTo };
     }
 
-    // If we can't extract a videoid, let tus produce its own 4xx for malformed
-    // input rather than synthesize a fake authorize failure.
-    if (!videoid) {
-      return { ok: true, videoid, kind };
+    // If we can't extract an artifactId, let tus produce its own 4xx for
+    // malformed input rather than synthesize a fake authorize failure.
+    if (!artifactId) {
+      return { ok: true, artifactId, kind, relatedTo };
     }
 
     try {
-      await authorize(request, { phase, videoid, kind });
-      return { ok: true, videoid, kind };
+      await authorize(request, { phase, artifactId, kind, relatedTo });
+      return { ok: true, artifactId, kind, relatedTo };
     } catch (err) {
       const statusCode = extractAuthzStatus(err);
       const message = extractAuthzMessage(err);
       request.log.info(
-        { err, videoid, phase, statusCode },
+        { err, artifactId, phase, statusCode },
         "pulsevault authorize rejected",
       );
+      // Only the create phase is a meaningful, low-frequency audit point —
+      // patch runs once per chunk and would make this noisy.
+      if (phase === "create") {
+        await onArtifactEvent?.({ phase: "authorize", artifactId, kind, reason: message });
+      }
       await reply.code(statusCode).send(pulseVaultError(message));
       return { ok: false };
     }
@@ -424,7 +431,7 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
     reply.hijack();
     try {
       await pulseVaultTusContext.run(
-        { request, videoid: authz.videoid },
+        { request, artifactId: authz.artifactId },
         () => tusServer.handle(request.raw, reply.raw),
       );
     } catch (err) {
@@ -453,36 +460,45 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
     handler: tusHandler,
   });
 
+  fastify.get("/capabilities", { schema: capabilitiesSchema }, async (_request, reply) => {
+    return reply.send({
+      protocolVersion: PROTOCOL_VERSION,
+      minSupportedVersion: MIN_SUPPORTED_PROTOCOL_VERSION,
+      maxSupportedVersion: MAX_SUPPORTED_PROTOCOL_VERSION,
+      uploadUnit,
+      kinds: ["video", "project", "captions"],
+      allowedExtensions,
+      maxUploadSize,
+      checksum: { algorithms: ["sha256", "sha1", "md5"] },
+    });
+  });
+
   fastify.delete(
-    "/:videoid",
-    { schema: videoDeleteSchema },
+    "/artifacts/:artifactId",
+    { schema: artifactDeleteSchema },
     async (request, reply) => {
-      const videoid = (request.params as { videoid?: unknown })?.videoid;
-      if (!isUuid(videoid)) {
+      const artifactId = (request.params as { artifactId?: unknown })?.artifactId;
+      if (!isUuid(artifactId)) {
         return reply
           .code(400)
-          .send(pulseVaultError("`videoid` must be a valid UUID"));
+          .send(pulseVaultError("`artifactId` must be a valid UUID"));
       }
 
-      const deleteKind = await resolveStorageKind(storage, videoid);
-
-      // This route is video-only. Project artifacts must use DELETE /project/:projectid.
-      if (deleteKind !== "video") {
-        return reply.code(404).send(pulseVaultError("Video not found"));
-      }
-
-      request.pulseVault = { videoid, kind: deleteKind };
+      const kind = await resolveStorageKind(storage, artifactId);
+      const relatedTo = await resolveStorageRelatedTo(storage, artifactId);
+      request.pulseVault = { artifactId, kind, relatedTo };
 
       if (authorize) {
         try {
-          await authorize(request, { phase: "delete", videoid, kind: deleteKind });
+          await authorize(request, { phase: "delete", artifactId, kind, relatedTo });
         } catch (err) {
           const statusCode = extractAuthzStatus(err);
           const message = extractAuthzMessage(err);
           request.log.info(
-            { err, videoid, phase: "delete", statusCode },
+            { err, artifactId, phase: "delete", statusCode },
             "pulsevault authorize rejected",
           );
+          await onArtifactEvent?.({ phase: "authorize", artifactId, kind, reason: message });
           return reply.code(statusCode).send(pulseVaultError(message));
         }
       }
@@ -497,56 +513,52 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
           );
       }
 
-      const removed = await storage.remove(videoid);
+      const removed = await storage.remove(artifactId);
       if (!removed) {
-        return reply.code(404).send(pulseVaultError("Video not found"));
+        return reply.code(404).send(pulseVaultError("Artifact not found"));
       }
       return reply.code(204).send();
     },
   );
 
-  fastify.get("/:videoid", { schema: videoGetSchema }, async (request, reply) => {
-    const videoid = (request.params as { videoid?: unknown })?.videoid;
-    if (!isUuid(videoid)) {
+  fastify.get("/artifacts/:artifactId", { schema: artifactGetSchema }, async (request, reply) => {
+    const artifactId = (request.params as { artifactId?: unknown })?.artifactId;
+    if (!isUuid(artifactId)) {
       return reply
         .code(400)
-        .send(pulseVaultError("`videoid` must be a valid UUID"));
+        .send(pulseVaultError("`artifactId` must be a valid UUID"));
     }
 
-    // Resolve kind before setting request.pulseVault so authorize hooks get
-    // a fully-populated context (cache hit after reserveUpload).
-    const resolvedKind = await resolveStorageKind(storage, videoid);
-
-    // This route is video-only. Project artifacts must use GET /project/:projectid.
-    if (resolvedKind !== "video") {
-      return reply.code(404).send(pulseVaultError("Video not found"));
-    }
-
-    request.pulseVault = { videoid, kind: resolvedKind };
+    // Resolve kind/relatedTo before setting request.pulseVault so authorize
+    // hooks get a fully-populated context (cache hit after reserveUpload).
+    const kind = await resolveStorageKind(storage, artifactId);
+    const relatedTo = await resolveStorageRelatedTo(storage, artifactId);
+    request.pulseVault = { artifactId, kind, relatedTo };
 
     // Extract the optional token forwarded by the mobile app in the watch URL.
     const token = (request.query as { token?: string })?.token;
 
     // Run authorize *before* resolve so consumers can reject without the
-    // response leaking "this videoid exists but you don't own it" vs. "no such
-    // videoid".
+    // response leaking "this artifactId exists but you don't own it" vs. "no
+    // such artifactId".
     if (authorize) {
       try {
-        await authorize(request, { phase: "resolve", videoid, kind: resolvedKind, token });
+        await authorize(request, { phase: "resolve", artifactId, kind, relatedTo, token });
       } catch (err) {
         const statusCode = extractAuthzStatus(err);
         const message = extractAuthzMessage(err);
         request.log.info(
-          { err, videoid, phase: "resolve", statusCode },
+          { err, artifactId, phase: "resolve", statusCode },
           "pulsevault authorize rejected",
         );
+        await onArtifactEvent?.({ phase: "authorize", artifactId, kind, reason: message });
         return reply.code(statusCode).send(pulseVaultError(message));
       }
     }
 
-    const resolved = await storage.resolve(videoid);
+    const resolved = await storage.resolve(artifactId);
     if (!resolved) {
-      return reply.code(404).send(pulseVaultError("Video not found"));
+      return reply.code(404).send(pulseVaultError("Artifact not found"));
     }
 
     if (resolved.kind === "redirect") {
@@ -567,117 +579,6 @@ const pulseVaultRoutes: FastifyPluginAsync<PulseVaultRoutesOptions> = async (
     // If the storage adapter provided an explicit content type (e.g. for
     // non-standard extensions like `.pulse`), override what @fastify/send
     // would otherwise infer from the filename.
-    if (resolved.contentType) {
-      reply.header("content-type", resolved.contentType);
-    }
-
-    for (const [name, value] of Object.entries(result.headers)) {
-      reply.header(name, value);
-    }
-    return reply.code(result.statusCode).send(result.stream);
-  });
-
-  fastify.delete(
-    "/project/:projectid",
-    { schema: projectDeleteSchema },
-    async (request, reply) => {
-      const projectid = (request.params as { projectid?: unknown })?.projectid;
-      if (!isUuid(projectid)) {
-        return reply
-          .code(400)
-          .send(pulseVaultError("`projectid` must be a valid UUID"));
-      }
-
-      const deleteKind = await resolveStorageKind(storage, projectid);
-
-      // This route is project-only. Video artifacts must use DELETE /:videoid.
-      if (deleteKind !== "project") {
-        return reply.code(404).send(pulseVaultError("Project not found"));
-      }
-
-      request.pulseVault = { videoid: projectid, kind: "project" };
-
-      if (authorize) {
-        try {
-          await authorize(request, { phase: "delete", videoid: projectid, kind: "project" });
-        } catch (err) {
-          const statusCode = extractAuthzStatus(err);
-          const message = extractAuthzMessage(err);
-          request.log.info(
-            { err, videoid: projectid, phase: "delete", statusCode },
-            "pulsevault authorize rejected",
-          );
-          return reply.code(statusCode).send(pulseVaultError(message));
-        }
-      }
-
-      if (typeof storage.remove !== "function") {
-        return reply
-          .code(501)
-          .send(pulseVaultError("Storage adapter does not support delete"));
-      }
-
-      const removed = await storage.remove(projectid);
-      if (!removed) {
-        return reply.code(404).send(pulseVaultError("Project not found"));
-      }
-      return reply.code(204).send();
-    },
-  );
-
-  fastify.get("/project/:projectid", { schema: projectGetSchema }, async (request, reply) => {
-    const projectid = (request.params as { projectid?: unknown })?.projectid;
-    if (!isUuid(projectid)) {
-      return reply
-        .code(400)
-        .send(pulseVaultError("`projectid` must be a valid UUID"));
-    }
-
-    const resolvedKind = await resolveStorageKind(storage, projectid);
-
-    // This route is project-only. Video artifacts must use GET /:videoid.
-    if (resolvedKind !== "project") {
-      return reply.code(404).send(pulseVaultError("Project not found"));
-    }
-
-    request.pulseVault = { videoid: projectid, kind: "project" };
-
-    const token = (request.query as { token?: string })?.token;
-
-    if (authorize) {
-      try {
-        await authorize(request, { phase: "resolve", videoid: projectid, kind: "project", token });
-      } catch (err) {
-        const statusCode = extractAuthzStatus(err);
-        const message = extractAuthzMessage(err);
-        request.log.info(
-          { err, videoid: projectid, phase: "resolve", statusCode },
-          "pulsevault authorize rejected",
-        );
-        return reply.code(statusCode).send(pulseVaultError(message));
-      }
-    }
-
-    const resolved = await storage.resolve(projectid);
-    if (!resolved) {
-      return reply.code(404).send(pulseVaultError("Project not found"));
-    }
-
-    if (resolved.kind === "redirect") {
-      return reply.redirect(resolved.url, resolved.statusCode ?? 302);
-    }
-
-    const result = await send(request.raw, resolved.filename, {
-      root: resolved.root,
-      ...cache,
-    });
-
-    if (result.type === "error") {
-      return reply
-        .code(result.statusCode)
-        .send(pulseVaultError(result.metadata.error.message));
-    }
-
     if (resolved.contentType) {
       reply.header("content-type", resolved.contentType);
     }

--- a/src/storage/local.ts
+++ b/src/storage/local.ts
@@ -9,9 +9,9 @@ import type {
 } from "./types.js";
 
 /**
- * Per-video metadata sidecar written at
- * `<workspaceRoot>/<videoid>/.pulsevault.json`. Lets `resolve()` recover a
- * video's extension and completion state without scanning the directory,
+ * Per-artifact metadata sidecar written at
+ * `<workspaceRoot>/.pulsevault/<artifactId>.json`. Lets `resolve()` recover an
+ * artifact's extension and completion state without scanning the directory,
  * and keeps the on-disk layout self-describing for downstream tools
  * (ArtiPod pipelines, ffmpeg, rsync, etc.).
  */
@@ -33,19 +33,32 @@ type Sidecar = {
    * kind was introduced are read as `"video"` with no on-disk migration.
    */
   kind?: UploadKind;
+  /** Optional id of another artifact this one belongs to. See `ReserveUploadParams.relatedTo`. */
+  relatedTo?: string;
+  /** Optional client-supplied checksum metadata. See `ReserveUploadParams.checksum`. */
+  checksum?: string;
 };
 
 const SIDECAR_VERSION = 1 as const;
 /** Hidden directory inside workspaceRoot that holds per-upload sidecar files. */
 const PULSEVAULT_META_DIR = ".pulsevault";
+/** Default cap on the in-memory metadata cache before evicting the oldest entry. */
+const DEFAULT_META_CACHE_LIMIT = 10_000;
 
-type CachedMeta = { ext: string; ready: boolean; kind: UploadKind };
+type CachedMeta = {
+  ext: string;
+  ready: boolean;
+  kind: UploadKind;
+  relatedTo?: string;
+  checksum?: string;
+};
 
 /** Map a file extension to the `Content-Type` the GET route should return. */
 function extToContentType(ext: string): string {
   switch (ext) {
     case ".mp4": return "video/mp4";
     case ".zip": return "application/zip";
+    case ".srt": return "application/x-subrip";
     default: return "application/octet-stream";
   }
 }
@@ -53,6 +66,13 @@ function extToContentType(ext: string): string {
 export type LocalStorageOptions = {
   /** Directory where uploads are stored (flat kind-scoped subdirs). Resolved against CWD if relative. */
   workspaceDir: string;
+  /**
+   * Max number of entries kept in the in-memory metadata cache before the
+   * oldest (by insertion order) is evicted. A cache miss falls back to
+   * reading the sidecar from disk, so eviction only costs an extra read, not
+   * correctness. Defaults to 10,000.
+   */
+  metaCacheLimit?: number;
 };
 
 /**
@@ -61,11 +81,13 @@ export type LocalStorageOptions = {
  *
  * ```text
  * <workspaceRoot>/
- *   .pulsevault/<videoid>.json   # sidecar: { version, ext, filename, status, kind }
- *   video/<videoid><ext>         # finalized video bytes
- *   video/<videoid><ext>.json    # @tus/file-store offset/metadata sidecar
- *   project/<videoid><ext>       # finalized project bytes
- *   project/<videoid><ext>.json  # @tus/file-store offset/metadata sidecar
+ *   .pulsevault/<artifactId>.json   # sidecar: { version, ext, filename, status, kind, relatedTo }
+ *   video/<artifactId><ext>         # finalized video bytes
+ *   video/<artifactId><ext>.json    # @tus/file-store offset/metadata sidecar
+ *   project/<artifactId><ext>       # finalized project bytes
+ *   project/<artifactId><ext>.json  # @tus/file-store offset/metadata sidecar
+ *   captions/<artifactId><ext>      # finalized captions bytes
+ *   captions/<artifactId><ext>.json # @tus/file-store offset/metadata sidecar
  * ```
  *
  * `workspaceRoot` is exposed so consumers can layer post-processing (e.g.
@@ -77,54 +99,73 @@ export type LocalStorageOptions = {
 export type LocalStorage = PulseVaultStorage & {
   readonly workspaceRoot: string;
   /**
-   * Return the absolute path to the upload bytes for `videoid`, regardless
+   * Return the absolute path to the upload bytes for `artifactId`, regardless
    * of ready state. Falls back to reading the sidecar if the in-memory cache
    * is cold (so it works even after a server restart mid-upload). Returns
-   * `null` if the videoid is unknown.
+   * `null` if the artifactId is unknown.
    */
-  getLocalPath(videoid: string): Promise<string | null>;
+  getLocalPath(artifactId: string): Promise<string | null>;
   /**
-   * Return the artifact kind for a known videoid without a full resolve.
-   * Returns `null` if the videoid is unknown. Satisfies the optional
+   * Return the artifact kind for a known artifactId without a full resolve.
+   * Returns `null` if the artifactId is unknown. Satisfies the optional
    * `PulseVaultStorage.getKind` contract.
    */
-  getKind(videoid: string): Promise<UploadKind | null>;
+  getKind(artifactId: string): Promise<UploadKind | null>;
+  /** Satisfies the optional `PulseVaultStorage.getRelatedTo` contract. */
+  getRelatedTo(artifactId: string): Promise<string | null>;
+  /** Satisfies the optional `PulseVaultStorage.getChecksum` contract. */
+  getChecksum(artifactId: string): Promise<string | null>;
 };
 
 export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
   const workspaceRoot = path.resolve(opts.workspaceDir);
   const datastore = new FileStore({ directory: workspaceRoot });
-  // Metadata cache keyed by videoid. Populated eagerly on reserve and lazily
-  // from the sidecar on cache-miss — so we never do a workspace-wide scan at
-  // boot and never do a per-request readdir on the GET hot path.
+  const metaCacheLimit = opts.metaCacheLimit ?? DEFAULT_META_CACHE_LIMIT;
+  // Metadata cache keyed by artifactId. Populated eagerly on reserve and
+  // lazily from the sidecar on cache-miss — so we never do a workspace-wide
+  // scan at boot and never do a per-request readdir on the GET hot path.
+  // Bounded with simple insertion-order eviction (a `Map` preserves insertion
+  // order, and re-setting a key moves it to the end) so a long-running server
+  // doesn't grow this unboundedly; a cache miss just costs an extra disk read.
   const metaCache = new Map<string, CachedMeta>();
+
+  const cacheSet = (artifactId: string, meta: CachedMeta): void => {
+    // Re-inserting moves the key to the end of iteration order, so eviction
+    // below always drops the actual least-recently-set entry.
+    metaCache.delete(artifactId);
+    metaCache.set(artifactId, meta);
+    if (metaCache.size > metaCacheLimit) {
+      const oldest = metaCache.keys().next().value;
+      if (oldest !== undefined) metaCache.delete(oldest);
+    }
+  };
 
   /** Absolute path to the hidden metadata directory. */
   const sidecarDir = (): string => path.join(workspaceRoot, PULSEVAULT_META_DIR);
-  /** Absolute path to the sidecar JSON for a given videoid. */
-  const sidecarPath = (videoid: string): string =>
-    path.join(sidecarDir(), `${videoid}.json`);
+  /** Absolute path to the sidecar JSON for a given artifactId. */
+  const sidecarPath = (artifactId: string): string =>
+    path.join(sidecarDir(), `${artifactId}.json`);
   /** Relative path (from workspaceRoot) to the artifact bytes. */
-  const artifactRelPath = (videoid: string, kind: UploadKind, ext: string): string =>
-    `${kind}/${videoid}${ext}`;
+  const artifactRelPath = (artifactId: string, kind: UploadKind, ext: string): string =>
+    `${kind}/${artifactId}${ext}`;
 
   const writeSidecar = async (
-    videoid: string,
+    artifactId: string,
     sidecar: Sidecar,
   ): Promise<void> => {
     // Atomic tmp + rename so a crash mid-write can never leave a truncated
     // JSON blob that `loadMeta` would then treat as corrupt.
-    const finalPath = sidecarPath(videoid);
+    const finalPath = sidecarPath(artifactId);
     const tmpPath = `${finalPath}.tmp`;
     await fs.mkdir(sidecarDir(), { recursive: true });
     await fs.writeFile(tmpPath, JSON.stringify(sidecar), "utf8");
     await fs.rename(tmpPath, finalPath);
   };
 
-  const readSidecar = async (videoid: string): Promise<Sidecar | null> => {
+  const readSidecar = async (artifactId: string): Promise<Sidecar | null> => {
     let raw: string;
     try {
-      raw = await fs.readFile(sidecarPath(videoid), "utf8");
+      raw = await fs.readFile(sidecarPath(artifactId), "utf8");
     } catch (err) {
       if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
       throw err;
@@ -139,13 +180,16 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
       const status: Sidecar["status"] =
         parsed.status === "uploading" ? "uploading" : "ready";
       // Older sidecars without `kind` default to `"video"` — no migration.
-      const kind: UploadKind = parsed.kind === "project" ? "project" : "video";
+      const kind: UploadKind =
+        parsed.kind === "project" ? "project" : parsed.kind === "captions" ? "captions" : "video";
       return {
         version: SIDECAR_VERSION,
         ext: parsed.ext,
         filename: parsed.filename,
         status,
         kind,
+        relatedTo: typeof parsed.relatedTo === "string" ? parsed.relatedTo : undefined,
+        checksum: typeof parsed.checksum === "string" ? parsed.checksum : undefined,
       };
     } catch {
       // Malformed sidecar — treat as absent. `reserveUpload` will rewrite
@@ -154,17 +198,19 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     }
   };
 
-  const loadMeta = async (videoid: string): Promise<CachedMeta | null> => {
-    const cached = metaCache.get(videoid);
+  const loadMeta = async (artifactId: string): Promise<CachedMeta | null> => {
+    const cached = metaCache.get(artifactId);
     if (cached) return cached;
-    const sidecar = await readSidecar(videoid);
+    const sidecar = await readSidecar(artifactId);
     if (!sidecar) return null;
     const meta: CachedMeta = {
       ext: sidecar.ext,
       ready: sidecar.status === "ready",
       kind: sidecar.kind ?? "video",
+      relatedTo: sidecar.relatedTo,
+      checksum: sidecar.checksum,
     };
-    metaCache.set(videoid, meta);
+    cacheSet(artifactId, meta);
     return meta;
   };
 
@@ -173,48 +219,52 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
   };
 
   const reserveUpload = async ({
-    videoid,
+    artifactId,
     filename,
     ext,
     kind,
+    relatedTo,
+    checksum,
   }: ReserveUploadParams): Promise<string> => {
     // Collision guard: if an upload (in-progress or ready) already exists
-    // for this videoid, refuse the new upload rather than letting
+    // for this artifactId, refuse the new upload rather than letting
     // @tus/file-store silently reset the metadata sidecar to offset 0 and
     // overwrite the file chunk-by-chunk on subsequent PATCHes. Translates
     // to HTTP 409 via @tus/server's error path.
-    const meta = await loadMeta(videoid);
+    const meta = await loadMeta(artifactId);
     if (meta) {
       throw Object.assign(
-        new Error(`videoid ${videoid} already has an upload`),
+        new Error(`artifactId ${artifactId} already has an upload`),
         { statusCode: 409, status_code: 409 },
       );
     }
 
     await fs.mkdir(path.join(workspaceRoot, kind), { recursive: true });
 
-    await writeSidecar(videoid, {
+    await writeSidecar(artifactId, {
       version: SIDECAR_VERSION,
       ext,
       filename,
       status: "uploading",
       kind,
+      relatedTo,
+      checksum,
     });
 
-    metaCache.set(videoid, { ext, ready: false, kind });
+    cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum });
     // @tus/file-store joins this onto its configured `directory`, so the
-    // actual file lands at `<workspaceRoot>/<kind>/<videoid><ext>`.
-    return artifactRelPath(videoid, kind, ext);
+    // actual file lands at `<workspaceRoot>/<kind>/<artifactId><ext>`.
+    return artifactRelPath(artifactId, kind, ext);
   };
 
   const resolve = async (
-    videoid: string,
+    artifactId: string,
   ): Promise<PulseVaultResolution | null> => {
-    const meta = await loadMeta(videoid);
+    const meta = await loadMeta(artifactId);
     // Only serve ready uploads. In-progress uploads stay hidden — a client
     // GETting mid-upload would otherwise receive a truncated file.
     if (!meta || !meta.ready) return null;
-    const relFile = artifactRelPath(videoid, meta.kind, meta.ext);
+    const relFile = artifactRelPath(artifactId, meta.kind, meta.ext);
     try {
       const stat = await fs.stat(path.join(workspaceRoot, relFile));
       if (!stat.isFile()) return null;
@@ -230,48 +280,70 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     };
   };
 
-  const markReady = async (videoid: string): Promise<void> => {
-    const sidecar = await readSidecar(videoid);
+  const markReady = async (artifactId: string): Promise<void> => {
+    const sidecar = await readSidecar(artifactId);
     if (!sidecar) {
-      // No sidecar means no `reserveUpload` happened for this videoid — this
-      // is a contract violation by the caller, not a recoverable state.
+      // No sidecar means no `reserveUpload` happened for this artifactId —
+      // this is a contract violation by the caller, not a recoverable state.
       throw new Error(
-        `markReady: no sidecar for videoid ${videoid} (was reserveUpload called?)`,
+        `markReady: no sidecar for artifactId ${artifactId} (was reserveUpload called?)`,
       );
     }
     if (sidecar.status === "ready") {
       // Idempotent: already ready is fine, keep the cache consistent.
-      metaCache.set(videoid, { ext: sidecar.ext, ready: true, kind: sidecar.kind ?? "video" });
+      cacheSet(artifactId, {
+        ext: sidecar.ext,
+        ready: true,
+        kind: sidecar.kind ?? "video",
+        relatedTo: sidecar.relatedTo,
+        checksum: sidecar.checksum,
+      });
       return;
     }
-    await writeSidecar(videoid, { ...sidecar, status: "ready" });
-    metaCache.set(videoid, { ext: sidecar.ext, ready: true, kind: sidecar.kind ?? "video" });
+    await writeSidecar(artifactId, { ...sidecar, status: "ready" });
+    cacheSet(artifactId, {
+      ext: sidecar.ext,
+      ready: true,
+      kind: sidecar.kind ?? "video",
+      relatedTo: sidecar.relatedTo,
+      checksum: sidecar.checksum,
+    });
   };
 
-  const remove = async (videoid: string): Promise<boolean> => {
-    const meta = await loadMeta(videoid);
+  const remove = async (artifactId: string): Promise<boolean> => {
+    const meta = await loadMeta(artifactId);
     // Drop from cache before rm so a racing `resolve` arriving after the
     // rm but before cache eviction can't hand back a stale path.
-    metaCache.delete(videoid);
+    metaCache.delete(artifactId);
     if (!meta) return false;
-    const artifactPath = path.join(workspaceRoot, meta.kind, `${videoid}${meta.ext}`);
+    const artifactPath = path.join(workspaceRoot, meta.kind, `${artifactId}${meta.ext}`);
     await Promise.all([
       fs.rm(artifactPath, { force: true }),
       fs.rm(`${artifactPath}.json`, { force: true }),
-      fs.rm(sidecarPath(videoid), { force: true }),
+      fs.rm(sidecarPath(artifactId), { force: true }),
     ]);
     return true;
   };
 
-  const getLocalPath = async (videoid: string): Promise<string | null> => {
-    const meta = await loadMeta(videoid);
+  const getLocalPath = async (artifactId: string): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
     if (!meta) return null;
-    return path.join(workspaceRoot, meta.kind, `${videoid}${meta.ext}`);
+    return path.join(workspaceRoot, meta.kind, `${artifactId}${meta.ext}`);
   };
 
-  const getKind = async (videoid: string): Promise<UploadKind | null> => {
-    const meta = await loadMeta(videoid);
+  const getKind = async (artifactId: string): Promise<UploadKind | null> => {
+    const meta = await loadMeta(artifactId);
     return meta ? meta.kind : null;
+  };
+
+  const getRelatedTo = async (artifactId: string): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
+    return meta?.relatedTo ?? null;
+  };
+
+  const getChecksum = async (artifactId: string): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
+    return meta?.checksum ?? null;
   };
 
   return {
@@ -284,5 +356,7 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     remove,
     getLocalPath,
     getKind,
+    getRelatedTo,
+    getChecksum,
   };
 }

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -13,10 +13,11 @@ import type {
 
 /**
  * Per-upload metadata sidecar, stored as a small JSON object in the bucket at
- * `.pulsevault/<videoid>.json`. This mirrors the local adapter's on-disk
+ * `.pulsevault/<artifactId>.json`. This mirrors the local adapter's on-disk
  * sidecar: it lets `resolve`/`getKind` recover an upload's extension, kind and
- * completion state from the `videoid` alone (the object key needs both `kind`
- * and `ext`, which the bare videoid doesn't carry), and survives a restart.
+ * completion state from the `artifactId` alone (the object key needs both
+ * `kind` and `ext`, which the bare artifactId doesn't carry), and survives a
+ * restart.
  */
 type Sidecar = {
   /** Sidecar schema version. Increment for breaking changes. */
@@ -33,6 +34,10 @@ type Sidecar = {
   status: "uploading" | "ready";
   /** Artifact kind. Optional for back-compat; absent is read as `"video"`. */
   kind?: UploadKind;
+  /** Optional id of another artifact this one belongs to. See `ReserveUploadParams.relatedTo`. */
+  relatedTo?: string;
+  /** Optional client-supplied checksum metadata. See `ReserveUploadParams.checksum`. */
+  checksum?: string;
 };
 
 const SIDECAR_VERSION = 1 as const;
@@ -40,14 +45,23 @@ const SIDECAR_VERSION = 1 as const;
 const PULSEVAULT_META_PREFIX = ".pulsevault";
 /** Default presigned playback URL lifetime (15 minutes). */
 const DEFAULT_PRESIGN_TTL_SECONDS = 900;
+/** Default cap on the in-memory metadata cache before evicting the oldest entry. */
+const DEFAULT_META_CACHE_LIMIT = 10_000;
 
-type CachedMeta = { ext: string; ready: boolean; kind: UploadKind };
+type CachedMeta = {
+  ext: string;
+  ready: boolean;
+  kind: UploadKind;
+  relatedTo?: string;
+  checksum?: string;
+};
 
 /** Map a file extension to the `Content-Type` the playback URL should return. */
 function extToContentType(ext: string): string {
   switch (ext) {
     case ".mp4": return "video/mp4";
     case ".zip": return "application/zip";
+    case ".srt": return "application/x-subrip";
     default: return "application/octet-stream";
   }
 }
@@ -90,6 +104,13 @@ export type S3StorageOptions = {
    */
   partSize?: number;
   /**
+   * Max number of entries kept in the in-memory metadata cache before the
+   * oldest (by insertion order) is evicted. A cache miss falls back to a
+   * bucket read, so eviction only costs an extra request, not correctness.
+   * Defaults to 10,000.
+   */
+  metaCacheLimit?: number;
+  /**
    * Advanced escape hatch: extra `S3ClientConfig` fields merged into the
    * client used for both playback presigning and the underlying TUS datastore
    * (e.g. checksum flags for S3-compatible stores). Values here win over the
@@ -109,12 +130,23 @@ export type S3Storage = PulseVaultStorage & {
   readonly bucket: string;
   /**
    * Ranged GET of the first `n` bytes of a finalized upload, or `null` if the
-   * videoid is unknown. Used by `createS3Mp4Sniffer` to validate the payload
-   * without downloading the whole object.
+   * artifactId is unknown. Used by `createS3Mp4Sniffer` to validate the
+   * payload without downloading the whole object.
    */
-  readHeader(videoid: string, n: number): Promise<Buffer | null>;
-  /** Artifact kind for a known videoid, or `null`. Satisfies `getKind`. */
-  getKind(videoid: string): Promise<UploadKind | null>;
+  readHeader(artifactId: string, n: number): Promise<Buffer | null>;
+  /**
+   * Full GET of a finalized upload's bytes, or `null` if the artifactId is
+   * unknown. Used by `createS3ChecksumValidator` — unlike `readHeader`, this
+   * downloads the whole object, so it's only worth using for an explicit,
+   * opt-in integrity check, not on every upload by default.
+   */
+  readAll(artifactId: string): Promise<Buffer | null>;
+  /** Artifact kind for a known artifactId, or `null`. Satisfies `getKind`. */
+  getKind(artifactId: string): Promise<UploadKind | null>;
+  /** Satisfies the optional `PulseVaultStorage.getRelatedTo` contract. */
+  getRelatedTo(artifactId: string): Promise<string | null>;
+  /** Satisfies the optional `PulseVaultStorage.getChecksum` contract. */
+  getChecksum(artifactId: string): Promise<string | null>;
 };
 
 /**
@@ -159,6 +191,7 @@ export async function createS3Storage(
 
   const bucket = opts.bucket;
   const presignTtl = opts.presignTtlSeconds ?? DEFAULT_PRESIGN_TTL_SECONDS;
+  const metaCacheLimit = opts.metaCacheLimit ?? DEFAULT_META_CACHE_LIMIT;
 
   const credentials =
     opts.accessKeyId && opts.secretAccessKey
@@ -185,36 +218,46 @@ export async function createS3Storage(
     s3ClientConfig: { ...clientConfig, bucket },
   }) as unknown as DataStore;
 
-  // Metadata cache keyed by videoid, mirroring the local adapter: populated
+  // Metadata cache keyed by artifactId, mirroring the local adapter: populated
   // eagerly on reserve and lazily from the sidecar on a cache-miss, so the GET
-  // hot path avoids a per-request round-trip to the bucket.
+  // hot path avoids a per-request round-trip to the bucket. Bounded with
+  // simple insertion-order eviction, same rationale as the local adapter.
   const metaCache = new Map<string, CachedMeta>();
 
-  const sidecarKey = (videoid: string): string =>
-    `${PULSEVAULT_META_PREFIX}/${videoid}.json`;
+  const cacheSet = (artifactId: string, meta: CachedMeta): void => {
+    metaCache.delete(artifactId);
+    metaCache.set(artifactId, meta);
+    if (metaCache.size > metaCacheLimit) {
+      const oldest = metaCache.keys().next().value;
+      if (oldest !== undefined) metaCache.delete(oldest);
+    }
+  };
+
+  const sidecarKey = (artifactId: string): string =>
+    `${PULSEVAULT_META_PREFIX}/${artifactId}.json`;
   /** Object key for the artifact bytes — also the TUS file id / multipart key. */
-  const artifactKey = (videoid: string, kind: UploadKind, ext: string): string =>
-    `${kind}/${videoid}${ext}`;
+  const artifactKey = (artifactId: string, kind: UploadKind, ext: string): string =>
+    `${kind}/${artifactId}${ext}`;
 
   const writeSidecar = async (
-    videoid: string,
+    artifactId: string,
     sidecar: Sidecar,
   ): Promise<void> => {
     await client.send(
       new PutObjectCommand({
         Bucket: bucket,
-        Key: sidecarKey(videoid),
+        Key: sidecarKey(artifactId),
         Body: JSON.stringify(sidecar),
         ContentType: "application/json",
       }),
     );
   };
 
-  const readSidecar = async (videoid: string): Promise<Sidecar | null> => {
+  const readSidecar = async (artifactId: string): Promise<Sidecar | null> => {
     let raw: string;
     try {
       const res = await client.send(
-        new GetObjectCommand({ Bucket: bucket, Key: sidecarKey(videoid) }),
+        new GetObjectCommand({ Bucket: bucket, Key: sidecarKey(artifactId) }),
       );
       raw = (await bodyToBuffer(res.Body)).toString("utf8");
     } catch (err) {
@@ -227,13 +270,16 @@ export async function createS3Storage(
       if (typeof parsed.filename !== "string") return null;
       const status: Sidecar["status"] =
         parsed.status === "uploading" ? "uploading" : "ready";
-      const kind: UploadKind = parsed.kind === "project" ? "project" : "video";
+      const kind: UploadKind =
+        parsed.kind === "project" ? "project" : parsed.kind === "captions" ? "captions" : "video";
       return {
         version: SIDECAR_VERSION,
         ext: parsed.ext,
         filename: parsed.filename,
         status,
         kind,
+        relatedTo: typeof parsed.relatedTo === "string" ? parsed.relatedTo : undefined,
+        checksum: typeof parsed.checksum === "string" ? parsed.checksum : undefined,
       };
     } catch {
       // Malformed sidecar — treat as absent; `reserveUpload` rewrites it.
@@ -241,59 +287,65 @@ export async function createS3Storage(
     }
   };
 
-  const loadMeta = async (videoid: string): Promise<CachedMeta | null> => {
-    const cached = metaCache.get(videoid);
+  const loadMeta = async (artifactId: string): Promise<CachedMeta | null> => {
+    const cached = metaCache.get(artifactId);
     if (cached) return cached;
-    const sidecar = await readSidecar(videoid);
+    const sidecar = await readSidecar(artifactId);
     if (!sidecar) return null;
     const meta: CachedMeta = {
       ext: sidecar.ext,
       ready: sidecar.status === "ready",
       kind: sidecar.kind ?? "video",
+      relatedTo: sidecar.relatedTo,
+      checksum: sidecar.checksum,
     };
-    metaCache.set(videoid, meta);
+    cacheSet(artifactId, meta);
     return meta;
   };
 
   const reserveUpload = async ({
-    videoid,
+    artifactId,
     filename,
     ext,
     kind,
+    relatedTo,
+    checksum,
   }: ReserveUploadParams): Promise<string> => {
     // Collision guard, same contract as the local adapter: refuse a second
-    // upload for a videoid that already has one (in-progress or ready) rather
-    // than letting the datastore silently reset the multipart upload. Surfaces
-    // as HTTP 409 via @tus/server's error path.
-    const meta = await loadMeta(videoid);
+    // upload for an artifactId that already has one (in-progress or ready)
+    // rather than letting the datastore silently reset the multipart upload.
+    // Surfaces as HTTP 409 via @tus/server's error path.
+    const meta = await loadMeta(artifactId);
     if (meta) {
-      throw Object.assign(new Error(`videoid ${videoid} already has an upload`), {
+      throw Object.assign(new Error(`artifactId ${artifactId} already has an upload`), {
         statusCode: 409,
         status_code: 409,
       });
     }
 
-    await writeSidecar(videoid, {
+    await writeSidecar(artifactId, {
       version: SIDECAR_VERSION,
       ext,
       filename,
       status: "uploading",
       kind,
+      relatedTo,
+      checksum,
     });
-    metaCache.set(videoid, { ext, ready: false, kind });
+    cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum });
     // @tus/s3-store uses this as the object key for the multipart upload, so
-    // the finished object lands at `<kind>/<videoid><ext>`.
-    return artifactKey(videoid, kind, ext);
+    // the finished object lands at `<kind>/<artifactId><ext>`.
+    return artifactKey(artifactId, kind, ext);
   };
 
   const resolve = async (
-    videoid: string,
+    artifactId: string,
   ): Promise<PulseVaultResolution | null> => {
-    const meta = await loadMeta(videoid);
+    const meta = await loadMeta(artifactId);
     // Only serve ready uploads — an object that exists but is mid-upload or
     // failed validation stays hidden.
     if (!meta || !meta.ready) return null;
-    const key = artifactKey(videoid, meta.kind, meta.ext);
+    const key = artifactKey(artifactId, meta.kind, meta.ext);
     const url = await getSignedUrl(
       client,
       new GetObjectCommand({
@@ -308,33 +360,35 @@ export async function createS3Storage(
     return { kind: "redirect", url, statusCode: 302 };
   };
 
-  const markReady = async (videoid: string): Promise<void> => {
-    const sidecar = await readSidecar(videoid);
+  const markReady = async (artifactId: string): Promise<void> => {
+    const sidecar = await readSidecar(artifactId);
     if (!sidecar) {
       throw new Error(
-        `markReady: no sidecar for videoid ${videoid} (was reserveUpload called?)`,
+        `markReady: no sidecar for artifactId ${artifactId} (was reserveUpload called?)`,
       );
     }
     const next: CachedMeta = {
       ext: sidecar.ext,
       ready: true,
       kind: sidecar.kind ?? "video",
+      relatedTo: sidecar.relatedTo,
+      checksum: sidecar.checksum,
     };
     if (sidecar.status === "ready") {
       // Idempotent: already ready, just keep the cache consistent.
-      metaCache.set(videoid, next);
+      cacheSet(artifactId, next);
       return;
     }
-    await writeSidecar(videoid, { ...sidecar, status: "ready" });
-    metaCache.set(videoid, next);
+    await writeSidecar(artifactId, { ...sidecar, status: "ready" });
+    cacheSet(artifactId, next);
   };
 
-  const remove = async (videoid: string): Promise<boolean> => {
-    const meta = await loadMeta(videoid);
+  const remove = async (artifactId: string): Promise<boolean> => {
+    const meta = await loadMeta(artifactId);
     // Evict before deleting so a racing `resolve` can't hand back a stale key.
-    metaCache.delete(videoid);
+    metaCache.delete(artifactId);
     if (!meta) return false;
-    const key = artifactKey(videoid, meta.kind, meta.ext);
+    const key = artifactKey(artifactId, meta.kind, meta.ext);
     // Abort any still-in-progress multipart upload (no-op / best-effort once
     // the upload has completed) so we never orphan an open multipart session.
     await Promise.allSettled([
@@ -349,19 +403,19 @@ export async function createS3Storage(
         new DeleteObjectCommand({ Bucket: bucket, Key: `${key}.info` }),
       ),
       client.send(
-        new DeleteObjectCommand({ Bucket: bucket, Key: sidecarKey(videoid) }),
+        new DeleteObjectCommand({ Bucket: bucket, Key: sidecarKey(artifactId) }),
       ),
     ]);
     return true;
   };
 
   const readHeader = async (
-    videoid: string,
+    artifactId: string,
     n: number,
   ): Promise<Buffer | null> => {
-    const meta = await loadMeta(videoid);
+    const meta = await loadMeta(artifactId);
     if (!meta) return null;
-    const key = artifactKey(videoid, meta.kind, meta.ext);
+    const key = artifactKey(artifactId, meta.kind, meta.ext);
     try {
       const res = await client.send(
         new GetObjectCommand({
@@ -377,9 +431,32 @@ export async function createS3Storage(
     }
   };
 
-  const getKind = async (videoid: string): Promise<UploadKind | null> => {
-    const meta = await loadMeta(videoid);
+  const readAll = async (artifactId: string): Promise<Buffer | null> => {
+    const meta = await loadMeta(artifactId);
+    if (!meta) return null;
+    const key = artifactKey(artifactId, meta.kind, meta.ext);
+    try {
+      const res = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+      return await bodyToBuffer(res.Body);
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  };
+
+  const getKind = async (artifactId: string): Promise<UploadKind | null> => {
+    const meta = await loadMeta(artifactId);
     return meta ? meta.kind : null;
+  };
+
+  const getRelatedTo = async (artifactId: string): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
+    return meta?.relatedTo ?? null;
+  };
+
+  const getChecksum = async (artifactId: string): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
+    return meta?.checksum ?? null;
   };
 
   const shutdown = async (): Promise<void> => {
@@ -394,7 +471,10 @@ export async function createS3Storage(
     markReady,
     remove,
     readHeader,
+    readAll,
     getKind,
+    getRelatedTo,
+    getChecksum,
     shutdown,
   };
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -1,9 +1,9 @@
 import type { DataStore } from "@tus/server";
 
 /**
- * How the GET route should serve a resolved video. Stream means `@fastify/send`
- * reads directly from a local path; Redirect issues an HTTP 3xx to a URL the
- * adapter produced (e.g. a pre-signed object storage URL).
+ * How the GET route should serve a resolved artifact. Stream means
+ * `@fastify/send` reads directly from a local path; Redirect issues an HTTP
+ * 3xx to a URL the adapter produced (e.g. a pre-signed object storage URL).
  */
 export type PulseVaultResolution =
   | {
@@ -26,17 +26,35 @@ export type PulseVaultResolution =
       statusCode?: number;
     };
 
-export type UploadKind = "video" | "project";
+export type UploadKind = "video" | "project" | "captions";
 
 export type ReserveUploadParams = {
-  /** UUID from `Upload-Metadata.videoid` (or `projectid` alias). */
-  videoid: string;
+  /** UUID from `Upload-Metadata.artifactId` (or the `videoid`/`projectid` legacy aliases). */
+  artifactId: string;
   /** Raw filename from `Upload-Metadata.filename`. */
   filename: string;
   /** Lowercase extension including the leading dot, validated upstream. */
   ext: string;
   /** Artifact kind derived from `Upload-Metadata.kind`. Defaults to `"video"`. */
   kind: UploadKind;
+  /**
+   * Optional UUID of another artifact this one belongs to, from
+   * `Upload-Metadata.relatedTo`. Lets a single capability token scoped to one
+   * "session" artifact (e.g. a video) authorize related artifacts uploaded in
+   * the same session (its captions, or — under `uploadUnit: "beat"` — each
+   * beat plus the pulse manifest) without minting a token per artifact.
+   * Purely bookkeeping for the storage layer; `pulsevault` does not enforce
+   * any relationship semantics beyond storing and returning it.
+   */
+  relatedTo?: string;
+  /**
+   * Optional client-supplied integrity digest from `Upload-Metadata.checksum`
+   * (`<algorithm>:<hex>`), persisted so `createChecksumValidator` can read it
+   * at completion time even when completion happens on a different request
+   * than creation (chunked uploads, or even a single-PATCH upload sent as
+   * two separate HTTP requests).
+   */
+  checksum?: string;
 };
 
 /**
@@ -65,12 +83,12 @@ export interface PulseVaultStorage {
   reserveUpload(params: ReserveUploadParams): Promise<string>;
 
   /**
-   * Called by the GET route. Returns how to serve the video, or `null` if
-   * the videoid is unknown *or* the upload is still in progress — adapters
+   * Called by the GET route. Returns how to serve the artifact, or `null` if
+   * the artifactId is unknown *or* the upload is still in progress — adapters
    * that implement `markReady` should only return non-null once the bytes
    * have been promoted to "ready."
    */
-  resolve(videoid: string): Promise<PulseVaultResolution | null>;
+  resolve(artifactId: string): Promise<PulseVaultResolution | null>;
 
   /**
    * Mark an upload as fully written and safe to serve. Called by the plugin
@@ -80,20 +98,35 @@ export interface PulseVaultStorage {
    * may omit this method — `resolve` will be trusted to only return finished
    * uploads in that case.
    */
-  markReady?(videoid: string): Promise<void>;
+  markReady?(artifactId: string): Promise<void>;
 
   /**
-   * Delete all storage associated with a videoid. Returns `true` if
-   * something was removed, `false` if the videoid was already absent.
-   * Called both from the `DELETE /:videoid` route and from the plugin's
-   * cleanup path when `validatePayload` rejects a completed upload.
+   * Delete all storage associated with an artifactId. Returns `true` if
+   * something was removed, `false` if the artifactId was already absent.
+   * Called both from the `DELETE /artifacts/:artifactId` route and from the
+   * plugin's cleanup path when `validatePayload` rejects a completed upload.
    */
-  remove?(videoid: string): Promise<boolean>;
+  remove?(artifactId: string): Promise<boolean>;
 
   /**
-   * Return the artifact kind for a known videoid, or `null` if the videoid
-   * is not found. Used by consumer routes (e.g. `report-issue`) to assert
-   * the kind before acting on an upload without a full resolve.
+   * Return the artifact kind for a known artifactId, or `null` if the
+   * artifactId is not found. Used by the generic artifact route to resolve
+   * which kind to serve without it being encoded in the URL.
    */
-  getKind?(videoid: string): Promise<UploadKind | null>;
+  getKind?(artifactId: string): Promise<UploadKind | null>;
+
+  /**
+   * Return the `relatedTo` artifact id stored at `reserveUpload` time, or
+   * `null` if the artifactId is unknown or has no relation recorded. Used by
+   * `createCapabilityAuthorize` to authorize an artifact against a token
+   * scoped to the session it belongs to, not just its own id.
+   */
+  getRelatedTo?(artifactId: string): Promise<string | null>;
+
+  /**
+   * Return the `checksum` metadata stored at `reserveUpload` time, or `null`
+   * if the artifactId is unknown or no checksum was supplied. Used by
+   * `createChecksumValidator`/`createS3ChecksumValidator` at completion time.
+   */
+  getChecksum?(artifactId: string): Promise<string | null>;
 }

--- a/test/artifact-kinds.test.mjs
+++ b/test/artifact-kinds.test.mjs
@@ -1,7 +1,10 @@
-// Tests for kind=project uploads through the TUS endpoint.
-// Covers: happy paths (.pulse / .zip), extension-mismatch rejections,
-// authorize ctx kind, projectid alias, hook dispatch, getKind(), legacy
-// back-compat (sidecars without `kind`).
+// Tests for kind=project and kind=captions uploads through the TUS endpoint
+// and the generic /artifacts/:artifactId route.
+// Covers: happy paths (.pulse / .zip / .srt), extension-mismatch rejections,
+// authorize ctx kind, the artifactId/videoid/projectid metadata aliases,
+// unified hook dispatch (incl. the deprecated per-kind project hooks),
+// relatedTo linking, getKind(), and legacy back-compat (sidecars without
+// `kind`).
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -10,6 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import Fastify from "fastify";
 import pulseVault, { createLocalStorage } from "../dist/app.js";
+import { makeMp4 } from "./helpers.mjs";
 
 const ID1 = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
 const ID2 = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
@@ -19,18 +23,16 @@ function b64(str) {
   return Buffer.from(str, "utf8").toString("base64");
 }
 
-/**
- * Build a TUS Upload-Metadata header supporting kind, id key (videoid or
- * projectid), and filename.
- */
-function buildMetadata({ videoid, idKey = "videoid", filename, kind }) {
-  const parts = [`${idKey} ${b64(videoid)}`, `filename ${b64(filename)}`];
+/** Build a TUS Upload-Metadata header supporting kind, id key, relatedTo, and filename. */
+function buildMetadata({ artifactId, idKey = "artifactId", filename, kind, relatedTo }) {
+  const parts = [`${idKey} ${b64(artifactId)}`, `filename ${b64(filename)}`];
   if (kind) parts.push(`kind ${b64(kind)}`);
+  if (relatedTo) parts.push(`relatedTo ${b64(relatedTo)}`);
   return parts.join(",");
 }
 
 async function startApp(pluginOptions = {}) {
-  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-proj-test-"));
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-kinds-test-"));
   const storage = createLocalStorage({ workspaceDir });
   const app = Fastify({ logger: false });
   await app.register(pulseVault, {
@@ -52,13 +54,13 @@ async function startApp(pluginOptions = {}) {
   };
 }
 
-async function tusCreate(baseUrl, { videoid, idKey = "videoid", filename, size, kind }) {
+async function tusCreate(baseUrl, { artifactId, idKey = "artifactId", filename, size, kind, relatedTo }) {
   return fetch(`${baseUrl}${PREFIX}/upload`, {
     method: "POST",
     headers: {
       "Tus-Resumable": "1.0.0",
       "Upload-Length": String(size),
-      "Upload-Metadata": buildMetadata({ videoid, idKey, filename, kind }),
+      "Upload-Metadata": buildMetadata({ artifactId, idKey, filename, kind, relatedTo }),
     },
   });
 }
@@ -76,13 +78,14 @@ async function tusPatch(url, offset, body) {
 }
 
 /** Do a complete TUS upload in one go. Returns the response bodies. */
-async function uploadFull(ctx, { videoid, idKey = "videoid", filename, kind, payload }) {
+async function uploadFull(ctx, { artifactId, idKey = "artifactId", filename, kind, relatedTo, payload }) {
   const create = await tusCreate(ctx.baseUrl, {
-    videoid,
+    artifactId,
     idKey,
     filename,
     size: payload.length,
     kind,
+    relatedTo,
   });
   assert.equal(create.status, 201, `create ${filename}`);
   const location = create.headers.get("location");
@@ -92,25 +95,25 @@ async function uploadFull(ctx, { videoid, idKey = "videoid", filename, kind, pay
   return { location };
 }
 
-// ---------- tests ----------
+const artifactUrl = (ctx, id) => `${ctx.baseUrl}${PREFIX}/artifacts/${id}`;
+
+// ---------- kind=project ----------
 
 test("kind=project .pulse happy path: file under project/ subdir, correct Content-Type", async () => {
   const ctx = await startApp();
   try {
     const payload = Buffer.from(JSON.stringify({ format: "pulse", version: 1 }));
     await uploadFull(ctx, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "draft.pulse",
       kind: "project",
       payload,
     });
 
-    // File must land at <uuid>/project/<uuid>.pulse
     const expectedPath = path.join(ctx.workspaceDir, "project", `${ID1}.pulse`);
     const stat = await fs.stat(expectedPath);
     assert.ok(stat.isFile(), "file exists at project/ subdir");
 
-    // Sidecar must record kind
     const sidecar = JSON.parse(
       await fs.readFile(path.join(ctx.workspaceDir, ".pulsevault", `${ID1}.json`), "utf8"),
     );
@@ -118,8 +121,7 @@ test("kind=project .pulse happy path: file under project/ subdir, correct Conten
     assert.equal(sidecar.ext, ".pulse");
     assert.equal(sidecar.status, "ready");
 
-    // GET must return 200 with application/octet-stream
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 200);
     const ct = get.headers.get("content-type");
     assert.ok(ct?.includes("application/octet-stream"), `content-type was: ${ct}`);
@@ -135,7 +137,7 @@ test("kind=project .zip happy path: file under project/ subdir, Content-Type: ap
   try {
     const payload = Buffer.alloc(512, 0x50); // fake zip bytes
     await uploadFull(ctx, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "diagnostic.zip",
       kind: "project",
       payload,
@@ -145,7 +147,7 @@ test("kind=project .zip happy path: file under project/ subdir, Content-Type: ap
     const stat = await fs.stat(expectedPath);
     assert.ok(stat.isFile(), "zip exists at project/ subdir");
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 200);
     const ct = get.headers.get("content-type");
     assert.ok(ct?.includes("application/zip"), `content-type was: ${ct}`);
@@ -158,7 +160,7 @@ test("kind=project with .mp4 extension is rejected at create", async () => {
   const ctx = await startApp();
   try {
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "sneaky.mp4",
       size: 1024,
       kind: "project",
@@ -175,9 +177,8 @@ test("kind=project with .mp4 extension is rejected at create", async () => {
 test("kind=video (default) with .pulse extension is rejected at create", async () => {
   const ctx = await startApp();
   try {
-    // No `kind` in metadata defaults to video; .pulse is not in the video list.
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "draft.pulse",
       size: 1024,
       // kind omitted → defaults to "video"
@@ -201,7 +202,7 @@ test("authorize receives kind='project' on create and resolve", async () => {
   try {
     const payload = Buffer.from("pulse data");
     await uploadFull(ctx, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "draft.pulse",
       kind: "project",
       payload,
@@ -209,62 +210,71 @@ test("authorize receives kind='project' on create and resolve", async () => {
 
     assert.equal(capturedPhases["create"], "project", "kind on create");
 
-    // GET /project/:projectid triggers resolve phase
-    await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`);
+    await fetch(artifactUrl(ctx, ID1));
     assert.equal(capturedPhases["resolve"], "project", "kind on resolve");
   } finally {
     await ctx.teardown();
   }
 });
 
-test("validateProjectPayload fires for kind=project but not for kind=video", async () => {
+test("validatePayload runs for every kind, with ctx.kind distinguishing them", async () => {
   const calls = [];
   const ctx = await startApp({
-    validateProjectPayload: async (_req, info) => {
-      calls.push({ kind: "project", videoid: info.videoid });
-    },
     validatePayload: async (_req, info) => {
-      calls.push({ kind: "video", videoid: info.videoid });
+      calls.push({ kind: info.kind, artifactId: info.artifactId });
     },
   });
   try {
-    const payload = Buffer.from("pulse data");
-
-    // Upload a video first (no kind in metadata → defaults to video)
-    const mp4Header = Buffer.from([
-      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70,
-      0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
-    ]);
-    const mp4 = Buffer.alloc(1024);
-    mp4Header.copy(mp4, 0);
+    await uploadFull(ctx, { artifactId: ID1, filename: "clip.mp4", payload: makeMp4(1024) });
     await uploadFull(ctx, {
-      videoid: ID1,
-      filename: "clip.mp4",
-      // kind omitted → video
-      payload: mp4,
-    });
-
-    // Upload a project
-    await uploadFull(ctx, {
-      videoid: ID2,
+      artifactId: ID2,
       filename: "draft.pulse",
       kind: "project",
-      payload,
+      payload: Buffer.from("pulse data"),
+    });
+
+    assert.equal(calls.length, 2, "both uploads ran validatePayload");
+    const videoCall = calls.find((c) => c.kind === "video");
+    const projectCall = calls.find((c) => c.kind === "project");
+    assert.ok(videoCall && videoCall.artifactId === ID1);
+    assert.ok(projectCall && projectCall.artifactId === ID2);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("[deprecated] validateProjectPayload still fires for kind=project but not for kind=video", async () => {
+  const calls = [];
+  const ctx = await startApp({
+    validateProjectPayload: async (_req, info) => {
+      calls.push({ kind: "project", artifactId: info.artifactId });
+    },
+    validatePayload: async (_req, info) => {
+      calls.push({ kind: "video", artifactId: info.artifactId });
+    },
+  });
+  try {
+    await uploadFull(ctx, { artifactId: ID1, filename: "clip.mp4", payload: makeMp4(1024) });
+    await uploadFull(ctx, {
+      artifactId: ID2,
+      filename: "draft.pulse",
+      kind: "project",
+      payload: Buffer.from("pulse data"),
     });
 
     assert.equal(calls.length, 2, "both validators fired");
     const videoCall = calls.find((c) => c.kind === "video");
     const projectCall = calls.find((c) => c.kind === "project");
     assert.ok(videoCall, "validatePayload (video) fired");
-    assert.equal(videoCall.videoid, ID1);
+    assert.equal(videoCall.artifactId, ID1);
     assert.ok(projectCall, "validateProjectPayload (project) fired");
-    assert.equal(projectCall.videoid, ID2);
+    assert.equal(projectCall.artifactId, ID2);
   } finally {
     await ctx.teardown();
   }
 });
 
-test("onProjectUploadComplete fires for kind=project but not for kind=video", async () => {
+test("[deprecated] onProjectUploadComplete still fires for kind=project but not for kind=video", async () => {
   const calls = [];
   const ctx = await startApp({
     onProjectUploadComplete: async (_req, info) => {
@@ -275,150 +285,91 @@ test("onProjectUploadComplete fires for kind=project but not for kind=video", as
     },
   });
   try {
-    const mp4Header = Buffer.from([
-      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70,
-      0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
-    ]);
-    const mp4 = Buffer.alloc(1024);
-    mp4Header.copy(mp4, 0);
-    await uploadFull(ctx, { videoid: ID1, filename: "clip.mp4", payload: mp4 });
-
-    const pulse = Buffer.from("pulse data");
+    await uploadFull(ctx, { artifactId: ID1, filename: "clip.mp4", payload: makeMp4(1024) });
     await uploadFull(ctx, {
-      videoid: ID2,
+      artifactId: ID2,
       filename: "draft.pulse",
       kind: "project",
-      payload: pulse,
+      payload: Buffer.from("pulse data"),
     });
 
     assert.equal(calls.length, 2);
     const videoCall = calls.find((c) => c.hook === "video");
     const projectCall = calls.find((c) => c.hook === "project");
     assert.ok(videoCall, "onUploadComplete fired for video");
-    assert.equal(videoCall.videoid, ID1);
+    assert.equal(videoCall.artifactId, ID1);
     assert.ok(projectCall, "onProjectUploadComplete fired for project");
-    assert.equal(projectCall.videoid, ID2);
+    assert.equal(projectCall.artifactId, ID2);
   } finally {
     await ctx.teardown();
   }
 });
 
-test("projectid metadata alias works identically to videoid", async () => {
+test("artifactId/videoid/projectid metadata keys are all accepted as the id alias", async () => {
   const ctx = await startApp();
   try {
-    const payload = Buffer.from("pulse project data");
     await uploadFull(ctx, {
-      videoid: ID1,
-      idKey: "projectid", // use the alias
-      filename: "draft.pulse",
-      kind: "project",
-      payload,
-    });
-
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`);
-    assert.equal(get.status, 200, "GET succeeds with projectid alias");
-    const ct = get.headers.get("content-type");
-    assert.ok(ct?.includes("application/octet-stream"), `content-type was: ${ct}`);
-  } finally {
-    await ctx.teardown();
-  }
-});
-
-test("getKind returns 'project' for project uploads and 'video' for video uploads", async () => {
-  const ctx = await startApp();
-  try {
-    // Project upload
-    const pulse = Buffer.from("pulse data");
-    await uploadFull(ctx, {
-      videoid: ID1,
-      filename: "draft.pulse",
-      kind: "project",
-      payload: pulse,
-    });
-
-    // Video upload (no kind → defaults to video)
-    const mp4Header = Buffer.from([
-      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70,
-      0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
-    ]);
-    const mp4 = Buffer.alloc(1024);
-    mp4Header.copy(mp4, 0);
-    await uploadFull(ctx, { videoid: ID2, filename: "clip.mp4", payload: mp4 });
-
-    const projectKind = await ctx.storage.getKind(ID1);
-    assert.equal(projectKind, "project");
-
-    const videoKind = await ctx.storage.getKind(ID2);
-    assert.equal(videoKind, "video");
-
-    const unknownKind = await ctx.storage.getKind("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee");
-    assert.equal(unknownKind, null);
-  } finally {
-    await ctx.teardown();
-  }
-});
-
-test("legacy sidecar without kind field resolves as video and streams correctly", async () => {
-  const ctx = await startApp();
-  try {
-    // Manually write a pre-kind sidecar (as if written by the old plugin version)
-    await fs.mkdir(path.join(ctx.workspaceDir, "video"), { recursive: true });
-    await fs.mkdir(path.join(ctx.workspaceDir, ".pulsevault"), { recursive: true });
-
-    // Write a minimal valid MP4 as the upload bytes
-    const mp4Header = Buffer.from([
-      0x00, 0x00, 0x00, 0x20, 0x66, 0x74, 0x79, 0x70,
-      0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
-    ]);
-    const mp4 = Buffer.alloc(1024);
-    mp4Header.copy(mp4, 0);
-    await fs.writeFile(path.join(ctx.workspaceDir, "video", `${ID1}.mp4`), mp4);
-
-    // Old sidecar format: no `kind` field
-    const legacySidecar = JSON.stringify({
-      version: 1,
-      ext: ".mp4",
+      artifactId: ID1,
+      idKey: "videoid",
       filename: "clip.mp4",
-      status: "ready",
-      // `kind` intentionally absent
+      payload: makeMp4(1024),
     });
-    await fs.writeFile(path.join(ctx.workspaceDir, ".pulsevault", `${ID1}.json`), legacySidecar);
+    const get1 = await fetch(artifactUrl(ctx, ID1));
+    assert.equal(get1.status, 200, "videoid alias works");
 
-    // GET must succeed as a video
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
-    assert.equal(get.status, 200, "legacy sidecar resolves as 200");
-    const ct = get.headers.get("content-type");
-    assert.ok(ct?.includes("video/mp4"), `expected video/mp4, got ${ct}`);
-
-    // getKind must default to "video"
-    const kind = await ctx.storage.getKind(ID1);
-    assert.equal(kind, "video", "legacy upload reports kind=video");
+    await uploadFull(ctx, {
+      artifactId: ID2,
+      idKey: "projectid",
+      filename: "draft.pulse",
+      kind: "project",
+      payload: Buffer.from("pulse project data"),
+    });
+    const get2 = await fetch(artifactUrl(ctx, ID2));
+    assert.equal(get2.status, 200, "projectid alias works");
   } finally {
     await ctx.teardown();
   }
 });
 
-test("DELETE works for kind=project", async () => {
+test("getKind returns the right kind for video/project/captions, null for unknown", async () => {
   const ctx = await startApp();
   try {
-    const payload = Buffer.from("pulse data");
     await uploadFull(ctx, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "draft.pulse",
       kind: "project",
-      payload,
+      payload: Buffer.from("pulse data"),
+    });
+    await uploadFull(ctx, { artifactId: ID2, filename: "clip.mp4", payload: makeMp4(1024) });
+
+    assert.equal(await ctx.storage.getKind(ID1), "project");
+    assert.equal(await ctx.storage.getKind(ID2), "video");
+    assert.equal(await ctx.storage.getKind("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee"), null);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("DELETE works for kind=project, through the generic route", async () => {
+  const ctx = await startApp();
+  try {
+    await uploadFull(ctx, {
+      artifactId: ID1,
+      filename: "draft.pulse",
+      kind: "project",
+      payload: Buffer.from("pulse data"),
     });
 
-    const preGet = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`);
+    const preGet = await fetch(artifactUrl(ctx, ID1));
     assert.equal(preGet.status, 200);
 
-    const del = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`, { method: "DELETE" });
+    const del = await fetch(artifactUrl(ctx, ID1), { method: "DELETE" });
     assert.equal(del.status, 204);
 
     const sidecarStat = await fs.stat(path.join(ctx.workspaceDir, ".pulsevault", `${ID1}.json`)).catch(() => null);
     assert.equal(sidecarStat, null, "sidecar removed");
 
-    const postGet = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`);
+    const postGet = await fetch(artifactUrl(ctx, ID1));
     assert.equal(postGet.status, 404);
   } finally {
     await ctx.teardown();
@@ -430,9 +381,8 @@ test("allowedExtensions object form: custom video and project extensions", async
     allowedExtensions: { video: [".mp4"], project: [".pulse"] },
   });
   try {
-    // .zip should be rejected (not in the custom project list)
     const zipCreate = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "archive.zip",
       size: 512,
       kind: "project",
@@ -442,16 +392,97 @@ test("allowedExtensions object form: custom video and project extensions", async
       `expected 4xx for .zip, got ${zipCreate.status}`,
     );
 
-    // .pulse should still be allowed
-    const payload = Buffer.from("pulse data");
     await uploadFull(ctx, {
-      videoid: ID2,
+      artifactId: ID2,
       filename: "draft.pulse",
       kind: "project",
-      payload,
+      payload: Buffer.from("pulse data"),
     });
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID2}`);
+    const get = await fetch(artifactUrl(ctx, ID2));
     assert.equal(get.status, 200);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+// ---------- kind=captions ----------
+
+test("kind=captions happy path: .srt under captions/ subdir, sharing a session via relatedTo", async () => {
+  const ctx = await startApp();
+  try {
+    // The video this captions artifact belongs to.
+    await uploadFull(ctx, { artifactId: ID1, filename: "clip.mp4", payload: makeMp4(1024) });
+
+    const srt = Buffer.from("1\n00:00:00,000 --> 00:00:01,000\nHello\n");
+    await uploadFull(ctx, {
+      artifactId: ID2,
+      filename: "clip.srt",
+      kind: "captions",
+      relatedTo: ID1,
+      payload: srt,
+    });
+
+    const expectedPath = path.join(ctx.workspaceDir, "captions", `${ID2}.srt`);
+    const stat = await fs.stat(expectedPath);
+    assert.ok(stat.isFile(), "srt exists at captions/ subdir");
+
+    const get = await fetch(artifactUrl(ctx, ID2));
+    assert.equal(get.status, 200);
+    const ct = get.headers.get("content-type");
+    assert.ok(ct?.includes("application/x-subrip"), `content-type was: ${ct}`);
+
+    assert.equal(await ctx.storage.getKind(ID2), "captions");
+    assert.equal(await ctx.storage.getRelatedTo(ID2), ID1, "relatedTo recorded for the session link");
+    assert.equal(await ctx.storage.getRelatedTo(ID1), null, "the video itself has no relatedTo");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("kind=captions with a non-.srt extension is rejected at create", async () => {
+  const ctx = await startApp();
+  try {
+    const create = await tusCreate(ctx.baseUrl, {
+      artifactId: ID1,
+      filename: "clip.vtt",
+      size: 64,
+      kind: "captions",
+    });
+    assert.ok(
+      create.status >= 400 && create.status < 500,
+      `expected 4xx for .vtt under default captions extensions, got ${create.status}`,
+    );
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+// ---------- legacy back-compat ----------
+
+test("legacy sidecar without a kind field resolves as video and streams correctly", async () => {
+  const ctx = await startApp();
+  try {
+    await fs.mkdir(path.join(ctx.workspaceDir, "video"), { recursive: true });
+    await fs.mkdir(path.join(ctx.workspaceDir, ".pulsevault"), { recursive: true });
+    const mp4 = makeMp4(1024);
+    await fs.writeFile(path.join(ctx.workspaceDir, "video", `${ID1}.mp4`), mp4);
+
+    const legacySidecar = JSON.stringify({
+      version: 1,
+      ext: ".mp4",
+      filename: "clip.mp4",
+      status: "ready",
+      // `kind` intentionally absent.
+    });
+    await fs.writeFile(path.join(ctx.workspaceDir, ".pulsevault", `${ID1}.json`), legacySidecar);
+
+    const get = await fetch(artifactUrl(ctx, ID1));
+    assert.equal(get.status, 200, "legacy sidecar resolves as 200");
+    const ct = get.headers.get("content-type");
+    assert.ok(ct?.includes("video/mp4"), `expected video/mp4, got ${ct}`);
+
+    const kind = await ctx.storage.getKind(ID1);
+    assert.equal(kind, "video", "legacy upload reports kind=video");
   } finally {
     await ctx.teardown();
   }

--- a/test/capability-token.test.mjs
+++ b/test/capability-token.test.mjs
@@ -1,0 +1,113 @@
+// Fast unit tests for the pure capability-token crypto/parsing logic — no
+// Fastify server, no filesystem. Complements the integration-level coverage
+// in plugin.test.mjs (which exercises `createCapabilityAuthorize` wired into
+// real HTTP requests); this file is about the cryptographic/parsing
+// correctness in isolation.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import {
+  issueCapabilityToken,
+  verifyCapabilityToken,
+} from "../dist/lib/capability-token.js";
+
+const ARTIFACT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const SECRET = "shh";
+const ISSUER = "https://vault.example.test";
+const lookupSecret = (kid) => (kid === "k1" ? SECRET : null);
+
+test("issue + verify round-trips the artifactId", () => {
+  const token = issueCapabilityToken(ARTIFACT_ID, SECRET, { keyId: "k1", issuer: ISSUER });
+  const result = verifyCapabilityToken(token, lookupSecret, { issuer: ISSUER });
+  assert.deepEqual(result, { artifactId: ARTIFACT_ID });
+});
+
+test("rejects a token with a tampered signature", () => {
+  const token = issueCapabilityToken(ARTIFACT_ID, SECRET, { keyId: "k1", issuer: ISSUER });
+  const [payload] = token.split(".");
+  const tampered = `${payload}.not-the-real-signature`;
+  assert.equal(verifyCapabilityToken(tampered, lookupSecret, { issuer: ISSUER }), null);
+});
+
+test("rejects a token with a tampered payload (signature no longer matches)", () => {
+  const token = issueCapabilityToken(ARTIFACT_ID, SECRET, { keyId: "k1", issuer: ISSUER });
+  const [, signature] = token.split(".");
+  const forgedPayload = Buffer.from(
+    JSON.stringify({
+      artifactId: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 1800,
+      kid: "k1",
+      issuer: ISSUER,
+    }),
+  ).toString("base64url");
+  assert.equal(
+    verifyCapabilityToken(`${forgedPayload}.${signature}`, lookupSecret, { issuer: ISSUER }),
+    null,
+  );
+});
+
+test("rejects malformed tokens (no dot, truncated, non-JSON payload, missing claims)", () => {
+  const opts = { issuer: ISSUER };
+  assert.equal(verifyCapabilityToken("not-a-token", lookupSecret, opts), null);
+  assert.equal(verifyCapabilityToken("", lookupSecret, opts), null);
+  assert.equal(verifyCapabilityToken(".", lookupSecret, opts), null);
+  const notJson = Buffer.from("not json").toString("base64url");
+  assert.equal(verifyCapabilityToken(`${notJson}.sig`, lookupSecret, opts), null);
+  const missingClaims = Buffer.from(JSON.stringify({ artifactId: ARTIFACT_ID })).toString("base64url");
+  assert.equal(verifyCapabilityToken(`${missingClaims}.sig`, lookupSecret, opts), null);
+});
+
+test("rejects an unknown kid", () => {
+  const token = issueCapabilityToken(ARTIFACT_ID, SECRET, { keyId: "unknown-key", issuer: ISSUER });
+  assert.equal(verifyCapabilityToken(token, lookupSecret, { issuer: ISSUER }), null);
+});
+
+test("rejects an expired token, accepts one within the clock-tolerance window", () => {
+  const expired = issueCapabilityToken(ARTIFACT_ID, SECRET, {
+    keyId: "k1",
+    issuer: ISSUER,
+    expirySeconds: -120,
+  });
+  assert.equal(verifyCapabilityToken(expired, lookupSecret, { issuer: ISSUER }), null);
+
+  // Expired 10s ago, but within a 30s tolerance — should still verify.
+  const barelyExpired = issueCapabilityToken(ARTIFACT_ID, SECRET, {
+    keyId: "k1",
+    issuer: ISSUER,
+    expirySeconds: -10,
+  });
+  assert.deepEqual(
+    verifyCapabilityToken(barelyExpired, lookupSecret, { issuer: ISSUER, clockToleranceSeconds: 30 }),
+    { artifactId: ARTIFACT_ID },
+  );
+});
+
+test("rejects a token issued too far in the future (clock-skew guard)", () => {
+  // Simulate by hand-crafting claims with iat far in the future — issueCapabilityToken
+  // always uses Date.now(), so we sign the payload ourselves to test the boundary.
+  const claims = {
+    artifactId: ARTIFACT_ID,
+    iat: Math.floor(Date.now() / 1000) + 600,
+    exp: Math.floor(Date.now() / 1000) + 2400,
+    kid: "k1",
+    issuer: ISSUER,
+  };
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  const signature = createHmac("sha256", SECRET).update(payload).digest("base64url");
+  assert.equal(verifyCapabilityToken(`${payload}.${signature}`, lookupSecret, { issuer: ISSUER }), null);
+});
+
+test("rejects a token issued under a different issuer", () => {
+  const token = issueCapabilityToken(ARTIFACT_ID, SECRET, { keyId: "k1", issuer: "https://other.example" });
+  assert.equal(verifyCapabilityToken(token, lookupSecret, { issuer: ISSUER }), null);
+});
+
+test("key rotation: old and new kid both verify when lookupSecret recognizes both", () => {
+  const lookup = (kid) => ({ old: "old-secret", new: "new-secret" })[kid] ?? null;
+  const oldToken = issueCapabilityToken(ARTIFACT_ID, "old-secret", { keyId: "old", issuer: ISSUER });
+  const newToken = issueCapabilityToken(ARTIFACT_ID, "new-secret", { keyId: "new", issuer: ISSUER });
+  assert.deepEqual(verifyCapabilityToken(oldToken, lookup, { issuer: ISSUER }), { artifactId: ARTIFACT_ID });
+  assert.deepEqual(verifyCapabilityToken(newToken, lookup, { issuer: ISSUER }), { artifactId: ARTIFACT_ID });
+});

--- a/test/checksum.test.mjs
+++ b/test/checksum.test.mjs
@@ -1,0 +1,111 @@
+// Fast unit tests for checksum parsing/verification logic. The local-path
+// validator is exercised against a real temp file (cheap, no Fastify
+// server); the S3 validator is exercised against a hand-rolled fake storage
+// object since it only needs `readAll`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  parseChecksumMetadata,
+  createChecksumValidator,
+  createS3ChecksumValidator,
+} from "../dist/lib/checksum.js";
+
+test("parseChecksumMetadata accepts well-formed values, rejects everything else", () => {
+  assert.deepEqual(parseChecksumMetadata("sha256:abcd1234"), {
+    algorithm: "sha256",
+    digest: "abcd1234",
+  });
+  assert.deepEqual(parseChecksumMetadata("SHA1:ABCD"), { algorithm: "sha1", digest: "abcd" });
+  assert.equal(parseChecksumMetadata(undefined), null);
+  assert.equal(parseChecksumMetadata(null), null);
+  assert.equal(parseChecksumMetadata(""), null);
+  assert.equal(parseChecksumMetadata("nocolon"), null);
+  assert.equal(parseChecksumMetadata("md7:abcd"), null, "unsupported algorithm");
+  assert.equal(parseChecksumMetadata("sha256:not-hex!"), null);
+  assert.equal(parseChecksumMetadata("sha256:"), null, "empty digest");
+});
+
+test("createChecksumValidator accepts a matching digest via localPath", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-checksum-"));
+  try {
+    const file = path.join(dir, "clip.mp4");
+    const bytes = Buffer.from("hello world");
+    await fs.writeFile(file, bytes);
+    const digest = createHash("sha256").update(bytes).digest("hex");
+
+    const validator = createChecksumValidator();
+    await assert.doesNotReject(() =>
+      validator({}, { artifactId: "id", size: bytes.length, uploadId: "u1", localPath: file, checksum: `sha256:${digest}` }),
+    );
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("createChecksumValidator rejects a mismatched digest with a 422", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-checksum-"));
+  try {
+    const file = path.join(dir, "clip.mp4");
+    await fs.writeFile(file, Buffer.from("hello world"));
+
+    const validator = createChecksumValidator();
+    await assert.rejects(
+      () =>
+        validator({}, {
+          artifactId: "id",
+          size: 11,
+          uploadId: "u1",
+          localPath: file,
+          checksum: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        }),
+      (err) => {
+        assert.equal(err.statusCode, 422);
+        return true;
+      },
+    );
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("createChecksumValidator passes through (no-op) when no checksum metadata is present", async () => {
+  let nextCalled = false;
+  const validator = createChecksumValidator(async () => {
+    nextCalled = true;
+  });
+  await validator({}, { artifactId: "id", size: 0, uploadId: "u1", localPath: null });
+  assert.equal(nextCalled, true, "chained validator still runs when checksum is absent");
+});
+
+test("createChecksumValidator throws a clear error when checksum is requested but localPath is unavailable", async () => {
+  const validator = createChecksumValidator();
+  await assert.rejects(() =>
+    validator({}, { artifactId: "id", size: 0, uploadId: "u1", localPath: null, checksum: "sha256:abcd" }),
+  );
+});
+
+test("createS3ChecksumValidator verifies against storage.readAll", async () => {
+  const bytes = Buffer.from("s3 object bytes");
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  const fakeStorage = { readAll: async () => bytes };
+
+  const validator = createS3ChecksumValidator(fakeStorage);
+  await assert.doesNotReject(() =>
+    validator({}, { artifactId: "id", size: bytes.length, uploadId: "u1", localPath: null, checksum: `sha256:${digest}` }),
+  );
+
+  await assert.rejects(() =>
+    validator({}, {
+      artifactId: "id",
+      size: bytes.length,
+      uploadId: "u1",
+      localPath: null,
+      checksum: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    }),
+  );
+});

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -27,26 +27,34 @@ export function makeMp4(size) {
   return body;
 }
 
-export async function tusCreate(baseUrl, prefix, { videoid, filename, size, kind }) {
-  const parts = [`videoid ${b64(videoid)}`, `filename ${b64(filename)}`];
+export async function tusCreate(
+  baseUrl,
+  prefix,
+  { artifactId, idKey = "artifactId", filename, size, kind, relatedTo, checksum, headers = {} },
+) {
+  const parts = [`${idKey} ${b64(artifactId)}`, `filename ${b64(filename)}`];
   if (kind) parts.push(`kind ${b64(kind)}`);
+  if (relatedTo) parts.push(`relatedTo ${b64(relatedTo)}`);
+  if (checksum) parts.push(`checksum ${b64(checksum)}`);
   return fetch(`${baseUrl}${prefix}/upload`, {
     method: "POST",
     headers: {
       "Tus-Resumable": "1.0.0",
       "Upload-Length": String(size),
       "Upload-Metadata": parts.join(","),
+      ...headers,
     },
   });
 }
 
-export async function tusPatch(url, offset, body) {
+export async function tusPatch(url, offset, body, headers = {}) {
   return fetch(url, {
     method: "PATCH",
     headers: {
       "Tus-Resumable": "1.0.0",
       "Upload-Offset": String(offset),
       "Content-Type": "application/offset+octet-stream",
+      ...headers,
     },
     body,
   });
@@ -64,19 +72,22 @@ export async function tusHead(url) {
 export async function uploadFull(
   baseUrl,
   prefix,
-  { videoid, filename = "clip.mp4", size = 1024, kind, body } = {},
+  { artifactId, filename = "clip.mp4", size = 1024, kind, relatedTo, checksum, body, headers } = {},
 ) {
   const payload = body ?? makeMp4(size);
   const create = await tusCreate(baseUrl, prefix, {
-    videoid,
+    artifactId,
     filename,
     size: payload.length,
     kind,
+    relatedTo,
+    checksum,
+    headers,
   });
   assert.equal(create.status, 201, "create");
   const location = create.headers.get("location");
   assert.ok(location, "location header");
-  const patch = await tusPatch(location, 0, payload);
+  const patch = await tusPatch(location, 0, payload, headers);
   assert.equal(patch.status, 204, "patch");
   return { body: payload, location };
 }

--- a/test/plugin.test.mjs
+++ b/test/plugin.test.mjs
@@ -8,10 +8,14 @@ import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { createHash } from "node:crypto";
 import Fastify from "fastify";
 import pulseVault, {
   createLocalStorage,
   createMp4Sniffer,
+  createChecksumValidator,
+  issueCapabilityToken,
+  createCapabilityAuthorize,
 } from "../dist/app.js";
 import {
   makeMp4,
@@ -34,8 +38,9 @@ const PREFIX = "/pulsevault";
 // Prefix-bound wrappers so the test bodies below read the same as before the
 // shared helpers were extracted.
 const tusCreate = (baseUrl, opts) => tusCreateRaw(baseUrl, PREFIX, opts);
-const uploadFullMp4 = (ctx, videoid, size = 1024) =>
-  uploadFull(ctx.baseUrl, PREFIX, { videoid, size });
+const uploadFullMp4 = (ctx, artifactId, size = 1024) =>
+  uploadFull(ctx.baseUrl, PREFIX, { artifactId, size });
+const artifactUrl = (ctx, id) => `${ctx.baseUrl}${PREFIX}/artifacts/${id}`;
 
 async function startApp({ pluginOptions = {}, withSniffer = false } = {}) {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-test-"));
@@ -78,8 +83,9 @@ test("reserve + full upload flips sidecar to ready and GET streams the bytes", a
     assert.equal(sidecar.ext, ".mp4");
     assert.equal(sidecar.version, 1);
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 200);
+    assert.equal(get.headers.get("protocol-version"), "1");
     const bytes = Buffer.from(await get.arrayBuffer());
     assert.equal(bytes.length, body.length);
     assert.equal(Buffer.compare(bytes, body), 0);
@@ -93,13 +99,13 @@ test("GET returns 404 while the upload is still in progress", async () => {
   try {
     // Create but never PATCH — file exists at 0 bytes, sidecar is "uploading".
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "clip.mp4",
       size: 1024,
     });
     assert.equal(create.status, 201);
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 404);
   } finally {
     await ctx.teardown();
@@ -111,7 +117,7 @@ test("HEAD + resume PATCH completes the upload", async () => {
   try {
     const body = makeMp4(4096);
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "clip.mp4",
       size: body.length,
     });
@@ -126,13 +132,13 @@ test("HEAD + resume PATCH completes the upload", async () => {
     assert.equal(head.headers.get("upload-offset"), String(half));
 
     // Before the final PATCH, GET must still be 404.
-    const midGet = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const midGet = await fetch(artifactUrl(ctx, ID1));
     assert.equal(midGet.status, 404);
 
     const p2 = await tusPatch(location, half, body.subarray(half));
     assert.equal(p2.status, 204);
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 200);
     const bytes = Buffer.from(await get.arrayBuffer());
     assert.equal(Buffer.compare(bytes, body), 0);
@@ -141,18 +147,18 @@ test("HEAD + resume PATCH completes the upload", async () => {
   }
 });
 
-test("second reserve for same videoid returns 409", async () => {
+test("second reserve for same artifactId returns 409", async () => {
   const ctx = await startApp();
   try {
     const first = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "clip.mp4",
       size: 1024,
     });
     assert.equal(first.status, 201);
 
     const dup = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "clip.mp4",
       size: 1024,
     });
@@ -166,7 +172,7 @@ test("non-allowed extension is rejected at create", async () => {
   const ctx = await startApp();
   try {
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "evil.exe",
       size: 1024,
     });
@@ -184,7 +190,7 @@ test("range GET returns 206 with the requested slice", async () => {
   try {
     const { body } = await uploadFullMp4(ctx, ID1, 2048);
 
-    const range = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`, {
+    const range = await fetch(artifactUrl(ctx, ID1), {
       headers: { Range: "bytes=0-99" },
     });
     assert.equal(range.status, 206);
@@ -196,10 +202,10 @@ test("range GET returns 206 with the requested slice", async () => {
   }
 });
 
-test("GET of an unknown videoid returns 404", async () => {
+test("GET of an unknown artifactId returns 404", async () => {
   const ctx = await startApp();
   try {
-    const res = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const res = await fetch(artifactUrl(ctx, ID1));
     assert.equal(res.status, 404);
   } finally {
     await ctx.teardown();
@@ -216,31 +222,31 @@ test("authorize rejection blocks create, GET, and DELETE", async () => {
   });
   try {
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "clip.mp4",
       size: 1024,
     });
     assert.equal(create.status, 403);
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 403);
 
-    const del = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`, { method: "DELETE" });
+    const del = await fetch(artifactUrl(ctx, ID1), { method: "DELETE" });
     assert.equal(del.status, 403);
   } finally {
     await ctx.teardown();
   }
 });
 
-test("DELETE removes the video; second DELETE is 404", async () => {
+test("DELETE removes the artifact; second DELETE is 404", async () => {
   const ctx = await startApp();
   try {
     await uploadFullMp4(ctx, ID1);
 
-    const preGet = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const preGet = await fetch(artifactUrl(ctx, ID1));
     assert.equal(preGet.status, 200);
 
-    const del = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`, { method: "DELETE" });
+    const del = await fetch(artifactUrl(ctx, ID1), { method: "DELETE" });
     assert.equal(del.status, 204);
 
     const sidecarStat = await fs
@@ -248,17 +254,17 @@ test("DELETE removes the video; second DELETE is 404", async () => {
       .catch(() => null);
     assert.equal(sidecarStat, null);
 
-    const postGet = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const postGet = await fetch(artifactUrl(ctx, ID1));
     assert.equal(postGet.status, 404);
 
-    const del2 = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`, { method: "DELETE" });
+    const del2 = await fetch(artifactUrl(ctx, ID1), { method: "DELETE" });
     assert.equal(del2.status, 404);
   } finally {
     await ctx.teardown();
   }
 });
 
-test("createMp4Sniffer rejects non-MP4 bytes and removes the video", async () => {
+test("createMp4Sniffer rejects non-MP4 bytes and removes the artifact", async () => {
   const ctx = await startApp({ withSniffer: true });
   try {
     // GIF header — deliberately not ISOBMFF.
@@ -267,7 +273,7 @@ test("createMp4Sniffer rejects non-MP4 bytes and removes the video", async () =>
       Buffer.alloc(1024, 0xff),
     ]);
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "fake.mp4",
       size: fake.length,
     });
@@ -285,7 +291,7 @@ test("createMp4Sniffer rejects non-MP4 bytes and removes the video", async () =>
       .catch(() => null);
     assert.equal(sidecarStat, null, "sidecar should be removed");
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 404);
   } finally {
     await ctx.teardown();
@@ -297,7 +303,7 @@ test("createMp4Sniffer accepts a valid MP4 payload", async () => {
   try {
     await uploadFullMp4(ctx, ID2, 2048);
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID2}`);
+    const get = await fetch(artifactUrl(ctx, ID2));
     assert.equal(get.status, 200);
   } finally {
     await ctx.teardown();
@@ -317,7 +323,8 @@ test("onUploadComplete fires exactly once with the right ctx", async () => {
     const { body } = await uploadFullMp4(ctx, ID1);
 
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].videoid, ID1);
+    assert.equal(calls[0].artifactId, ID1);
+    assert.equal(calls[0].kind, "video");
     assert.equal(calls[0].size, body.length);
     assert.equal(typeof calls[0].uploadId, "string");
   } finally {
@@ -331,15 +338,62 @@ test("malformed sidecar is treated as absent; reserve rewrites it", async () => 
     await fs.mkdir(path.join(ctx.workspaceDir, ".pulsevault"), { recursive: true });
     await fs.writeFile(path.join(ctx.workspaceDir, ".pulsevault", `${ID1}.json`), "not json");
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    const get = await fetch(artifactUrl(ctx, ID1));
     assert.equal(get.status, 404);
 
     const create = await tusCreate(ctx.baseUrl, {
-      videoid: ID1,
+      artifactId: ID1,
       filename: "clip.mp4",
       size: 1024,
     });
     assert.equal(create.status, 201);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("a pre-artifactId-rename sidecar (legacy fields only, no kind) still resolves through the new generic route", async () => {
+  // Simulates a workspace left behind by a pre-this-release deployment: the
+  // sidecar predates `kind` entirely (it was already optional for back-compat)
+  // and was written before this release renamed `videoid` to `artifactId`
+  // everywhere — but since the on-disk sidecar never stored the id as a field
+  // (the id is the filename), nothing on disk actually needs migrating. This
+  // is the real "does an existing deployment survive the upgrade" check.
+  const ctx = await startApp();
+  try {
+    await fs.mkdir(path.join(ctx.workspaceDir, "video"), { recursive: true });
+    await fs.mkdir(path.join(ctx.workspaceDir, ".pulsevault"), { recursive: true });
+    const mp4 = makeMp4(1024);
+    await fs.writeFile(path.join(ctx.workspaceDir, "video", `${ID1}.mp4`), mp4);
+    const legacySidecar = JSON.stringify({
+      version: 1,
+      ext: ".mp4",
+      filename: "clip.mp4",
+      status: "ready",
+      // `kind` intentionally absent, matching every pre-this-release sidecar.
+    });
+    await fs.writeFile(path.join(ctx.workspaceDir, ".pulsevault", `${ID1}.json`), legacySidecar);
+
+    const get = await fetch(artifactUrl(ctx, ID1));
+    assert.equal(get.status, 200, "legacy sidecar resolves through the new /artifacts/ route");
+    const bytes = Buffer.from(await get.arrayBuffer());
+    assert.equal(Buffer.compare(bytes, mp4), 0);
+
+    const kind = await ctx.storage.getKind(ID1);
+    assert.equal(kind, "video", "legacy upload reports kind=video");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("old per-kind routes (pre-generic-route) are gone, not kept as a parallel API", async () => {
+  const ctx = await startApp();
+  try {
+    await uploadFullMp4(ctx, ID1);
+    const oldVideoRoute = await fetch(`${ctx.baseUrl}${PREFIX}/${ID1}`);
+    assert.equal(oldVideoRoute.status, 404, "old GET /:videoid is gone");
+    const oldProjectRoute = await fetch(`${ctx.baseUrl}${PREFIX}/project/${ID1}`);
+    assert.equal(oldProjectRoute.status, 404, "old GET /project/:projectid is gone");
   } finally {
     await ctx.teardown();
   }
@@ -354,18 +408,179 @@ test("old root-level plugin paths return 404", async () => {
       headers: {
         "Tus-Resumable": "1.0.0",
         "Upload-Length": "1024",
-        "Upload-Metadata": `videoid ${Buffer.from(ID1).toString("base64")}`,
+        "Upload-Metadata": `artifactId ${Buffer.from(ID1).toString("base64")}`,
       },
     });
     assert.equal(uploadRoot.status, 404, "POST /upload should be 404");
 
-    // GET /:videoid (root) must not exist.
-    const getRoot = await fetch(`${ctx.baseUrl}/${ID1}`);
-    assert.equal(getRoot.status, 404, "GET /:videoid at root should be 404");
+    // GET /artifacts/:artifactId (root) must not exist.
+    const getRoot = await fetch(`${ctx.baseUrl}/artifacts/${ID1}`);
+    assert.equal(getRoot.status, 404, "GET /artifacts/:artifactId at root should be 404");
 
-    // DELETE /:videoid (root) must not exist.
-    const delRoot = await fetch(`${ctx.baseUrl}/${ID1}`, { method: "DELETE" });
-    assert.equal(delRoot.status, 404, "DELETE /:videoid at root should be 404");
+    // DELETE /artifacts/:artifactId (root) must not exist.
+    const delRoot = await fetch(`${ctx.baseUrl}/artifacts/${ID1}`, { method: "DELETE" });
+    assert.equal(delRoot.status, 404, "DELETE /artifacts/:artifactId at root should be 404");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("GET /capabilities is unauthenticated and reports the configured uploadUnit", async () => {
+  const authorizeCalls = [];
+  const ctx = await startApp({
+    pluginOptions: {
+      uploadUnit: "merged",
+      authorize: async (_req, ctx) => {
+        authorizeCalls.push(ctx.phase);
+      },
+    },
+  });
+  try {
+    const res = await fetch(`${ctx.baseUrl}${PREFIX}/capabilities`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.protocolVersion, 1);
+    assert.equal(body.minSupportedVersion, 1);
+    assert.equal(body.maxSupportedVersion, 1);
+    assert.equal(body.uploadUnit, "merged");
+    assert.deepEqual(body.kinds.sort(), ["captions", "project", "video"]);
+    assert.equal(body.maxUploadSize, 10 * 1024 * 1024);
+    assert.ok(Array.isArray(body.checksum.algorithms));
+    assert.equal(authorizeCalls.length, 0, "capabilities must not run authorize");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("checksum validator accepts a matching digest and rejects a mismatched one", async () => {
+  const ctx = await startApp({
+    pluginOptions: { validatePayload: createChecksumValidator() },
+  });
+  try {
+    const body = makeMp4(1024);
+    const digest = createHash("sha256").update(body).digest("hex");
+
+    const good = await uploadFull(ctx.baseUrl, PREFIX, {
+      artifactId: ID1,
+      body,
+      checksum: `sha256:${digest}`,
+    });
+    const get = await fetch(artifactUrl(ctx, ID1));
+    assert.equal(get.status, 200, "matching checksum is accepted");
+    void good;
+
+    const create = await tusCreate(ctx.baseUrl, {
+      artifactId: ID2,
+      filename: "clip.mp4",
+      size: body.length,
+      checksum: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    });
+    const location = create.headers.get("location");
+    const patch = await tusPatch(location, 0, body);
+    assert.equal(patch.status, 422, "mismatched checksum is rejected");
+
+    const sidecarStat = await fs
+      .stat(path.join(ctx.workspaceDir, ".pulsevault", `${ID2}.json`))
+      .catch(() => null);
+    assert.equal(sidecarStat, null, "rejected upload's sidecar is cleaned up");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("createCapabilityAuthorize: valid token authorizes its own artifact and a related one, rejects others", async () => {
+  const secret = "test-secret";
+  const issuer = "https://vault.example.test";
+  const lookupSecret = (kid) => (kid === "k1" ? secret : null);
+  const ctx = await startApp({
+    pluginOptions: {
+      authorize: createCapabilityAuthorize(lookupSecret, { issuer }),
+    },
+  });
+  try {
+    const token = issueCapabilityToken(ID1, secret, { keyId: "k1", issuer });
+
+    // Authorizes its own artifactId.
+    await uploadFull(ctx.baseUrl, PREFIX, {
+      artifactId: ID1,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const get1 = await fetch(artifactUrl(ctx, ID1), {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(get1.status, 200);
+
+    // Authorizes a related artifact (e.g. ID1's captions) via relatedTo.
+    const captionsCreate = await tusCreateRaw(ctx.baseUrl, PREFIX, {
+      artifactId: ID2,
+      filename: "clip.srt",
+      size: 10,
+      kind: "captions",
+      relatedTo: ID1,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(captionsCreate.status, 201, "related artifact authorized by the session token");
+
+    // An unrelated artifactId is rejected even with a structurally valid token.
+    const unrelatedToken = issueCapabilityToken(
+      "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+      secret,
+      { keyId: "k1", issuer },
+    );
+    const rejected = await tusCreateRaw(ctx.baseUrl, PREFIX, {
+      artifactId: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+      filename: "clip.mp4",
+      size: 1024,
+      headers: { Authorization: `Bearer ${unrelatedToken}` },
+    });
+    assert.equal(rejected.status, 403);
+
+    // Expired token is rejected. -120s is well past the default 30s clock-skew
+    // tolerance (see capability-token.test.mjs for the boundary case itself).
+    const expired = issueCapabilityToken(ID1, secret, { keyId: "k1", issuer, expirySeconds: -120 });
+    const expiredGet = await fetch(artifactUrl(ctx, ID1), {
+      headers: { Authorization: `Bearer ${expired}` },
+    });
+    assert.equal(expiredGet.status, 403);
+
+    // Unknown kid is rejected.
+    const unknownKid = issueCapabilityToken(ID1, secret, { keyId: "nope", issuer });
+    const unknownKidGet = await fetch(artifactUrl(ctx, ID1), {
+      headers: { Authorization: `Bearer ${unknownKid}` },
+    });
+    assert.equal(unknownKidGet.status, 403);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("createCapabilityAuthorize: key rotation overlap — old and new kid both verify", async () => {
+  const oldSecret = "old-secret";
+  const newSecret = "new-secret";
+  const issuer = "https://vault.example.test";
+  const lookupSecret = (kid) => ({ "2026-03": oldSecret, "2026-06": newSecret })[kid] ?? null;
+  const ctx = await startApp({
+    pluginOptions: { authorize: createCapabilityAuthorize(lookupSecret, { issuer }) },
+  });
+  try {
+    const oldToken = issueCapabilityToken(ID1, oldSecret, { keyId: "2026-03", issuer });
+    const newToken = issueCapabilityToken(ID2, newSecret, { keyId: "2026-06", issuer });
+
+    const r1 = await tusCreateRaw(ctx.baseUrl, PREFIX, {
+      artifactId: ID1,
+      filename: "a.mp4",
+      size: 1024,
+      headers: { Authorization: `Bearer ${oldToken}` },
+    });
+    assert.equal(r1.status, 201, "old key still verifies during rotation overlap");
+
+    const r2 = await tusCreateRaw(ctx.baseUrl, PREFIX, {
+      artifactId: ID2,
+      filename: "b.mp4",
+      size: 1024,
+      headers: { Authorization: `Bearer ${newToken}` },
+    });
+    assert.equal(r2.status, 201, "new key verifies");
   } finally {
     await ctx.teardown();
   }

--- a/test/s3-storage.test.mjs
+++ b/test/s3-storage.test.mjs
@@ -1,19 +1,20 @@
 // S3 / R2 backend suite for @mieweb/pulsevault. Runs against the built
 // `dist/` and an in-process `s3rver` S3 mock, so CI needs no real cloud
 // credentials. A single s3rver is shared across tests; each test uses a fresh
-// videoid (the bucket persists between tests).
+// artifactId (the bucket persists between tests).
 
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import { randomUUID, createHash } from "node:crypto";
 import S3rver from "s3rver";
 import Fastify from "fastify";
 import pulseVault, {
   createS3Storage,
   createS3Mp4Sniffer,
+  createS3ChecksumValidator,
 } from "../dist/app.js";
 import { makeMp4, tusCreate, tusPatch, tusHead, uploadFull } from "./helpers.mjs";
 import { installListPartsShim } from "./s3rver-listparts.mjs";
@@ -81,16 +82,18 @@ async function startApp({ pluginOptions = {}, withSniffer = false } = {}) {
   };
 }
 
+const artifactUrl = (ctx, id) => `${ctx.baseUrl}${PREFIX}/artifacts/${id}`;
+
 // ---------- tests ----------
 
 test("full upload → GET 302-redirects to a presigned URL that serves the bytes", async () => {
   const ctx = await startApp();
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
-    const { body } = await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
+    const { body } = await uploadFull(ctx.baseUrl, PREFIX, { artifactId: id, size: 2048 });
 
     // GET returns a redirect, not the bytes.
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    const get = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(get.status, 302, "GET should 302-redirect");
     const location = get.headers.get("location");
     assert.ok(location, "Location header present");
@@ -114,16 +117,16 @@ test("full upload → GET 302-redirects to a presigned URL that serves the bytes
 
 test("GET returns 404 while the upload is still in progress", async () => {
   const ctx = await startApp();
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
     const create = await tusCreate(ctx.baseUrl, PREFIX, {
-      videoid: vid,
+      artifactId: id,
       filename: "clip.mp4",
       size: 2048,
     });
     assert.equal(create.status, 201);
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    const get = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(get.status, 404);
   } finally {
     await ctx.teardown();
@@ -132,11 +135,11 @@ test("GET returns 404 while the upload is still in progress", async () => {
 
 test("HEAD + resume PATCH completes the multipart upload", async () => {
   const ctx = await startApp();
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
     const body = makeMp4(4096);
     const create = await tusCreate(ctx.baseUrl, PREFIX, {
-      videoid: vid,
+      artifactId: id,
       filename: "clip.mp4",
       size: body.length,
     });
@@ -151,13 +154,13 @@ test("HEAD + resume PATCH completes the multipart upload", async () => {
     assert.equal(head.headers.get("upload-offset"), String(half));
 
     // Still in progress → GET must be 404.
-    const midGet = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    const midGet = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(midGet.status, 404);
 
     const p2 = await tusPatch(location, half, body.subarray(half));
     assert.equal(p2.status, 204);
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    const get = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(get.status, 302);
     const direct = await fetch(get.headers.get("location"));
     const bytes = Buffer.from(await direct.arrayBuffer());
@@ -167,19 +170,19 @@ test("HEAD + resume PATCH completes the multipart upload", async () => {
   }
 });
 
-test("second reserve for same videoid returns 409", async () => {
+test("second reserve for same artifactId returns 409", async () => {
   const ctx = await startApp();
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
     const first = await tusCreate(ctx.baseUrl, PREFIX, {
-      videoid: vid,
+      artifactId: id,
       filename: "clip.mp4",
       size: 1024,
     });
     assert.equal(first.status, 201);
 
     const dup = await tusCreate(ctx.baseUrl, PREFIX, {
-      videoid: vid,
+      artifactId: id,
       filename: "clip.mp4",
       size: 1024,
     });
@@ -191,12 +194,12 @@ test("second reserve for same videoid returns 409", async () => {
 
 test("createS3Mp4Sniffer rejects non-MP4 bytes and removes the object", async () => {
   const ctx = await startApp({ withSniffer: true });
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
     // GIF header — deliberately not ISOBMFF.
     const fake = Buffer.concat([Buffer.from("GIF89a"), Buffer.alloc(2048, 0xff)]);
     const create = await tusCreate(ctx.baseUrl, PREFIX, {
-      videoid: vid,
+      artifactId: id,
       filename: "fake.mp4",
       size: fake.length,
     });
@@ -209,7 +212,7 @@ test("createS3Mp4Sniffer rejects non-MP4 bytes and removes the object", async ()
       `expected 4xx, got ${patch.status}`,
     );
 
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    const get = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(get.status, 404, "rejected upload is not served");
   } finally {
     await ctx.teardown();
@@ -218,63 +221,132 @@ test("createS3Mp4Sniffer rejects non-MP4 bytes and removes the object", async ()
 
 test("createS3Mp4Sniffer accepts a valid MP4 payload", async () => {
   const ctx = await startApp({ withSniffer: true });
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
-    await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: id, size: 2048 });
+    const get = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(get.status, 302);
   } finally {
     await ctx.teardown();
   }
 });
 
+test("createS3ChecksumValidator accepts a matching digest and rejects a mismatch", async () => {
+  // createS3ChecksumValidator needs the same storage instance the plugin
+  // uses, so this test builds the app directly rather than via `startApp`.
+  const storage = await createS3Storage({
+    bucket: BUCKET,
+    endpoint,
+    region: "us-east-1",
+    accessKeyId: "S3RVER",
+    secretAccessKey: "S3RVER",
+    forcePathStyle: true,
+    clientConfig: {
+      requestChecksumCalculation: "WHEN_REQUIRED",
+      responseChecksumValidation: "WHEN_REQUIRED",
+    },
+  });
+  const app = Fastify({ logger: false });
+  await app.register(pulseVault, {
+    prefix: PREFIX,
+    storage,
+    maxUploadSize: 10 * 1024 * 1024,
+    validatePayload: createS3ChecksumValidator(storage),
+  });
+  const baseUrl = await app.listen({ port: 0, host: "127.0.0.1" });
+  try {
+    const goodId = randomUUID();
+    const body = makeMp4(2048);
+    const digest = createHash("sha256").update(body).digest("hex");
+    await uploadFull(baseUrl, PREFIX, { artifactId: goodId, body, checksum: `sha256:${digest}` });
+    const get = await fetch(`${baseUrl}${PREFIX}/artifacts/${goodId}`, { redirect: "manual" });
+    assert.equal(get.status, 302, "matching checksum is accepted");
+
+    const badId = randomUUID();
+    const create = await tusCreate(baseUrl, PREFIX, {
+      artifactId: badId,
+      filename: "clip.mp4",
+      size: body.length,
+      checksum: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    });
+    const location = create.headers.get("location");
+    const patch = await tusPatch(location, 0, body);
+    assert.equal(patch.status, 422, "mismatched checksum is rejected");
+  } finally {
+    await app.close();
+  }
+});
+
 test("DELETE removes the object; second DELETE is 404", async () => {
   const ctx = await startApp();
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
-    await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: id, size: 2048 });
 
-    const pre = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    const pre = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(pre.status, 302);
 
-    const del = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { method: "DELETE" });
+    const del = await fetch(artifactUrl(ctx, id), { method: "DELETE" });
     assert.equal(del.status, 204);
 
-    const post = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
+    const post = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(post.status, 404);
 
-    const del2 = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { method: "DELETE" });
+    const del2 = await fetch(artifactUrl(ctx, id), { method: "DELETE" });
     assert.equal(del2.status, 404);
   } finally {
     await ctx.teardown();
   }
 });
 
-test("kind=project lands under project/ and GET /project/:id 302-redirects", async () => {
+test("kind=project lands under project/ and GET /artifacts/:id 302-redirects there too", async () => {
   const ctx = await startApp();
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
     // A .pulse bundle is opaque bytes — no MP4 sniffing for projects.
     const body = Buffer.alloc(2048, 0x42);
     await uploadFull(ctx.baseUrl, PREFIX, {
-      videoid: vid,
+      artifactId: id,
       filename: "draft.pulse",
       kind: "project",
       body,
     });
 
-    // Video route must not serve a project artifact.
-    const videoGet = await fetch(`${ctx.baseUrl}${PREFIX}/${vid}`, { redirect: "manual" });
-    assert.equal(videoGet.status, 404);
-
-    const get = await fetch(`${ctx.baseUrl}${PREFIX}/project/${vid}`, { redirect: "manual" });
+    const get = await fetch(artifactUrl(ctx, id), { redirect: "manual" });
     assert.equal(get.status, 302);
     const location = get.headers.get("location");
-    assert.ok(location.includes(`project/${vid}.pulse`), "redirect points at project key");
+    assert.ok(location.includes(`project/${id}.pulse`), "redirect points at project key");
 
     const direct = await fetch(location);
     const bytes = Buffer.from(await direct.arrayBuffer());
     assert.equal(Buffer.compare(bytes, body), 0);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("kind=captions lands under captions/ with relatedTo recorded", async () => {
+  const ctx = await startApp();
+  const videoId = randomUUID();
+  const captionsId = randomUUID();
+  try {
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: videoId, size: 2048 });
+    const srt = Buffer.from("1\n00:00:00,000 --> 00:00:01,000\nHello\n");
+    await uploadFull(ctx.baseUrl, PREFIX, {
+      artifactId: captionsId,
+      filename: "clip.srt",
+      kind: "captions",
+      relatedTo: videoId,
+      body: srt,
+    });
+
+    assert.equal(await ctx.storage.getKind(captionsId), "captions");
+    assert.equal(await ctx.storage.getRelatedTo(captionsId), videoId);
+
+    const get = await fetch(artifactUrl(ctx, captionsId), { redirect: "manual" });
+    assert.equal(get.status, 302);
+    const direct = await fetch(get.headers.get("location"));
+    assert.equal(direct.headers.get("content-type"), "application/x-subrip");
   } finally {
     await ctx.teardown();
   }
@@ -289,11 +361,12 @@ test("onUploadComplete fires once with the right ctx", async () => {
       },
     },
   });
-  const vid = randomUUID();
+  const id = randomUUID();
   try {
-    const { body } = await uploadFull(ctx.baseUrl, PREFIX, { videoid: vid, size: 2048 });
+    const { body } = await uploadFull(ctx.baseUrl, PREFIX, { artifactId: id, size: 2048 });
     assert.equal(calls.length, 1);
-    assert.equal(calls[0].videoid, vid);
+    assert.equal(calls[0].artifactId, id);
+    assert.equal(calls[0].kind, "video");
     assert.equal(calls[0].size, body.length);
     assert.equal(typeof calls[0].uploadId, "string");
   } finally {


### PR DESCRIPTION
## Summary

This reworks the upload contract so a third party can implement a compatible server from `PROTOCOL.md` alone, not just by reading this package's source. It bundles several breaking changes into one release rather than spreading them across several — see `OPERATIONS.md` for the upgrade path.

- Rename `videoid` → `artifactId` across the storage interface, `authorize` context, upload hooks, the `request.pulseVault` type augmentation, and the deep-link builder. `videoid`/`projectid` still work as legacy `Upload-Metadata` aliases.
- Collapse the per-kind routes into a single generic `GET/DELETE /artifacts/:artifactId` that resolves kind from storage instead of the URL, and add a new `kind: "captions"` artifact type.
- Add `relatedTo` to link one artifact to another (e.g. a video's captions).
- Add optional post-upload `checksum` verification, a stateless HMAC capability-token scheme (`issueCapabilityToken`/`verifyCapabilityToken`/`createCapabilityAuthorize`) with key rotation and clock-skew tolerance, an unauthenticated `GET /capabilities` discovery route, the `uploadUnit` plugin option, a low-frequency `onArtifactEvent` hook, a `Protocol-Version` response header, and a bounded LRU metadata cache in both storage adapters.
- Deprecate `validateProjectPayload`/`onProjectUploadComplete` in favor of the now-generic `validatePayload`/`onUploadComplete` (which receive `ctx.kind`), with a one-time `DeprecationWarning`.
- Update the `rn-demo` example server to the new protocol.
- Add `PROTOCOL.md` (wire-level spec) and `OPERATIONS.md` (deployment/upgrade guide), rework `README.md`, start `CHANGELOG.md`, and bump to `0.1.0`.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 61/61 passing, including new coverage for captions/relatedTo, checksum validation, capability tokens, the generic artifacts route, and legacy-alias/legacy-route behavior
- [x] Manually exercised the updated `rn-demo` server end-to-end (pairing, browsing, streaming, resumable upload) from a phone over Wi-Fi