### PR TITLE
Fix stale and inaccurate protocol documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,9 +76,9 @@ in `OPERATIONS.md` for the migration path.
   both ops metrics and a compliance audit trail from a single integration
   point.
 - **`Protocol-Version` response header** on every route this plugin mounts.
-- Bounded, LRU-evicting in-memory metadata cache in both storage adapters
-  (`metaCacheLimit` option, default 10,000 entries) — previously unbounded
-  for the life of the process.
+- Bounded, insertion-order-evicting in-memory metadata cache in both storage
+  adapters (`metaCacheLimit` option, default 10,000 entries) — previously
+  unbounded for the life of the process.
 - `S3Storage.readAll` — full-object read, used by `createS3ChecksumValidator`.
 
 ### Fixed
@@ -87,4 +87,4 @@ in `OPERATIONS.md` for the migration path.
   have explicit test coverage proving bytes are rejected/hidden at the right
   point, not just implied by the implementation.
 
-[Unreleased]: https://github.com/mieweb/pulsevault/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/mieweb/pulsevault/compare/v0.0.1...HEAD

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -41,7 +41,7 @@ The response body MUST be a JSON object with at least the following fields:
   "kinds": ["video", "project", "captions"],
   "allowedExtensions": { "video": [".mp4"], "project": [".pulse", ".zip"], "captions": [".srt"] },
   "maxUploadSize": 5368709120,
-  "checksum": { "algorithms": ["sha256"] }
+  "checksum": { "algorithms": ["sha256", "sha1", "md5"] }
 }
 ```
 
@@ -60,7 +60,10 @@ The response body MUST be a JSON object with at least the following fields:
 - `maxUploadSize` (integer, REQUIRED): maximum artifact size in bytes.
 - `checksum.algorithms` (array of string, OPTIONAL): digest algorithms this
   server can verify (§6.3). Absent or empty means the server does not
-  support checksum verification.
+  support checksum verification. Note for implementers: this field
+  describes capability, not whether verification is actually wired in for
+  every upload — a server MAY list an algorithm it's capable of checking
+  even for a deployment where the operator hasn't enabled that check.
 
 A server response to this endpoint MUST NOT include any secret. Every other
 response from the server MUST include a `Protocol-Version` header carrying

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ await app.register(pulseVault, {
 
 `createMp4Sniffer` reads the first 12 bytes and verifies the ISOBMFF `ftyp` header (MP4, MOV, M4V, 3GP). Uploads that pass the extension check but contain non-video bytes are rejected with 422 and the disk is cleaned up. The lower-level `sniffMp4(path)` is also exported if you want to drive your own validator.
 
+`createChecksumValidator`/`createS3ChecksumValidator` parse `ctx.checksum` with the also-exported `parseChecksumMetadata(raw)`, which returns `{ algorithm, digest }` or `null` for a missing/malformed value — use it directly if you're writing your own checksum check instead of the ship-ready validators.
+
 `createMp4Sniffer`/`createChecksumValidator` only make sense for `kind=video`/general payloads — they run unconditionally for every kind your hook receives, so branch on `ctx.kind` yourself if you only want them applied to one kind, or compose differently per kind:
 
 ```ts
@@ -336,6 +338,8 @@ When the final PATCH lands the plugin runs the following steps in order, for eve
   "checksum": { "algorithms": ["sha256", "sha1", "md5"] }
 }
 ```
+
+`checksum.algorithms` always lists what `createChecksumValidator`/`createS3ChecksumValidator` are capable of verifying — it does not detect whether this deployment's `validatePayload` actually calls one of them. A client sending a `checksum` metadata value is only verified if the operator wired in one of these helpers (or an equivalent check of their own).
 
 See `PROTOCOL.md` §2 for the full normative shape.
 
@@ -611,7 +615,7 @@ const uploadLink = buildUploadLink({
   artifactId: randomUUID(), // generate server-side; skip POST /reserve on the app
   token: "secret", // optional — forwarded to your authorize hook; see Capability tokens
 });
-// pulsecam://?v=1&artifactId=...&server=https%3A%2F%2Fexample.com&token=secret
+// pulsecam://?v=1&artifactId=...&server=https%3A%2F%2Fexample.com%2Fpulsevault&token=secret
 ```
 
 ## Tests

--- a/src/app.ts
+++ b/src/app.ts
@@ -249,8 +249,7 @@ function composeValidatePayload(
 ): PulseVaultValidatePayload | undefined {
   if (!legacyProject) return generic;
   return async (request, ctx) => {
-    const kind = (ctx as typeof ctx & { kind?: UploadKind }).kind;
-    if (kind === "project") {
+    if (ctx.kind === "project") {
       await legacyProject(request, ctx);
       return;
     }

--- a/src/lib/checksum.ts
+++ b/src/lib/checksum.ts
@@ -65,9 +65,7 @@ export function createChecksumValidator(
   next?: PulseVaultValidatePayload,
 ): PulseVaultValidatePayload {
   return async (request, ctx) => {
-    const checksum = parseChecksumMetadata(
-      (ctx as typeof ctx & { checksum?: string }).checksum,
-    );
+    const checksum = parseChecksumMetadata(ctx.checksum);
     if (checksum) {
       if (!ctx.localPath) {
         throw checksumError(
@@ -96,9 +94,7 @@ export function createS3ChecksumValidator(
   next?: PulseVaultValidatePayload,
 ): PulseVaultValidatePayload {
   return async (request, ctx) => {
-    const checksum = parseChecksumMetadata(
-      (ctx as typeof ctx & { checksum?: string }).checksum,
-    );
+    const checksum = parseChecksumMetadata(ctx.checksum);
     if (checksum) {
       const bytes = await storage.readAll(ctx.artifactId);
       if (!bytes) {

--- a/src/lib/magic.ts
+++ b/src/lib/magic.ts
@@ -2,12 +2,13 @@ import fs from "node:fs/promises";
 import type { FastifyRequest } from "fastify";
 import type { LocalStorage } from "../storage/local.js";
 import type { S3Storage } from "../storage/s3.js";
+import type { UploadKind } from "../storage/types.js";
 
 /**
  * Optional plugin-level hook: after TUS writes the final byte but before the
  * upload is marked ready (or the consumer's `onUploadComplete` runs),
  * validate the payload bytes. Throw to reject — the plugin translates the
- * throw into a 422 response, calls `storage.remove?.(videoid)` to free the
+ * throw into a 422 response, calls `storage.remove?.(artifactId)` to free the
  * disk, and never flips the sidecar to `"ready"`.
  *
  * The `localPath` field is populated for adapters that expose
@@ -21,8 +22,12 @@ export type PulseVaultValidatePayload = (
     artifactId: string;
     size: number;
     uploadId: string;
+    /** Which artifact kind this upload is. Runs for every kind — branch on this if you only want a check applied to one. */
+    kind: UploadKind;
     /** Absolute local path to the finalized bytes, or `null` if unavailable. */
     localPath: string | null;
+    /** Client-supplied `<algorithm>:<hex>` digest, if `Upload-Metadata.checksum` was sent. */
+    checksum?: string;
   },
 ) => void | Promise<void>;
 

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -214,7 +214,7 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
             localPath: await resolveLocalPath(storage, artifactId),
             ...(checksum ? { checksum } : {}),
             kind,
-          } as Parameters<PulseVaultValidatePayload>[1] & { kind: UploadKind; checksum?: string });
+          });
         } catch (err) {
           const status = statusCodeOf(err, 422);
           const message =


### PR DESCRIPTION
## Summary

An audit of the docs against the current code (post artifact-protocol rework) turned up several inaccuracies, plus one place where the published type was actually too narrow for the documented/runtime behavior:

- `PulseVaultValidatePayload`'s exported ctx type omitted `kind`/`checksum`, even though both are present at runtime and documented in the README — every internal caller had to cast around it. Widened the type and dropped the now-redundant casts.
- CHANGELOG called the metadata cache "LRU-evicting"; it's actually insertion-order eviction (a read never refreshes position).
- `GET /capabilities`'s `checksum.algorithms` is always the full supported list regardless of whether the operator actually wired a checksum validator into `validatePayload` — documented that caveat in both README and PROTOCOL.md, and aligned PROTOCOL.md's example response with what the reference implementation actually returns.
- The README's deep-link example showed an encoded output that dropped the `/pulsevault` prefix path segment present in its own input.
- `parseChecksumMetadata` was exported but undocumented anywhere.
- CHANGELOG's `[Unreleased]` compare link pointed at a `v0.0.2` tag that never existed.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 61/61 passing