### PR TITLE
Fix authorize() artifactId resolution and refresh the Fastify demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ just by reading this package's source. It bundles several breaking changes
 into one release rather than spreading them across several; see "Upgrading"
 in `OPERATIONS.md` for the migration path.
 
+### Security
+
+The `videoid` → `artifactId` / generic-route rework above introduced two
+related authorization bugs in `core.ts`'s `PATCH`/`HEAD` handling. Both are
+fixed in this same release; upgrade before this reaches a published version
+if you've evaluated against an intermediate build.
+
+- **`authorize` was never actually invoked for `PATCH`/`HEAD`/in-flight-`DELETE`
+  under `{prefix}/upload/<id>`**, regardless of configuration — including the
+  built-in `createCapabilityAuthorize`. The helper that recovered an
+  artifactId from the tus resource URL for the `authorize` context assumed
+  the wrong shape for the current `<kind>/<artifactId><ext>` tus id and never
+  successfully extracted a UUID, so the "no artifactId, so allow" fallback
+  silently took over on every such request. Since an artifactId is not a
+  secret (it's carried in the pairing deep link/QR code by design, per
+  `PROTOCOL.md` §3), this let anyone who had seen a pairing link write bytes
+  into that upload with no token at all. Fixed by resolving the artifactId
+  through the same parser the actual upload-completion path uses, and by
+  making authorization-context resolution failure a hard reject rather than
+  a silent allow (`PROTOCOL.md` §5.2).
+- **A crafted multi-segment `PATCH` URL could write bytes to a different
+  artifact than the one `authorize()` checked.** The `authorize`-context URL
+  parser took the first path segment after `/upload/`, while `@tus/server`'s
+  own request routing (which decides what's actually read/written) takes the
+  URL's last segment — a divergence exploitable via extra path segments
+  (accepted by the `/upload/*` wildcard route). A party holding a valid
+  token for their own artifact could append a second, victim artifactId as a
+  trailing segment: `authorize()` saw and approved their own id, while the
+  request body landed on the victim's file. Fixed by resolving the
+  authorization-context artifactId via the exact same last-segment
+  extraction `@tus/server` itself uses (`PROTOCOL.md` §4.4, a new normative
+  requirement on server implementations generally, not just this package).
+- Both are covered by new regression tests in `test/plugin.test.mjs` that
+  fail against the pre-fix code and pass against the fix.
+
 ### Breaking
 
 - **Renamed `videoid` → `artifactId`** across the storage interface
@@ -97,6 +132,10 @@ in `OPERATIONS.md` for the migration path.
   adapters (`metaCacheLimit` option, default 10,000 entries) — previously
   unbounded for the life of the process.
 - `S3Storage.readAll` — full-object read, used by `createS3ChecksumValidator`.
+- `S3Storage.digestAll` — streams a finalized object through a hash digest
+  without buffering the whole thing into memory first; the streaming
+  counterpart to `readAll`, now used internally by
+  `createS3ChecksumValidator` (see "Fixed" below).
 
 ### Fixed
 
@@ -118,5 +157,21 @@ in `OPERATIONS.md` for the migration path.
   resolution. Verified against a real Meteor 3.4 app: `WebApp.connectHandlers`
   resolves `@mieweb/pulsevault/core` cleanly and a full TUS
   create → PATCH → GET round-trip works.
+- **Unbounded memory use during checksum validation.** `createChecksumValidator`
+  read the whole finalized file into a single `Buffer` via `fs.readFile`
+  before hashing; combined with the documented-supported `maxUploadSize:
+  Infinity`, a large upload could exhaust process memory just to verify its
+  checksum. Now streams the file through the hash via `createReadStream` +
+  a stream pipeline. `createS3ChecksumValidator` had the same issue via
+  `S3Storage.readAll`'s full-object buffer — now uses the new streaming
+  `S3Storage.digestAll` instead.
+- **Silent TOCTOU on S3-compatible backends without `IfNoneMatch` support.**
+  `reserveUpload`'s conditional-write collision guard falls back to a
+  weaker check-then-write on backends that reject `IfNoneMatch` (some
+  S3-compatible stores, and the `s3rver` mock this repo's own test suite
+  runs against) — this reopens the race between concurrent/retried creates
+  for the same artifactId. There's no way to close it without an external
+  lock, so this is now at least surfaced: a one-time `console.warn` fires
+  per process the first time a deployment falls into this degraded mode.
 
 [Unreleased]: https://github.com/mieweb/pulsevault/compare/v0.0.1...HEAD

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -61,6 +61,26 @@ instance talks to the same bucket, so it scales horizontally with zero
 additional configuration. Prefer it for any multi-instance deployment unless
 you have a specific reason to use local disk.
 
+### S3-compatible backend collision-guard fallback
+
+`reserveUpload`'s collision guard normally uses `PutObjectCommand`'s
+`IfNoneMatch: "*"` to atomically reject a second create for an artifactId
+that already has an upload. Some S3-compatible backends (older/less-complete
+implementations; the `s3rver` mock this package's own test suite runs
+against) don't support conditional writes and reject that header outright.
+On those backends, `reserveUpload` falls back to a weaker check-then-write —
+functionally the same guard, but with the original race reopened: two
+truly concurrent (or retried) creates for the same artifactId can both pass
+the check before either writes, and the second silently clobbers the
+first's metadata. There's no way to close this without an external lock,
+since it's a limitation of the backend, not this package. If your bucket
+provider doesn't support `IfNoneMatch`, this fallback logs a one-time
+`console.warn` per process the first time it's used — treat that warning as
+a signal to either move to a backend that supports conditional writes, or
+serialize artifactId creation yourself (e.g. in your own `/reserve`
+endpoint) if concurrent creates for the same id are a real possibility in
+your deployment.
+
 ## Resource limits and abuse prevention
 
 `pulsevault` does not implement rate limiting or a concurrent-upload cap

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -144,6 +144,43 @@ offset before resuming an interrupted upload — it MUST NOT trust a locally
 cached byte count, which can be stale (server restart, a partial write that
 never committed, clock differences between client and a previous session).
 
+### 4.3 `Location` header validation
+
+The TUS spec permits the `POST /upload` response's `Location` header to be
+absolute or relative, and takes no position on where it may point. A client
+MUST resolve `Location` against the request's own origin and MUST reject
+(rather than follow) a result whose origin differs from the server it is
+already talking to. Without this check, a malicious or compromised server
+could return an absolute `Location` on a different host and receive every
+subsequent `HEAD`/`PATCH`/`DELETE` request for that upload — each carrying
+the bearer token per §5.1 — redirecting the credential to that host instead.
+This is the "token redirect" threat named in
+[RFC 6750 §10.4](https://datatracker.ietf.org/doc/html/rfc6750#section-10.4)
+(a bearer token accepted by, or in this case sent to, a party other than the
+one it was issued for) and matches the same-origin validation
+[OWASP recommends](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)
+for any server-supplied redirect target before resending credentials.
+
+### 4.4 Consistent request routing (server-side)
+
+A server implementation MUST resolve which artifact a `PATCH`/`HEAD`/`DELETE`
+request under `{prefix}/upload/<id>` applies to the same way for every
+purpose within that request — the identifier an authorization check is run
+against MUST be the exact identifier the request is actually applied to. A
+server MUST NOT use one code path (e.g. a hand-rolled URL parser feeding an
+`authorize` hook) to decide "which artifact is this for" and a different code
+path (e.g. an underlying TUS library's own request routing) to decide "which
+artifact do I actually read or write" — any divergence between the two lets a
+party authorized for one artifact write to, or probe, a different artifact
+they are not authorized for, by exploiting a URL shape the two parsers
+disagree on (e.g. extra path segments after the real id, which many routers
+accept on a wildcard route). Where a server is layered over an existing TUS
+implementation, resolve the identifier for authorization by calling that
+library's own identifier-resolution logic directly (or an exact copy of it)
+rather than an independent reimplementation — two parsers that happen to
+agree on well-formed requests can still silently disagree on adversarial
+ones.
+
 ## 5. Authentication
 
 ### 5.1 Token transport
@@ -152,14 +189,24 @@ A client MUST send the pairing token as `Authorization: Bearer <token>` on
 every `POST`/`PATCH`/`DELETE` request to `{prefix}/upload*`, and SHOULD also
 send it as `?token=` on `GET` requests to a watch/playback URL (some servers
 validate playback links without requiring a header, e.g. for browser
-playback).
+playback). See §4.3 for why the resource URL these requests target must
+itself be validated before the token is attached to a request against it.
 
 ### 5.2 Server-side verification
 
 A server MAY implement authentication however it chooses — this document
 does not mandate a scheme. A server MUST reject requests it cannot authorize
 with `403` (or `401` if no credential was presented at all), and SHOULD do
-so before any bytes are accepted for a new upload.
+so before any bytes are accepted for a new upload. This applies uniformly to
+every phase of an upload's lifecycle — creation, each `PATCH` chunk, `HEAD`
+offset queries, and `DELETE` (both the in-flight-cancel route and the
+finalized-artifact route) — not only to the initial `POST`. A server
+implementation MUST NOT skip authorization for `PATCH`/`HEAD` merely because
+an internal helper failed to recover the artifactId from the resource URL;
+that failure MUST be treated as an authorization failure (reject), not as
+"no artifactId to check, so allow." See §4.4 for the related requirement
+that the artifactId resolved for this check must be the one the request is
+actually applied to.
 
 ### 5.3 Rejection responses
 

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ Credentials are optional — omit `accessKeyId`/`secretAccessKey` to use the AWS
 
 ### Payload validation on remote storage
 
-The default `createMp4Sniffer`/`createChecksumValidator` read a local file path, which doesn't exist for a bucket object. Use **`createS3Mp4Sniffer(storage)`**/**`createS3ChecksumValidator(storage)`** instead: they fetch the bytes they need via the adapter (a small ranged GET for the MP4 sniff; a full object read for the checksum, since a digest needs every byte) rather than assuming a local path.
+The default `createMp4Sniffer`/`createChecksumValidator` read a local file path, which doesn't exist for a bucket object. Use **`createS3Mp4Sniffer(storage)`**/**`createS3ChecksumValidator(storage)`** instead: they fetch the bytes they need via the adapter (a small ranged GET for the MP4 sniff; a full object download for the checksum, since a digest needs every byte — streamed through the hash via `storage.digestAll` rather than buffered into memory at once) rather than assuming a local path.
 
 ### Direct playback & CORS
 

--- a/examples/rn-demo/.env.example
+++ b/examples/rn-demo/.env.example
@@ -10,10 +10,32 @@
 # Port / host the demo listens on.
 PORT=3000
 HOST=0.0.0.0
-# Optional bearer token. When set, every TUS upload must send
-# `Authorization: Bearer <DEMO_TOKEN>` and every watch URL must carry
-# `?token=<DEMO_TOKEN>`. Leave unset for an open demo.
-DEMO_TOKEN=
+
+# ---------------------------------------------------------------------------
+# Capability-token auth (the library's secure-by-default option — see
+# PROTOCOL.md §5.4 / README "Capability tokens"). Leave PULSEVAULT_SECRET
+# unset for an open demo with no auth at all, same as before.
+# ---------------------------------------------------------------------------
+# Set this to turn auth on. Every upload/watch then requires a real
+# HMAC-signed, per-artifact, expiring token minted by issueCapabilityToken and
+# checked by createCapabilityAuthorize — never hard-code a real secret here,
+# this file is committed; generate one with e.g. `openssl rand -hex 32`.
+PULSEVAULT_SECRET=
+# Key id the secret above is signed under. Lets you rotate secrets later by
+# adding a new PULSEVAULT_SECRET under a new kid while this one still verifies
+# tokens issued earlier, instead of invalidating every outstanding token at
+# once (see OPERATIONS.md "Secrets management").
+PULSEVAULT_KEY_ID=demo-1
+# REQUIRED for phones on your LAN once PULSEVAULT_SECRET is set — must be the
+# exact origin your phone/browser will actually reach this server at (a
+# token's `issuer` claim is checked for exact string equality, not derived
+# per-request). Find your LAN IP with `ipconfig getifaddr en0` (macOS) or
+# `hostname -I` (Linux), e.g.:
+#   PULSEVAULT_ISSUER=http://192.168.1.23:3000
+# If left unset, the server falls back to http://localhost:PORT (and prints
+# the same LAN-IP hint at startup) — fine for a desktop browser on this same
+# machine, but a phone on the same WiFi won't be able to redeem its tokens.
+PULSEVAULT_ISSUER=
 
 # ---------------------------------------------------------------------------
 # Storage backend

--- a/examples/rn-demo/public/index.html
+++ b/examples/rn-demo/public/index.html
@@ -3,79 +3,260 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>PulseVault demo</title>
+    <title>PulseVault — Reference Server</title>
     <style>
-      :root { font-family: system-ui, sans-serif; background: #0f1419; color: #e6edf3; }
-      body { max-width: 44rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.5; }
-      h1 { font-size: 1.25rem; font-weight: 600; margin: 0; }
-      .card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 1rem 1.25rem; margin-top: 1rem; }
-      .open-btn { display: block; padding: 0.6rem 1.2rem; font-size: 0.9rem; font-weight: 600; color: #fff; background: #238636; border-radius: 6px; text-align: center; text-decoration: none; margin-bottom: 0.75rem; }
-      .open-btn:hover { background: #2ea043; }
-      .mono { font-family: ui-monospace, monospace; font-size: 0.75rem; word-break: break-all; color: #8b949e; }
-      label { display: block; font-size: 0.875rem; color: #8b949e; margin-bottom: 0.25rem; }
-      .ghost-btn { display: block; width: 100%; padding: 0.5rem; margin-bottom: 0.75rem; font-size: 0.875rem; background: #161b22; color: #8b949e; border: 1px solid #30363d; border-radius: 6px; cursor: pointer; }
-      .top-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
-      .docs-link { display: inline-block; margin: 0; padding: 0.35rem 0.7rem; font-size: 0.75rem; background: #1f6feb; color: #fff; border-radius: 6px; text-decoration: none; font-weight: 600; }
-      .auth-badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 999px; font-size: 0.7rem; font-weight: 600; background: #1f2937; border: 1px solid #30363d; color: #8b949e; }
-      .auth-badge.on { background: #1d3a1d; border-color: #2ea043; color: #b9e6b9; }
+      :root {
+        --bg: #0a0e16;
+        --surface: #11161f;
+        --surface-2: #161c28;
+        --border: #232a38;
+        --text: #e7eaf0;
+        --text-2: #9aa4b8;
+        --text-3: #626d82;
+        --accent: #5b8cff;
+        --accent-soft: rgba(91, 140, 255, 0.14);
+        --success: #34d399;
+        --success-soft: rgba(52, 211, 153, 0.14);
+        --warning: #fbbf24;
+        --warning-soft: rgba(251, 191, 36, 0.14);
+        --danger: #f87171;
+        --danger-soft: rgba(248, 113, 113, 0.14);
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Inter, Roboto, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+      }
+      * { box-sizing: border-box; min-width: 0; }
+      html { overflow-x: hidden; }
+      body { max-width: 46rem; margin: 0 auto; padding: 2rem 1.25rem 4rem; line-height: 1.5; overflow-x: hidden; }
+
+      .eyebrow { font-size: 0.7rem; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--text-3); margin: 0 0 0.6rem; }
+      h1 { font-size: 1.05rem; font-weight: 700; margin: 0; letter-spacing: -0.01em; }
+      h2 { font-size: 0.95rem; font-weight: 600; margin: 0; }
+
+      .brand-row { display: flex; align-items: center; gap: 0.6rem; min-width: 0; }
+      .brand-mark { width: 1.9rem; height: 1.9rem; border-radius: 7px; background: linear-gradient(135deg, var(--accent), #7c5cff); display: flex; align-items: center; justify-content: center; font-weight: 800; font-size: 0.85rem; flex: none; }
+      .brand-sub { font-size: 0.75rem; color: var(--text-3); margin: 0.1rem 0 0; }
+      .top-row { display: flex; align-items: center; justify-content: space-between; gap: 0.75rem; flex-wrap: wrap; }
+
+      /* A sequence diagram with 3 participants routinely renders wider than a phone screen —
+         scroll it horizontally rather than letting it force the whole page to scroll, or
+         shrinking it down to illegible. */
+      .diagram-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; margin: 0 0 0.75rem; }
+      .diagram-wrap .mermaid { min-width: 460px; }
+      .diagram-caption { font-size: 0.72rem; font-weight: 600; color: var(--text-3); margin: 0 0 0.4rem; }
+
+      @media (max-width: 480px) {
+        body { padding: 1.25rem 1rem 3rem; }
+        .brand-mark { width: 1.7rem; height: 1.7rem; font-size: 0.75rem; }
+        h1 { font-size: 0.95rem; }
+        .brand-sub { font-size: 0.68rem; }
+        .docs-link { font-size: 0.68rem; padding: 0.35rem 0.6rem; }
+        .beat-row video { width: 8.5rem; max-height: 11rem; }
+        footer { flex-direction: column; align-items: flex-start; gap: 0.35rem; }
+      }
+
+      .docs-link { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.4rem 0.75rem; font-size: 0.75rem; font-weight: 600; background: var(--surface-2); border: 1px solid var(--border); color: var(--text-2); border-radius: 6px; text-decoration: none; }
+      .docs-link:hover { border-color: var(--accent); color: var(--text); }
+
+      .status-bar { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 1.25rem; }
+      .chip { display: flex; align-items: center; gap: 0.4rem; padding: 0.35rem 0.7rem; background: var(--surface); border: 1px solid var(--border); border-radius: 999px; font-size: 0.75rem; color: var(--text-2); }
+      .chip b { color: var(--text); font-weight: 600; }
+      .dot { width: 0.45rem; height: 0.45rem; border-radius: 999px; background: var(--text-3); flex: none; }
+      .dot.success { background: var(--success); box-shadow: 0 0 0 3px var(--success-soft); }
+      .dot.warning { background: var(--warning); box-shadow: 0 0 0 3px var(--warning-soft); }
+      .dot.off { background: var(--text-3); }
+
+      section { margin-top: 1.75rem; }
+      .panel { background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 1.1rem 1.25rem; box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35); }
+
+      .btn { display: block; width: 100%; padding: 0.55rem 1rem; font-size: 0.85rem; font-weight: 600; border-radius: 7px; text-align: center; text-decoration: none; cursor: pointer; border: 1px solid transparent; }
+      .btn-primary { color: #fff; background: var(--accent); margin-bottom: 0.6rem; }
+      .btn-primary:hover { background: #4a7bef; }
+      .btn-ghost { background: var(--surface-2); color: var(--text-2); border-color: var(--border); }
+      .btn-ghost:hover { color: var(--text); border-color: var(--accent); }
+      .btn-sm { width: auto; padding: 0.3rem 0.65rem; font-size: 0.72rem; }
+
+      .mono { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 0.72rem; word-break: break-all; color: var(--text-3); }
+      label { display: block; font-size: 0.72rem; font-weight: 600; letter-spacing: 0.03em; text-transform: uppercase; color: var(--text-3); margin: 0.7rem 0 0.2rem; }
+      label:first-of-type { margin-top: 0; }
+
+      details summary { cursor: pointer; list-style: none; }
+      details summary::-webkit-details-marker { display: none; }
+      details.panel summary { font-weight: 600; font-size: 0.85rem; display: flex; align-items: center; gap: 0.4rem; }
+      details.panel summary::before { content: "▸"; color: var(--text-3); font-size: 0.7rem; }
+      details.panel[open] summary::before { content: "▾"; }
+      details.panel[open] summary { margin-bottom: 0.9rem; }
+      details:not(.panel) summary { font-size: 0.72rem; color: var(--text-3); font-weight: 600; margin-top: 0.5rem; }
+      details:not(.panel) summary::before { content: "▸ "; }
+      details:not(.panel)[open] summary::before { content: "▾ "; }
+
+      .feature-list { margin: 0; padding: 0; list-style: none; font-size: 0.8rem; color: var(--text-2); }
+      /* Deliberately NOT display:flex — this <li> mixes plain text with inline <code>/<em> tags
+         that need to wrap normally. Flex would treat each text run/tag as its own flex item
+         (stretched to the row's cross-axis height by default), breaking natural text flow into
+         overlapping columns instead of wrapped paragraphs. An absolutely-positioned marker keeps
+         normal inline flow intact. */
+      .feature-list li { position: relative; padding: 0.4rem 0 0.4rem 1.1rem; border-top: 1px solid var(--border); }
+      .feature-list li:first-child { border-top: none; }
+      .feature-list li::before { content: "→"; color: var(--accent); position: absolute; left: 0; top: 0.4rem; }
+      code { background: var(--surface-2); border: 1px solid var(--border); border-radius: 4px; padding: 0.05rem 0.3rem; font-size: 0.85em; }
+
+      .badge { display: inline-flex; align-items: center; gap: 0.3rem; padding: 0.2rem 0.55rem; border-radius: 999px; font-size: 0.68rem; font-weight: 600; background: var(--surface-2); border: 1px solid var(--border); color: var(--text-2); }
+      .badge.on { background: var(--success-soft); border-color: rgba(52, 211, 153, 0.35); color: var(--success); }
+
+      .pulse-card { padding: 0.9rem 0; border-top: 1px solid var(--border); }
+      .pulse-card:first-child { border-top: none; padding-top: 0; }
+      .beat-row { display: flex; gap: 0.6rem; overflow-x: auto; padding-bottom: 0.4rem; -webkit-overflow-scrolling: touch; scroll-snap-type: x proximity; }
+      .beat-row video { scroll-snap-align: start; }
+      .beat-row video { width: 10.5rem; max-height: 13rem; border-radius: 7px; background: #000; flex: none; border: 1px solid var(--border); }
+      .pulse-meta { display: flex; align-items: center; gap: 0.4rem; flex-wrap: wrap; margin: 0.6rem 0 0; }
+
+      .event-row { display: flex; gap: 0.6rem; align-items: center; font-size: 0.76rem; padding: 0.35rem 0; border-top: 1px solid var(--border); }
+      .event-row:first-child { border-top: none; }
+      .event-phase { flex: none; width: 5rem; font-weight: 600; display: flex; align-items: center; gap: 0.4rem; color: var(--text-2); }
+      #eventList { max-height: 12rem; overflow-y: auto; }
+      #eventList::-webkit-scrollbar, #pulseList::-webkit-scrollbar { width: 6px; }
+      #eventList::-webkit-scrollbar-thumb, #pulseList::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
+
+      footer { margin-top: 2.5rem; padding-top: 1.25rem; border-top: 1px solid var(--border); font-size: 0.72rem; color: var(--text-3); display: flex; justify-content: space-between; flex-wrap: wrap; gap: 0.35rem; }
+      footer a { color: var(--text-3); word-break: break-all; }
     </style>
   </head>
   <body>
     <div class="top-row">
-      <h1>PulseVault demo</h1>
-      <a href="/docs" class="docs-link">API Docs →</a>
-    </div>
-    <p style="font-size: 0.9rem; color: #8b949e;">
-      <span id="authBadge" class="auth-badge">auth: off</span>
-      Pair the Pulse app with this demo server and upload a video.
-    </p>
-
-    <div class="card">
-      <strong>Upload</strong>
-      <p style="font-size: 0.875rem; color: #8b949e; margin: 0.5rem 0 0;">
-        Each scan opens the chooser in the Pulse app: record a new video, or
-        pick an existing draft to upload to this server.
-      </p>
-
-      <img id="qrUpload" width="224" height="224" style="display: block; margin: 1.25rem auto; border-radius: 8px; background: #fff; padding: 10px;" />
-
-      <a id="openBtnUpload" class="open-btn" href="#">Open in Pulse app</a>
-      <button id="refreshUpload" class="ghost-btn">↻ New QR</button>
-
-      <label>Server</label>
-      <p class="mono" id="serverUrl"></p>
-
-      <label>Artifact ID</label>
-      <p class="mono" id="uploadArtifactId"></p>
-
-      <label>Deep link</label>
-      <p class="mono" id="deeplinkUpload"></p>
-    </div>
-
-    <div id="authHelp" class="card" hidden>
-      <strong>Auth demo enabled</strong>
-      <p style="font-size: 0.875rem; color: #8b949e; margin: 0.5rem 0 0;">
-        This server requires a bearer token for every upload and watch request.
-        The QR above embeds it, so the Pulse app handles auth automatically.
-        Tampering with the token in the deeplink should produce a 403 from
-        <code>authorize</code>. To disable, restart the server without
-        <code>DEMO_TOKEN</code> set.
-      </p>
-    </div>
-
-    <div class="card">
-      <div class="top-row">
-        <strong>Uploads</strong>
-        <button id="refreshVideos" class="ghost-btn" style="width: auto; margin: 0; padding: 0.3rem 0.7rem;">↻ Refresh</button>
+      <div class="brand-row">
+        <div class="brand-mark">PV</div>
+        <div>
+          <h1>PulseVault</h1>
+          <p class="brand-sub">Reference server · Fastify</p>
+        </div>
       </div>
-      <div id="videoList" style="margin-top: 0.75rem; max-height: 48rem; overflow-y: auto; padding-right: 0.25rem;">
-        <p class="mono">Loading…</p>
-      </div>
+      <a href="/docs" class="docs-link">API Reference ↗</a>
     </div>
 
+    <div class="status-bar" id="statusBar"></div>
+
+    <section>
+      <details class="panel">
+        <summary>How this works</summary>
+        <p class="diagram-caption">Deployment model — this server is one fully independent "Org", no central Pulse service involved</p>
+        <div class="diagram-wrap">
+          <pre class="mermaid">
+graph LR
+    subgraph thisOrg ["This server — fully independent"]
+        A1["This Fastify server"] -->|registers| A2["@mieweb/pulsevault"]
+        A1 -->|owns| A3["artifactId minting, token issuance,<br/>TTL policy, secret rotation, revocation"]
+    end
+    subgraph otherOrg ["Any other org — fully independent, no pulsevault required"]
+        B1["Their own server"] -->|implements from spec only| B2["PROTOCOL.md"]
+        B1 -->|owns| B3["its own auth scheme entirely"]
+    end
+    P["Pulse mobile app<br/>multi-tenant client"] -->|pairs + uploads via open contract| A1
+    P -->|pairs + uploads via open contract| B1
+    P -.->|no dependency on either| X[("No central Pulse service")]
+          </pre>
+        </div>
+        <p class="diagram-caption">Pairing + upload flow — what happens once you scan the QR below</p>
+        <div class="diagram-wrap">
+          <pre class="mermaid">
+sequenceDiagram
+    participant Org as This server
+    participant User
+    participant Pulse as Pulse app
+
+    Org->>Org: mint artifactId + issue a token
+    Org->>User: show QR / deep link
+    User->>Pulse: open link
+    Pulse->>Pulse: validate link, show pairing screen
+    User->>Pulse: confirm and choose draft
+    Pulse->>Org: POST upload, Bearer token, kind video, checksum
+    Org->>Pulse: 201 Location
+    Pulse->>Org: PATCH chunks, HEAD before resume
+    Org->>Org: validatePayload, markReady, onUploadComplete
+    Pulse->>Org: POST upload, kind captions, same session
+    Org->>Org: validatePayload, markReady, onUploadComplete
+    Org->>Pulse: ready for playback and captions fetch
+          </pre>
+        </div>
+        <ul class="feature-list" id="howItWorksList"></ul>
+      </details>
+    </section>
+
+    <section>
+      <p class="eyebrow">Pair a device</p>
+      <div class="panel">
+        <img id="qrUpload" width="200" height="200" style="display: block; margin: 0 auto 1rem; border-radius: 8px; background: #fff; padding: 10px;" />
+        <a id="openBtnUpload" class="btn btn-primary" href="#">Open in Pulse app</a>
+        <button id="refreshUpload" class="btn btn-ghost">↻ Generate new pairing link</button>
+        <details>
+          <summary>Link details</summary>
+          <label>Server</label>
+          <p class="mono" id="serverUrl"></p>
+          <label>Artifact ID (session anchor)</label>
+          <p class="mono" id="uploadArtifactId"></p>
+          <label>Deep link</label>
+          <p class="mono" id="deeplinkUpload"></p>
+        </details>
+      </div>
+    </section>
+
+    <section>
+      <p class="eyebrow">Activity</p>
+      <div class="panel">
+        <div class="top-row">
+          <h2>Live events</h2>
+          <span class="mono" id="eventCount"></span>
+        </div>
+        <div id="eventList" style="margin-top: 0.5rem;"><p class="mono">Loading…</p></div>
+      </div>
+    </section>
+
+    <section>
+      <p class="eyebrow">Recordings</p>
+      <div class="panel">
+        <div class="top-row">
+          <h2 id="pulseCount">Uploads</h2>
+          <button id="refreshPulses" class="btn btn-ghost btn-sm">↻ Refresh</button>
+        </div>
+        <div id="pulseList" style="margin-top: 0.75rem; max-height: 54rem; overflow-y: auto; padding-right: 0.25rem;">
+          <p class="mono">Loading…</p>
+        </div>
+      </div>
+    </section>
+
+    <footer>
+      <span>@mieweb/pulsevault</span>
+      <a href="https://github.com/mieweb/pulsevault" target="_blank" rel="noreferrer">github.com/mieweb/pulsevault</a>
+    </footer>
+
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: "dark" });
+    </script>
     <script>
+      async function loadStatusBar() {
+        const caps = await fetch("/pulsevault/capabilities").then((r) => r.json());
+        window.__caps = caps;
+        renderStatusBar();
+      }
+
+      function renderStatusBar(auth) {
+        const caps = window.__caps;
+        if (!caps) return;
+        const chips = [
+          `<span class="chip"><span class="dot success"></span>Protocol <b>v${caps.protocolVersion}</b></span>`,
+          `<span class="chip">Upload unit <b>${caps.uploadUnit}</b></span>`,
+          window.__storage ? `<span class="chip">Storage <b>${window.__storage}</b></span>` : "",
+          auth
+            ? `<span class="chip"><span class="dot ${auth.authMode ? "success" : "off"}"></span>Auth <b>${auth.authMode ? `capability tokens (${auth.keyId})` : "open"}</b></span>`
+            : "",
+        ].filter(Boolean);
+        document.getElementById("statusBar").innerHTML = chips.join("");
+      }
+
       async function loadDeeplinks() {
         const data = await fetch("/deeplinks").then((r) => r.json());
+        window.__storage = data.storage;
 
         document.getElementById("serverUrl").textContent = window.location.origin;
         document.getElementById("uploadArtifactId").textContent = data.artifactId;
@@ -83,10 +264,17 @@
         document.getElementById("openBtnUpload").href = data.upload;
         document.getElementById("qrUpload").src = data.qrUpload;
 
-        const badge = document.getElementById("authBadge");
-        badge.textContent = data.authMode ? "auth: on" : "auth: off";
-        badge.classList.toggle("on", data.authMode);
-        document.getElementById("authHelp").hidden = !data.authMode;
+        renderStatusBar(data);
+
+        const items = [
+          data.authMode
+            ? `Capability tokens: HMAC-signed by <code>issueCapabilityToken</code>, scoped to this session, expiring in ${Math.round(data.tokenExpiresInSeconds / 60)} min (issuer <code>${data.issuer}</code>). One token covers every beat/caption/manifest via <code>relatedTo</code>.`
+            : `Capability tokens: off — set <code>PULSEVAULT_SECRET</code> to turn on real HMAC-signed, expiring, per-session tokens.`,
+          `Checksum: the app's sha256 is verified server-side before an upload is marked ready (<code>createChecksumValidator</code>).`,
+          `Live activity below is fed by <code>onArtifactEvent</code> — the same hook used for ops metrics + audit logging.`,
+          `Uploads are grouped by <em>pulse</em> (recording session) via the wire protocol's <code>relatedTo</code> field, not listed as unrelated files.`,
+        ];
+        document.getElementById("howItWorksList").innerHTML = items.map((i) => `<li>${i}</li>`).join("");
       }
 
       function formatSize(bytes) {
@@ -96,27 +284,76 @@
         return `${n.toFixed(n < 10 && i > 0 ? 1 : 0)} ${units[i]}`;
       }
 
-      async function loadVideos() {
-        const list = document.getElementById("videoList");
-        const videos = await fetch("/videos").then((r) => r.json());
-        if (!videos.length) {
+      function pulseCard(p) {
+        const beatVideos = p.beats
+          .map(
+            (b) => `
+              <video src="${b.playbackUrl}" controls preload="metadata">
+                ${b.captions ? `<track kind="subtitles" src="${b.captions.vttUrl}" srclang="en" label="Captions" default>` : ""}
+              </video>`,
+          )
+          .join("");
+
+        const captionsCount = p.beats.filter((b) => b.captions).length + p.unmatchedCaptions.length;
+        const checksumCount = p.beats.filter((b) => b.checksumVerified).length;
+
+        const badges = [
+          `<span class="badge">${p.mode === "beat" ? `${p.beats.length} beat${p.beats.length === 1 ? "" : "s"}` : "merged video"}</span>`,
+          p.manifest ? `<span class="badge">relatedTo-linked</span>` : "",
+          captionsCount ? `<span class="badge">${captionsCount} caption track${captionsCount === 1 ? "" : "s"}</span>` : "",
+          checksumCount ? `<span class="badge on">✓ checksum verified</span>` : "",
+        ].filter(Boolean).join("");
+
+        return `
+          <div class="pulse-card">
+            <div class="beat-row">${beatVideos}</div>
+            <div class="pulse-meta">${badges}</div>
+            <p class="mono" style="margin: 0.5rem 0 0;">
+              ${new Date(p.creation_date).toLocaleString()} · ${p.anchorArtifactId}
+            </p>
+          </div>`;
+      }
+
+      async function loadPulses() {
+        const list = document.getElementById("pulseList");
+        const pulses = await fetch("/pulses").then((r) => r.json());
+        document.getElementById("pulseCount").textContent = pulses.length ? `Uploads (${pulses.length})` : "Uploads";
+        if (!pulses.length) {
           list.innerHTML = '<p class="mono">No uploads yet.</p>';
           return;
         }
-        list.innerHTML = videos.map((v) => `
-          <div style="margin-bottom: 1rem; padding-bottom: 1rem; border-bottom: 1px solid #30363d;">
-            <video src="/pulsevault/artifacts/${v.artifactId}" controls preload="metadata" style="width: 100%; max-height: 26rem; border-radius: 6px; background: #000; display: block; object-fit: contain;"></video>
-            <p class="mono" style="margin: 0.4rem 0 0;">${v.filename}</p>
-            <p class="mono" style="margin: 0.15rem 0 0; color: #6e7681;">${formatSize(v.size)} • ${new Date(v.creation_date).toLocaleString()}</p>
-            <p class="mono" style="margin: 0.15rem 0 0; color: #6e7681;">${v.artifactId}</p>
-          </div>
-        `).join("");
+        list.innerHTML = pulses.map(pulseCard).join("");
       }
 
+      function eventRow(e) {
+        const cls = e.phase === "complete" ? "success" : e.phase === "reject" ? "warning" : "off";
+        const detail = e.reason ? ` — ${e.reason}` : e.size != null ? ` — ${formatSize(e.size)}` : "";
+        return `
+          <div class="event-row">
+            <span class="event-phase"><span class="dot ${cls}"></span>${e.phase}</span>
+            <span class="mono">${e.kind}/${e.artifactId.slice(0, 8)}…${detail}</span>
+            <span class="mono" style="margin-left: auto;">${new Date(e.at).toLocaleTimeString()}</span>
+          </div>`;
+      }
+
+      async function loadEvents() {
+        const events = await fetch("/events").then((r) => r.json());
+        document.getElementById("eventCount").textContent = events.length ? `${events.length} recent` : "";
+        document.getElementById("eventList").innerHTML = events.length
+          ? events.map(eventRow).join("")
+          : '<p class="mono">Nothing yet — pair and upload to see events appear here.</p>';
+      }
+
+      loadStatusBar();
       loadDeeplinks();
-      loadVideos();
+      loadPulses();
+      loadEvents();
       document.getElementById("refreshUpload").addEventListener("click", loadDeeplinks);
-      document.getElementById("refreshVideos").addEventListener("click", loadVideos);
+      document.getElementById("refreshPulses").addEventListener("click", loadPulses);
+      // Live-ish feed: poll rather than hold a socket open, since this is a demo page, not
+      // something that needs to survive a flaky connection.
+      setInterval(loadEvents, 3000);
+      setInterval(loadPulses, 8000);
     </script>
   </body>
 </html>

--- a/examples/rn-demo/server.mjs
+++ b/examples/rn-demo/server.mjs
@@ -1,4 +1,5 @@
 import path from "node:path";
+import os from "node:os";
 import { readFileSync } from "node:fs";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
@@ -13,16 +14,86 @@ import pulseVault, {
   createMp4Sniffer,
   createS3Storage,
   createS3Mp4Sniffer,
+  createChecksumValidator,
+  createS3ChecksumValidator,
   buildUploadLink,
+  issueCapabilityToken,
+  verifyCapabilityToken,
+  createCapabilityAuthorize,
 } from "@mieweb/pulsevault";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const html = readFileSync(path.join(__dirname, "public/index.html"), "utf8");
 const dataDir = path.join(__dirname, "data");
 
-// Set DEMO_TOKEN to enable the auth demo: every upload + watch is verified
-// against this token. Leave unset for an open demo with no authentication.
-const DEMO_TOKEN = process.env.DEMO_TOKEN || null;
+const port = Number(process.env.PORT ?? 3000);
+const host = process.env.HOST ?? "0.0.0.0";
+
+// ---------------------------------------------------------------------------
+// Capability-token auth (this demo's "secure-by-default" option — see
+// `PROTOCOL.md` §5.4 and the README's "Capability tokens" section).
+//
+// Unset `PULSEVAULT_SECRET` -> open demo, no auth, same as before. Set it and
+// every upload/watch is gated by a real HMAC-signed, per-artifact, expiring
+// token minted by `issueCapabilityToken` and checked by
+// `createCapabilityAuthorize` — not a hand-rolled comparison.
+// ---------------------------------------------------------------------------
+const PULSEVAULT_SECRET = process.env.PULSEVAULT_SECRET || null;
+const PULSEVAULT_KEY_ID = process.env.PULSEVAULT_KEY_ID || "demo-1";
+const TOKEN_TTL_SECONDS = 30 * 60; // 30 minutes — long enough for one upload session
+const WATCH_TOKEN_TTL_SECONDS = 5 * 60; // short-lived — minted fresh per gallery load, never persisted
+
+/**
+ * A capability token's `issuer` claim is checked for exact string equality
+ * (PROTOCOL.md §5.4) — it has to be the one fixed origin this server issues
+ * tokens under, not derived per-request from whatever `Host` header a client
+ * happened to send (that would make "issuer" meaningless as an identity
+ * check). `PULSEVAULT_ISSUER` is required to set this properly for phones on
+ * your LAN; falls back to localhost (desktop-browser-only testing) with a
+ * loud warning and a list of candidate LAN addresses to copy from.
+ */
+function detectLanIPv4s() {
+  const addrs = [];
+  for (const ifaces of Object.values(os.networkInterfaces())) {
+    for (const iface of ifaces ?? []) {
+      if (iface.family === "IPv4" && !iface.internal) addrs.push(iface.address);
+    }
+  }
+  return addrs;
+}
+
+let ISSUER = process.env.PULSEVAULT_ISSUER || null;
+if (PULSEVAULT_SECRET && !ISSUER) {
+  ISSUER = `http://localhost:${port}`;
+  console.warn(
+    `\nPULSEVAULT_SECRET is set but PULSEVAULT_ISSUER is not — tokens will be issued for ${ISSUER}.`,
+  );
+  console.warn("That only works from a browser/phone on this same machine.");
+  const lan = detectLanIPv4s();
+  if (lan.length) {
+    console.warn("For phones on your LAN, restart with one of:");
+    for (const ip of lan) console.warn(`  PULSEVAULT_ISSUER=http://${ip}:${port}`);
+  }
+  console.warn("");
+}
+
+function lookupSecret(kid) {
+  return kid === PULSEVAULT_KEY_ID ? PULSEVAULT_SECRET : null;
+}
+
+// ---------------------------------------------------------------------------
+// Low-frequency artifact event feed — `onArtifactEvent` fires on authorize
+// rejection, upload completion, and payload-validation rejection (never per
+// chunk). Kept as an in-memory ring buffer so the pairing page can render a
+// small "what's actually happening on this server" live feed — the same
+// events an operator would otherwise only see in structured logs.
+// ---------------------------------------------------------------------------
+const MAX_EVENTS = 60;
+const recentEvents = [];
+function recordEvent(event) {
+  recentEvents.unshift({ ...event, at: new Date().toISOString() });
+  if (recentEvents.length > MAX_EVENTS) recentEvents.length = MAX_EVENTS;
+}
 
 const app = Fastify({
   logger: true,
@@ -63,7 +134,7 @@ app.get(
       tags: ["demo"],
       summary: "Pairing page (HTML)",
       description:
-        "Returns the static pairing UI that renders the upload QR code.",
+        "Returns the static pairing UI that renders the upload QR code, a live artifact-event feed, and the uploads gallery.",
       response: {
         200: {
           description: "HTML pairing page.",
@@ -103,36 +174,105 @@ app.post(
   },
 );
 
-// List all uploads under dataDir. Reads each upload's sidecar to determine
-// kind and subdir rather than hard-coding "video/" — handles video/project/captions.
-const uploadSummarySchema = {
-  type: "object",
-  properties: {
-    artifactId: { type: "string", format: "uuid" },
-    kind: { type: "string", enum: ["video", "project", "captions"], description: "Artifact kind." },
-    filename: { type: "string" },
-    ext: { type: "string" },
-    size: { type: "integer", minimum: 0 },
-    creation_date: { type: "string", format: "date-time" },
-  },
-  required: ["artifactId", "kind", "filename", "ext", "size", "creation_date"],
-};
-
 app.get(
-  "/videos",
+  "/events",
   {
     schema: {
       tags: ["demo"],
-      summary: "List previously uploaded artifacts",
+      summary: "Recent artifact events",
       description:
-        "Enumerates completed uploads on disk by reading each upload's sidecar. Returns both `kind=video` and `kind=project` artifacts.",
-      response: {
-        200: {
-          description: "Uploads sorted by creation time, newest first.",
-          type: "array",
-          items: uploadSummarySchema,
-        },
-      },
+        "The last `onArtifactEvent` firings (authorize rejections, upload completions, validation rejections) — an in-memory feed for the pairing page, not a durable audit log.",
+    },
+  },
+  async (_req, reply) => reply.send(recentEvents),
+);
+
+/**
+ * Reads a finalized artifact's bytes as text, regardless of storage backend.
+ * Used for parsing the ordering manifest (`kind=project`) and for
+ * SRT->WebVTT conversion (`kind=captions`) — both small text files, so a
+ * full read is fine (unlike video bytes, which the checksum
+ * validators/sniffers stream instead of buffering).
+ */
+async function readArtifactText(artifactId) {
+  if (useS3) {
+    const buf = await pulseStorage.readAll(artifactId);
+    return buf ? buf.toString("utf8") : null;
+  }
+  const localPath = await pulseStorage.getLocalPath(artifactId);
+  if (!localPath) return null;
+  try {
+    return await readFile(localPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/** Minimal SRT -> WebVTT conversion so the gallery's <video> can attach real, playable subtitles — browsers only understand WebVTT in a <track>, never SRT. */
+function srtToVtt(srt) {
+  const body = srt
+    .replace(/\r+/g, "")
+    .replace(/^﻿/, "")
+    .split(/\n\n+/)
+    .filter((block) => block.trim().length > 0)
+    .map((block) => {
+      const lines = block.split("\n");
+      if (/^\d+$/.test(lines[0])) lines.shift(); // SRT's numeric cue index — WebVTT doesn't need it
+      return lines.join("\n");
+    })
+    .join("\n\n");
+  return `WEBVTT\n\n${body.replace(/(\d{2}:\d{2}:\d{2}),(\d{3})/g, "$1.$2")}\n`;
+}
+
+app.get(
+  "/captions/:artifactId",
+  {
+    schema: {
+      tags: ["demo"],
+      summary: "Fetch a captions artifact as WebVTT",
+      description:
+        "Demo-only convenience route (not part of the pulsevault plugin) that converts a `kind=captions` SRT upload to WebVTT so the gallery's <track> element can render it. Applies the same relatedTo-aware capability-token check as the plugin's own routes when auth is on.",
+    },
+  },
+  async (req, reply) => {
+    const { artifactId } = req.params;
+    if (PULSEVAULT_SECRET) {
+      const token = req.query?.token ?? "";
+      const verified = token ? verifyCapabilityToken(token, lookupSecret, { issuer: ISSUER }) : null;
+      const relatedTo = (await pulseStorage.getRelatedTo?.(artifactId)) ?? null;
+      const authorized = verified && (verified.artifactId === artifactId || verified.artifactId === relatedTo);
+      if (!authorized) return reply.code(403).send();
+    }
+    const text = await readArtifactText(artifactId);
+    if (text === null) return reply.code(404).send();
+    return reply.type("text/vtt").send(srtToVtt(text));
+  },
+);
+
+/**
+ * List uploads grouped by *pulse* (the recording session a phone actually
+ * produces), not as a flat list of unrelated files. Reconstructs the
+ * grouping the wire protocol already encodes (`PROTOCOL.md` §8):
+ *
+ * - "beat" mode: a `kind=project` manifest (no `relatedTo` — it IS the
+ *   session anchor) lists its beats' artifactIds in order; every beat
+ *   video and caption declares `relatedTo` pointing at the manifest.
+ * - "merged" mode: the single video itself has no `relatedTo` (it's its own
+ *   anchor); any captions declare `relatedTo` pointing at it.
+ *
+ * When capability tokens are on, mints exactly ONE short-lived token per
+ * pulse (scoped to the anchor artifactId) and reuses it for every beat's and
+ * caption's playback URL — the same `relatedTo`-based session authorization
+ * `PROTOCOL.md` §5.4 describes for uploads, exercised here for playback too.
+ */
+app.get(
+  "/pulses",
+  {
+    schema: {
+      tags: ["demo"],
+      summary: "List uploads grouped by pulse (recording session)",
+      description:
+        "Groups beats + manifest + captions via `relatedTo` instead of listing every artifact as an unrelated flat entry.",
     },
   },
   async (_req, reply) => {
@@ -145,52 +285,145 @@ app.get(
       throw err;
     }
 
-    const uploads = await Promise.all(
-      entries
-        .filter((e) => e.isFile() && e.name.endsWith(".json") && !e.name.endsWith(".tmp"))
-        .map(async (e) => {
-          const artifactId = e.name.slice(0, -".json".length);
-          const sidecarFilePath = path.join(pulsevaultMetaDir, e.name);
-          let sidecar;
+    const sidecars = (
+      await Promise.all(
+        entries
+          .filter((e) => e.isFile() && e.name.endsWith(".json") && !e.name.endsWith(".tmp"))
+          .map(async (e) => {
+            const artifactId = e.name.slice(0, -".json".length);
+            let sidecar;
+            try {
+              sidecar = JSON.parse(await readFile(path.join(pulsevaultMetaDir, e.name), "utf8"));
+            } catch {
+              return null;
+            }
+            if (sidecar.status !== "ready") return null;
+
+            const kind = sidecar.kind ?? "video";
+            const ext = sidecar.ext ?? ".mp4";
+            const artifactPath = path.join(dataDir, kind, `${artifactId}${ext}`);
+            const [artifactStat, tusMeta] = await Promise.all([
+              stat(artifactPath).catch(() => null),
+              readFile(`${artifactPath}.json`, "utf8").then(JSON.parse).catch(() => null),
+            ]);
+            if (!artifactStat || artifactStat.size === 0) return null;
+
+            return {
+              artifactId,
+              kind,
+              filename: sidecar.filename ?? tusMeta?.metadata?.filename ?? `${artifactId}${ext}`,
+              ext,
+              size: artifactStat.size,
+              relatedTo: sidecar.relatedTo ?? null,
+              checksumVerified: Boolean(sidecar.checksum),
+              creation_date: tusMeta?.creation_date ?? artifactStat.birthtime.toISOString(),
+            };
+          }),
+      )
+    ).filter(Boolean);
+
+    const byArtifactId = new Map(sidecars.map((s) => [s.artifactId, s]));
+    const anchors = sidecars.filter((s) => !s.relatedTo);
+    const childrenByAnchor = new Map();
+    for (const s of sidecars) {
+      if (!s.relatedTo) continue;
+      if (!childrenByAnchor.has(s.relatedTo)) childrenByAnchor.set(s.relatedTo, []);
+      childrenByAnchor.get(s.relatedTo).push(s);
+    }
+
+    const filenameStem = (filename) => filename.replace(/\.[^.]+$/, "");
+
+    const pulses = await Promise.all(
+      anchors.map(async (anchor) => {
+        const children = childrenByAnchor.get(anchor.artifactId) ?? [];
+        const captionsPool = children.filter((c) => c.kind === "captions");
+        const videoChildren = children.filter((c) => c.kind === "video");
+
+        // One token per pulse (not per artifact) — demonstrates relatedTo-based
+        // session authorization from PROTOCOL.md §5.4 for playback, exactly as
+        // it's used for uploads.
+        const pulseToken = PULSEVAULT_SECRET
+          ? issueCapabilityToken(anchor.artifactId, PULSEVAULT_SECRET, {
+              keyId: PULSEVAULT_KEY_ID,
+              issuer: ISSUER,
+              expirySeconds: WATCH_TOKEN_TTL_SECONDS,
+            })
+          : null;
+        const withToken = (url) => (pulseToken ? `${url}?token=${pulseToken}` : url);
+
+        const attachCaptions = (videoLike) => {
+          const stem = filenameStem(videoLike.filename);
+          const idx = captionsPool.findIndex((c) => filenameStem(c.filename) === stem);
+          if (idx < 0) return null;
+          const [captions] = captionsPool.splice(idx, 1);
+          return { artifactId: captions.artifactId, vttUrl: withToken(`/captions/${captions.artifactId}`) };
+        };
+
+        let mode;
+        let manifest = null;
+        let beats;
+
+        if (anchor.kind === "project") {
+          mode = "beat";
+          manifest = { artifactId: anchor.artifactId, size: anchor.size };
+          let order = null;
           try {
-            sidecar = JSON.parse(await readFile(sidecarFilePath, "utf8"));
+            const parsed = JSON.parse(await readArtifactText(anchor.artifactId));
+            order = Array.isArray(parsed?.beats) ? parsed.beats : null;
           } catch {
-            return null;
+            order = null;
           }
-          // Only list ready uploads; skip in-progress ones.
-          if (sidecar.status !== "ready") return null;
+          const videoByArtifactId = new Map(videoChildren.map((v) => [v.artifactId, v]));
+          const ordered = [];
+          if (order) {
+            for (const b of order) {
+              const v = videoByArtifactId.get(b.artifactId);
+              if (v) {
+                ordered.push(v);
+                videoByArtifactId.delete(b.artifactId);
+              }
+            }
+          }
+          // Any beat not listed in the manifest (shouldn't normally happen) — keep it
+          // visible rather than silently dropping an uploaded video.
+          ordered.push(...videoByArtifactId.values());
+          beats = ordered;
+        } else {
+          mode = "merged";
+          beats = [anchor];
+        }
 
-          const kind = sidecar.kind ?? "video";
-          const ext = sidecar.ext ?? ".mp4";
-          const artifactFile = `${artifactId}${ext}`;
-          const artifactPath = path.join(dataDir, kind, artifactFile);
-          const tusJsonPath = `${artifactPath}.json`;
+        const beatViews = beats.map((v, i) => ({
+          artifactId: v.artifactId,
+          filename: v.filename,
+          size: v.size,
+          order: i,
+          checksumVerified: v.checksumVerified,
+          playbackUrl: withToken(`/pulsevault/artifacts/${v.artifactId}`),
+          captions: attachCaptions(v),
+        }));
 
-          const [artifactStat, tusMeta] = await Promise.all([
-            stat(artifactPath).catch(() => null),
-            readFile(tusJsonPath, "utf8")
-              .then(JSON.parse)
-              .catch(() => null),
-          ]);
-          if (!artifactStat || artifactStat.size === 0) return null;
+        const creation_date = [anchor, ...children].reduce(
+          (latest, s) => (s.creation_date > latest ? s.creation_date : latest),
+          anchor.creation_date,
+        );
 
-          return {
-            artifactId,
-            kind,
-            filename: sidecar.filename ?? tusMeta?.metadata?.filename ?? artifactFile,
-            ext,
-            size: artifactStat.size,
-            creation_date:
-              tusMeta?.creation_date ?? artifactStat.birthtime.toISOString(),
-          };
-        }),
+        return {
+          anchorArtifactId: anchor.artifactId,
+          mode,
+          manifest,
+          beats: beatViews,
+          unmatchedCaptions: captionsPool.map((c) => ({
+            artifactId: c.artifactId,
+            filename: c.filename,
+            vttUrl: withToken(`/captions/${c.artifactId}`),
+          })),
+          creation_date,
+        };
+      }),
     );
 
-    return reply.send(
-      uploads
-        .filter(Boolean)
-        .sort((a, b) => b.creation_date.localeCompare(a.creation_date)),
-    );
+    return reply.send(pulses.sort((a, b) => b.creation_date.localeCompare(a.creation_date)));
   },
 );
 
@@ -199,15 +432,29 @@ app.get(
 // `prefix` ("/pulsevault") — the client builds every request as
 // `${server}/<path>` with no prefix concept of its own.
 app.get("/deeplinks", async (req, reply) => {
+  // In the open (no-auth) case, keep deriving `server` from request headers —
+  // convenient, and there's no issuer consistency requirement to protect.
+  // Once auth is on, `server` MUST be built from the same fixed ISSUER the
+  // capability token's `issuer` claim uses, or verification would fail for
+  // every request that didn't happen to arrive on the exact host header the
+  // token was issued under.
   const proto = req.headers["x-forwarded-proto"] ?? "http";
   const host = req.headers["x-forwarded-host"] ?? req.headers.host;
-  const server = `${proto}://${host}/pulsevault`;
+  const server = PULSEVAULT_SECRET ? `${ISSUER}/pulsevault` : `${proto}://${host}/pulsevault`;
   const artifactId = randomUUID();
+
+  const token = PULSEVAULT_SECRET
+    ? issueCapabilityToken(artifactId, PULSEVAULT_SECRET, {
+        keyId: PULSEVAULT_KEY_ID,
+        issuer: ISSUER,
+        expirySeconds: TOKEN_TTL_SECONDS,
+      })
+    : null;
 
   const upload = buildUploadLink({
     server,
     artifactId,
-    ...(DEMO_TOKEN && { token: DEMO_TOKEN }),
+    ...(token && { token }),
   });
 
   const qrUpload = await QRCode.toDataURL(upload, {
@@ -220,7 +467,11 @@ app.get("/deeplinks", async (req, reply) => {
     upload,
     artifactId,
     qrUpload,
-    authMode: Boolean(DEMO_TOKEN),
+    authMode: Boolean(PULSEVAULT_SECRET),
+    keyId: PULSEVAULT_SECRET ? PULSEVAULT_KEY_ID : null,
+    issuer: PULSEVAULT_SECRET ? ISSUER : null,
+    tokenExpiresInSeconds: token ? TOKEN_TTL_SECONDS : null,
+    storage: useS3 ? "s3" : "local",
   });
 });
 
@@ -228,8 +479,8 @@ app.get("/deeplinks", async (req, reply) => {
 // uploads into Cloudflare R2 / AWS S3 instead and serve playback via presigned
 // redirects. S3 mode needs the optional packages installed
 // (`@aws-sdk/client-s3 @aws-sdk/s3-request-presigner @tus/s3-store`) and the
-// S3_*/AWS_* env vars below — see `.env.example`. Note: the demo's GET /videos
-// route lists local sidecars only, so it returns [] in S3 mode.
+// S3_*/AWS_* env vars below — see `.env.example`. Note: /pulses lists local
+// sidecars only, so it returns [] in S3 mode.
 const useS3 = (process.env.STORAGE || "local").toLowerCase() === "s3";
 const pulseStorage = useS3
   ? await createS3Storage({
@@ -263,15 +514,19 @@ await app.register(pulseVault, {
   maxUploadSize: 5 * 1024 * 1024 * 1024, // 5 GiB
   // Accept MP4 videos, Pulse draft bundles (.pulse) + diagnostic zips, and SRT captions.
   allowedExtensions: { video: [".mp4"], project: [".pulse", ".zip"], captions: [".srt"] },
-  // validatePayload now runs for every kind, with ctx.kind telling you which
-  // — only apply the MP4 magic-byte sniff to actual videos, since project
-  // bundles and SRT captions never start with an ISOBMFF ftyp box. The S3
-  // sniffer does a ranged read of the object; the local one reads the file
-  // on disk.
+  // validatePayload runs for every kind, with ctx.kind telling you which.
+  // For video: verify the client-supplied checksum first (the Pulse app
+  // always sends one), then the MP4 magic-byte sniff — chained per the
+  // README's `createChecksumValidator(createMp4Sniffer(storage))` pattern.
+  // Project bundles and SRT captions get neither: they never start with an
+  // ISOBMFF ftyp box, and the app doesn't checksum them.
   validatePayload: async (request, ctx) => {
     if (ctx.kind !== "video") return;
     const sniff = useS3 ? createS3Mp4Sniffer(pulseStorage) : createMp4Sniffer(pulseStorage);
-    await sniff(request, ctx);
+    const withChecksum = useS3
+      ? createS3ChecksumValidator(pulseStorage, sniff)
+      : createChecksumValidator(sniff);
+    await withChecksum(request, ctx);
   },
   // Fired once any artifact (video, project bundle, or captions) finishes
   // uploading. The bytes are opaque to the plugin — index them, relay them,
@@ -279,37 +534,31 @@ await app.register(pulseVault, {
   onUploadComplete: async (_req, { artifactId, kind, size }) => {
     app.log.info({ artifactId, kind, size }, "pulsevault upload complete");
   },
-  /**
-   * authorize hook — the demo's auth proof-of-concept.
-   *
-   * When DEMO_TOKEN is unset (default), this is a no-op and the server accepts
-   * every request. When DEMO_TOKEN is set, every TUS create/patch must carry
-   * `Authorization: Bearer <DEMO_TOKEN>` and every watch must carry
-   * `?token=<DEMO_TOKEN>`. Swap this body with your real auth — sessions, JWT,
-   * mTLS, etc.
-   */
-  authorize: async (request, ctx) => {
-    if (!DEMO_TOKEN) return;
-
-    const supplied =
-      ctx.phase === "resolve"
-        ? ctx.token
-        : (request.headers.authorization || "").replace(/^Bearer\s+/i, "");
-
-    if (supplied !== DEMO_TOKEN) {
-      throw { statusCode: 403, message: "Forbidden: invalid demo token" };
-    }
+  // One hook covers both ops metrics and a compliance audit trail (see
+  // OPERATIONS.md "Monitoring and audit logging") — fed straight into the
+  // in-memory feed `/events` exposes to the pairing page.
+  onArtifactEvent: (event) => {
+    app.log.info(event, "pulsevault artifact event");
+    recordEvent(event);
   },
+  /**
+   * `createCapabilityAuthorize` — the library's secure-by-default auth
+   * option (see README "Capability tokens" / PROTOCOL.md §5.4): a
+   * stateless, HMAC-signed, expiring token per artifact (or artifact
+   * family, via `relatedTo`). No server-side session table, so secrets can
+   * rotate and TTLs can change entirely on this server's own schedule.
+   *
+   * `undefined` when `PULSEVAULT_SECRET` is unset — same as before, an open
+   * demo with no authorization at all.
+   */
+  authorize: PULSEVAULT_SECRET ? createCapabilityAuthorize(lookupSecret, { issuer: ISSUER }) : undefined,
 });
-
-const port = Number(process.env.PORT ?? 3000);
-const host = process.env.HOST ?? "0.0.0.0";
 
 await app.listen({ port, host });
 console.log(`\nPulseVault demo running on http://localhost:${port}/`);
 console.log(`Swagger UI:                   http://localhost:${port}/docs`);
-if (DEMO_TOKEN) {
-  console.log(`Auth demo:                    ON  (DEMO_TOKEN is set)`);
+if (PULSEVAULT_SECRET) {
+  console.log(`Capability tokens:            ON  (kid=${PULSEVAULT_KEY_ID}, issuer=${ISSUER})`);
 } else {
-  console.log(`Auth demo:                    off (set DEMO_TOKEN=... to enable)`);
+  console.log("Capability tokens:            off (set PULSEVAULT_SECRET=... to enable)");
 }

--- a/scripts/e2e-tus.mjs
+++ b/scripts/e2e-tus.mjs
@@ -20,7 +20,12 @@ const demoDir = path.join(__dirname, "..", "examples", "rn-demo");
 const PORT = 4173;
 const BASE = `http://127.0.0.1:${PORT}`;
 const PREFIX = `${BASE}/pulsevault`;
-const DEMO_TOKEN = "e2e-smoke-test-token";
+const PULSEVAULT_SECRET = "e2e-smoke-test-secret";
+
+/** Extracts the `token` query param from a `pulsecam://` deep link, the same way a real client parses it. */
+function tokenFromDeepLink(deepLink) {
+  return new URL(deepLink.replace("pulsecam://", "http://x/")).searchParams.get("token");
+}
 
 function b64(str) {
   return Buffer.from(str, "utf8").toString("base64");
@@ -57,7 +62,14 @@ async function main() {
   console.log("Starting rn-demo server...");
   const child = spawn(process.execPath, ["server.mjs"], {
     cwd: demoDir,
-    env: { ...process.env, PORT: String(PORT), HOST: "127.0.0.1", DEMO_TOKEN, STORAGE: "local" },
+    env: {
+      ...process.env,
+      PORT: String(PORT),
+      HOST: "127.0.0.1",
+      STORAGE: "local",
+      PULSEVAULT_SECRET,
+      PULSEVAULT_ISSUER: BASE,
+    },
     stdio: ["ignore", "pipe", "pipe"],
   });
 
@@ -83,15 +95,20 @@ async function main() {
     assert.ok(["beat", "merged"].includes(caps.uploadUnit));
     console.log(`  ✓ /capabilities reports protocolVersion=${caps.protocolVersion}, uploadUnit=${caps.uploadUnit}`);
 
-    // 2. Pairing — mints an artifactId + deep link carrying the demo token.
+    // 2. Pairing — mints an artifactId + a real HMAC-signed capability token
+    // (issueCapabilityToken), carried in the deep link exactly as a real
+    // client would receive it.
     const linkRes = await fetch(`${BASE}/deeplinks`);
     assert.equal(linkRes.status, 200, "GET /deeplinks should be 200");
-    const { artifactId, upload: deepLink } = await linkRes.json();
+    const { artifactId, upload: deepLink, authMode } = await linkRes.json();
     assert.ok(artifactId, "deeplinks response should include an artifactId");
     assert.ok(deepLink.startsWith("pulsecam://"), "deep link should use the pulsecam scheme");
-    console.log(`  ✓ /deeplinks minted artifactId=${artifactId}`);
+    assert.equal(authMode, true, "PULSEVAULT_SECRET is set, so authMode should be true");
+    const token = tokenFromDeepLink(deepLink);
+    assert.ok(token, "deep link should carry a capability token when PULSEVAULT_SECRET is set");
+    console.log(`  ✓ /deeplinks minted artifactId=${artifactId} with a signed capability token`);
 
-    // 3. Full chunked TUS upload, authorized with the demo bearer token.
+    // 3. Full chunked TUS upload, authorized with the real capability token.
     const body = makeMp4(2 * 1024 * 1024);
     const digest = createHash("sha256").update(body).digest("hex");
     const metadata = [
@@ -106,7 +123,7 @@ async function main() {
         "Tus-Resumable": "1.0.0",
         "Upload-Length": String(body.length),
         "Upload-Metadata": metadata,
-        Authorization: `Bearer ${DEMO_TOKEN}`,
+        Authorization: `Bearer ${token}`,
       },
     });
     assert.equal(create.status, 201, `create should be 201, got ${create.status}`);
@@ -121,7 +138,7 @@ async function main() {
         "Tus-Resumable": "1.0.0",
         "Upload-Offset": "0",
         "Content-Type": "application/offset+octet-stream",
-        Authorization: `Bearer ${DEMO_TOKEN}`,
+        Authorization: `Bearer ${token}`,
       },
       body: body.subarray(0, half),
     });
@@ -130,7 +147,7 @@ async function main() {
     // Resume via HEAD before the second chunk — never trust a cached offset.
     const head = await fetch(location, {
       method: "HEAD",
-      headers: { "Tus-Resumable": "1.0.0", Authorization: `Bearer ${DEMO_TOKEN}` },
+      headers: { "Tus-Resumable": "1.0.0", Authorization: `Bearer ${token}` },
     });
     assert.equal(Number(head.headers.get("upload-offset")), half, "HEAD should report the offset after chunk 1");
 
@@ -140,7 +157,7 @@ async function main() {
         "Tus-Resumable": "1.0.0",
         "Upload-Offset": String(half),
         "Content-Type": "application/offset+octet-stream",
-        Authorization: `Bearer ${DEMO_TOKEN}`,
+        Authorization: `Bearer ${token}`,
       },
       body: body.subarray(half),
     });
@@ -151,16 +168,22 @@ async function main() {
     // demo's authorize hook reads the resolve-phase token from `?token=`
     // (forwarded from the watch URL), not the Authorization header — that's
     // the documented contract for the "resolve" phase specifically.
-    const get = await fetch(`${PREFIX}/artifacts/${artifactId}?token=${DEMO_TOKEN}`);
+    const get = await fetch(`${PREFIX}/artifacts/${artifactId}?token=${token}`);
     assert.equal(get.status, 200, `GET /artifacts/:id should be 200, got ${get.status}`);
     const got = Buffer.from(await get.arrayBuffer());
     assert.equal(Buffer.compare(got, body), 0, "downloaded bytes should match what was uploaded");
     console.log("  ✓ GET /artifacts/:artifactId serves the exact uploaded bytes");
 
-    // 5. A request with no/wrong token must be rejected, not silently accepted.
-    const unauthorized = await fetch(`${PREFIX}/artifacts/${artifactId}`);
-    assert.equal(unauthorized.status, 403, "unauthenticated GET should be rejected");
-    console.log("  ✓ request with no token is rejected (403)");
+    // 5. No credential at all -> 401; a well-formed but wrong/unrelated token -> 403.
+    // createCapabilityAuthorize distinguishes these (PROTOCOL.md §5.2) — neither is
+    // silently accepted.
+    const noToken = await fetch(`${PREFIX}/artifacts/${artifactId}`);
+    assert.equal(noToken.status, 401, "GET with no token should be 401");
+    const other = await fetch(`${BASE}/deeplinks`).then((r) => r.json());
+    const otherToken = tokenFromDeepLink(other.upload);
+    const wrongToken = await fetch(`${PREFIX}/artifacts/${artifactId}?token=${otherToken}`);
+    assert.equal(wrongToken.status, 403, "GET with a token for a different artifact should be 403");
+    console.log("  ✓ no token -> 401, wrong-artifact token -> 403");
 
     console.log("\nAll e2e checks passed.");
   } finally {

--- a/src/core.ts
+++ b/src/core.ts
@@ -3,6 +3,7 @@ import send from "@fastify/send";
 import {
   createPulsevaultTusServer,
   pulseVaultTusContext,
+  artifactIdFromUploadId,
   type PulseVaultOnUploadComplete,
   type PulseVaultOnArtifactEvent,
 } from "./lib/pulsevaultTus.js";
@@ -120,11 +121,20 @@ export type PulseVaultCore = {
  * and `relatedTo` out of a raw `Upload-Metadata` header. Format is a
  * comma-separated list of `<key> <base64-value>` pairs (tus v1 creation
  * extension).
+ *
+ * Alias precedence is a fixed priority (`artifactId` beats `videoid` beats
+ * `projectid`, regardless of header order) so this always agrees with
+ * `namingFunction` in `lib/pulsevaultTus.ts` — which uses the same
+ * `?? `-chain precedence to decide what's actually reserved/written to
+ * storage. If these two disagreed, `authorize()` could validate ownership of
+ * a different artifactId than the one the upload actually lands under.
  */
 function parseUploadMetadata(
   header: string,
 ): { artifactId: string | undefined; kind: UploadKind; relatedTo: string | undefined } {
-  let artifactId: string | undefined;
+  let artifactIdRaw: string | undefined;
+  let videoidRaw: string | undefined;
+  let projectidRaw: string | undefined;
   let kind: UploadKind = "video";
   let relatedTo: string | undefined;
   for (const pair of header.split(",")) {
@@ -137,8 +147,12 @@ function parseUploadMetadata(
     if (!value) continue;
     try {
       const decoded = Buffer.from(value, "base64").toString("utf8");
-      if ((key === "artifactId" || key === "videoid" || key === "projectid") && !artifactId) {
-        artifactId = isUuid(decoded) ? decoded : undefined;
+      if (key === "artifactId") {
+        artifactIdRaw ??= decoded;
+      } else if (key === "videoid") {
+        videoidRaw ??= decoded;
+      } else if (key === "projectid") {
+        projectidRaw ??= decoded;
       } else if (key === "kind") {
         const lower = decoded.trim().toLowerCase();
         kind = lower === "project" ? "project" : lower === "captions" ? "captions" : "video";
@@ -149,25 +163,52 @@ function parseUploadMetadata(
       // ignore malformed base64
     }
   }
+  const candidate = (artifactIdRaw ?? videoidRaw ?? projectidRaw ?? "").trim();
+  const artifactId = isUuid(candidate) ? candidate : undefined;
   return { artifactId, kind, relatedTo };
 }
 
 /**
- * Decode the last URL segment of a tus PATCH/HEAD/DELETE (base64url-encoded
- * id) and extract the first path component, which the plugin always shapes as
- * the artifactId (see `lib/pulsevaultTus.ts`).
+ * `@tus/server`'s `BaseHandler.getFileIdFromRequest` — the function that
+ * ultimately decides which upload a PATCH/HEAD/DELETE actually operates on —
+ * extracts its file id from the request URL's *last* `/`-delimited segment
+ * (`reExtractFileID = /([^/]+)\/?$/`), not from the first segment after
+ * `/upload/`. This MUST mirror that exact regex: a URL with extra path
+ * segments after the real id (Fastify's `/upload/*` route accepts them) would
+ * otherwise let `authorize()` see and approve one artifactId (whichever this
+ * function resolved) while `@tus/server` writes the request body against a
+ * *different* one (whichever it resolved) — an attacker holding a valid
+ * token for their own artifact could smuggle a second, victim artifactId as
+ * a trailing path segment and have their bytes land there instead, fully
+ * bypassing authorization for the artifact actually written to.
+ */
+const TUS_LAST_URL_SEGMENT = /([^/]+)\/?$/;
+
+/**
+ * Decode the tus file id (base64url-encoded, shaped `<kind>/<artifactId><ext>`
+ * by `namingFunction` in `lib/pulsevaultTus.ts`) that `@tus/server` itself
+ * will resolve a PATCH/HEAD/DELETE request to, and recover the artifactId via
+ * the exact same parser `onUploadFinish` uses — so this can never drift from
+ * what `@tus/server` actually operates on. See `TUS_LAST_URL_SEGMENT` above
+ * for why this must match the *last* URL segment, not the first one after
+ * `/upload/`.
  */
 function artifactIdFromTusUrl(url: string): string | undefined {
-  const match = url.match(/\/upload\/([^/?#]+)/);
+  const match = TUS_LAST_URL_SEGMENT.exec(url);
   if (!match?.[1]) return undefined;
-  let decoded: string;
+  let lastSegment: string;
   try {
-    decoded = Buffer.from(match[1], "base64url").toString("utf8");
+    lastSegment = decodeURIComponent(match[1]);
   } catch {
     return undefined;
   }
-  const first = decoded.split("/", 1)[0];
-  return isUuid(first) ? first : undefined;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(lastSegment, "base64url").toString("utf8");
+  } catch {
+    return undefined;
+  }
+  return artifactIdFromUploadId(decoded);
 }
 
 /**

--- a/src/lib/checksum.ts
+++ b/src/lib/checksum.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import fs from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
 import type { S3Storage } from "../storage/s3.js";
 import type { PulseVaultValidatePayload } from "./magic.js";
 
@@ -29,12 +30,16 @@ function isSupportedAlgorithm(value: string): value is ChecksumAlgorithm {
   return (SUPPORTED_ALGORITHMS as readonly string[]).includes(value);
 }
 
-function digestBuffer(buf: Buffer, algorithm: ChecksumAlgorithm): string {
-  return createHash(algorithm).update(buf).digest("hex");
-}
-
+/**
+ * Hashes the file at `path` via a stream instead of `fs.readFile` so a
+ * multi-gigabyte upload (`maxUploadSize: Infinity` is a supported
+ * configuration) never has to be held in memory as a single `Buffer` just to
+ * compute its checksum.
+ */
 async function digestLocalFile(path: string, algorithm: ChecksumAlgorithm): Promise<string> {
-  return digestBuffer(await fs.readFile(path), algorithm);
+  const hash = createHash(algorithm);
+  await pipeline(createReadStream(path), hash);
+  return hash.digest("hex");
 }
 
 function checksumError(message: string): Error {
@@ -84,10 +89,12 @@ export function createChecksumValidator(
 }
 
 /**
- * `createChecksumValidator` for the S3/R2 backend — downloads the whole
- * finalized object (via `S3Storage.readAll`) to compute the digest, since
- * S3 has no local path to hash directly. Only worth using when checksum
- * verification is explicitly wanted; it's a full extra download per upload.
+ * `createChecksumValidator` for the S3/R2 backend — streams the whole
+ * finalized object through a hash digest via `S3Storage.digestAll`, since S3
+ * has no local path to hash directly. Only worth using when checksum
+ * verification is explicitly wanted; it's a full extra download per upload,
+ * but (unlike buffering the object via `readAll`) never holds the whole
+ * object in memory at once.
  */
 export function createS3ChecksumValidator(
   storage: S3Storage,
@@ -96,14 +103,13 @@ export function createS3ChecksumValidator(
   return async (request, ctx) => {
     const checksum = parseChecksumMetadata(ctx.checksum);
     if (checksum) {
-      const bytes = await storage.readAll(ctx.artifactId);
-      if (!bytes) {
+      const actual = await storage.digestAll(ctx.artifactId, checksum.algorithm);
+      if (actual === null) {
         throw Object.assign(
           new Error(`Cannot validate upload ${ctx.artifactId}: no object bytes available`),
           { statusCode: 500 },
         );
       }
-      const actual = digestBuffer(bytes, checksum.algorithm);
       if (actual !== checksum.digest) {
         throw checksumError(
           `Checksum mismatch: expected ${checksum.algorithm}:${checksum.digest}, got ${checksum.algorithm}:${actual}`,

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -22,14 +22,56 @@ export type UploadLinkOptions = {
 const LINK_VERSION = "1";
 
 /**
+ * Private/dev origins allowed over plain http — mirrors the Pulse client's
+ * own `isPrivateDevOrigin` check (PROTOCOL.md §3) exactly, so a link this
+ * helper is willing to build is also one the client is willing to accept.
+ * Never extended beyond non-globally-routable address space (RFC 1918
+ * private ranges, RFC 6598 carrier-grade NAT, link-local) plus
+ * loopback/localhost — never a public IP or domain just because it "looks
+ * internal."
+ */
+function isPrivateDevOrigin(url: URL): boolean {
+  if (url.protocol !== "http:") return false;
+  const host = url.hostname;
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    /^10\.\d+\.\d+\.\d+$/.test(host) ||
+    /^192\.168\.\d+\.\d+$/.test(host) ||
+    /^172\.(1[6-9]|2\d|3[01])\.\d+\.\d+$/.test(host) ||
+    /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+$/.test(host) || // RFC 6598, 100.64.0.0/10
+    /^169\.254\.\d+\.\d+$/.test(host) // link-local
+  );
+}
+
+/**
  * Build a `pulsecam://` deep link that opens the Pulse app directly on the
  * upload screen for a specific artifact, pointed at this server.
  *
  * No `mode` param — there's only one mode, so it was always redundant. `v`
  * lets the app refuse/explain a future incompatible link shape instead of
  * misparsing it.
+ *
+ * Throws if `server` isn't `https://` (or the narrow localhost/private-IP dev
+ * exception PROTOCOL.md §3 carves out) — failing fast here, at the one place
+ * that constructs the link, is more reliable than relying on every client to
+ * independently reject a plaintext origin the operator never should have
+ * issued in the first place.
  */
 export function buildUploadLink(opts: UploadLinkOptions): string {
+  let server: URL;
+  try {
+    server = new URL(opts.server);
+  } catch {
+    throw new Error(`buildUploadLink: \`server\` is not a valid URL: ${opts.server}`);
+  }
+  if (server.protocol !== "https:" && !isPrivateDevOrigin(server)) {
+    throw new Error(
+      `buildUploadLink: \`server\` must be https:// (got "${opts.server}") — ` +
+        "the only exception is http://localhost or a private IP literal for local development.",
+    );
+  }
+
   const params = new URLSearchParams({
     v: LINK_VERSION,
     artifactId: opts.artifactId,

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -88,7 +88,7 @@ export function tusError(status: number, body: string): Error {
 }
 
 /** Parse the artifactId UUID from a tus upload id of the form `<kind>/<artifactId><ext>`. */
-function artifactIdFromUploadId(id: string): string | undefined {
+export function artifactIdFromUploadId(id: string): string | undefined {
   const [, nameWithExt] = id.split("/");
   if (!nameWithExt) return undefined;
   const ext = path.extname(nameWithExt);

--- a/src/storage/local.ts
+++ b/src/storage/local.ts
@@ -216,6 +216,9 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
 
   const initialize = async (): Promise<void> => {
     await fs.mkdir(sidecarDir(), { recursive: true });
+    // @tus/file-store creates `workspaceRoot` with mode 0777 if it doesn't already exist;
+    // tighten it so the upload tree isn't world-writable under a permissive umask.
+    await fs.chmod(workspaceRoot, 0o750).catch(() => {});
   };
 
   const reserveUpload = async ({
@@ -226,22 +229,10 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     relatedTo,
     checksum,
   }: ReserveUploadParams): Promise<string> => {
-    // Collision guard: if an upload (in-progress or ready) already exists
-    // for this artifactId, refuse the new upload rather than letting
-    // @tus/file-store silently reset the metadata sidecar to offset 0 and
-    // overwrite the file chunk-by-chunk on subsequent PATCHes. Translates
-    // to HTTP 409 via @tus/server's error path.
-    const meta = await loadMeta(artifactId);
-    if (meta) {
-      throw Object.assign(
-        new Error(`artifactId ${artifactId} already has an upload`),
-        { statusCode: 409, status_code: 409 },
-      );
-    }
-
     await fs.mkdir(path.join(workspaceRoot, kind), { recursive: true });
+    await fs.mkdir(sidecarDir(), { recursive: true });
 
-    await writeSidecar(artifactId, {
+    const sidecar: Sidecar = {
       version: SIDECAR_VERSION,
       ext,
       filename,
@@ -249,7 +240,30 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
       kind,
       relatedTo,
       checksum,
-    });
+    };
+
+    // Collision guard: `wx` fails atomically with EEXIST if a sidecar already exists for
+    // this artifactId, rather than the previous read-then-write (`loadMeta` then
+    // `writeSidecar`) which left a window for two concurrent/retried requests to both pass
+    // the check before either had written — letting the second silently clobber the first's
+    // sidecar and race @tus/file-store's own offset tracking. Translates to HTTP 409 via
+    // @tus/server's error path, same as before.
+    try {
+      await fs.writeFile(sidecarPath(artifactId), JSON.stringify(sidecar), { flag: "wx" });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") throw err;
+      // A file already exists at this path, but `readSidecar` treats a malformed/corrupt
+      // one as absent (e.g. debris from a crash mid-write) — re-check before deciding this
+      // is a genuine collision rather than debris that's safe to overwrite.
+      const existing = await readSidecar(artifactId);
+      if (existing) {
+        throw Object.assign(
+          new Error(`artifactId ${artifactId} already has an upload`),
+          { statusCode: 409, status_code: 409 },
+        );
+      }
+      await writeSidecar(artifactId, sidecar);
+    }
 
     cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum });
     // @tus/file-store joins this onto its configured `directory`, so the

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { DataStore } from "@tus/server";
 // Type-only imports: erased at compile time (verbatimModuleSyntax), so loading
 // this module never pulls in the AWS SDK. The real modules are loaded lazily
@@ -141,6 +142,14 @@ export type S3Storage = PulseVaultStorage & {
    * opt-in integrity check, not on every upload by default.
    */
   readAll(artifactId: string): Promise<Buffer | null>;
+  /**
+   * Streams a finalized upload's bytes through a hash digest, returning the
+   * hex digest, or `null` if the artifactId is unknown. The streaming
+   * counterpart to `readAll` — used by `createS3ChecksumValidator` so
+   * checksum verification never has to hold an entire (potentially
+   * multi-gigabyte) object in memory as one `Buffer`.
+   */
+  digestAll(artifactId: string, algorithm: "sha256" | "sha1" | "md5"): Promise<string | null>;
   /** Artifact kind for a known artifactId, or `null`. Satisfies `getKind`. */
   getKind(artifactId: string): Promise<UploadKind | null>;
   /** Satisfies the optional `PulseVaultStorage.getRelatedTo` contract. */
@@ -311,19 +320,7 @@ export async function createS3Storage(
     relatedTo,
     checksum,
   }: ReserveUploadParams): Promise<string> => {
-    // Collision guard, same contract as the local adapter: refuse a second
-    // upload for an artifactId that already has one (in-progress or ready)
-    // rather than letting the datastore silently reset the multipart upload.
-    // Surfaces as HTTP 409 via @tus/server's error path.
-    const meta = await loadMeta(artifactId);
-    if (meta) {
-      throw Object.assign(new Error(`artifactId ${artifactId} already has an upload`), {
-        statusCode: 409,
-        status_code: 409,
-      });
-    }
-
-    await writeSidecar(artifactId, {
+    const sidecar: Sidecar = {
       version: SIDECAR_VERSION,
       ext,
       filename,
@@ -331,7 +328,59 @@ export async function createS3Storage(
       kind,
       relatedTo,
       checksum,
-    });
+    };
+
+    // Fast-path rejection for the common case. Not atomic by itself (two concurrent
+    // requests can both observe no existing meta before either writes) — the conditional
+    // write below closes that race on backends that support it — but it's also the only
+    // enforcement on S3-compatible backends that silently ignore `IfNoneMatch` instead of
+    // erroring (e.g. the `s3rver` mock this repo's own test suite runs against).
+    const existing = await loadMeta(artifactId);
+    if (existing) {
+      throw Object.assign(new Error(`artifactId ${artifactId} already has an upload`), {
+        statusCode: 409,
+        status_code: 409,
+      });
+    }
+
+    // Collision guard: `IfNoneMatch: "*"` makes the write itself atomically fail
+    // (PreconditionFailed) if a sidecar object already exists for this artifactId, closing
+    // the race the check above can't close by itself. Surfaces as HTTP 409 via @tus/server's
+    // error path, same as before.
+    try {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: sidecarKey(artifactId),
+          Body: JSON.stringify(sidecar),
+          ContentType: "application/json",
+          IfNoneMatch: "*",
+        }),
+      );
+    } catch (err) {
+      if (isPreconditionFailed(err)) {
+        throw Object.assign(new Error(`artifactId ${artifactId} already has an upload`), {
+          statusCode: 409,
+          status_code: 409,
+        });
+      }
+      if (!isConditionalWriteUnsupported(err)) throw err;
+      // Some S3-compatible backends don't support conditional writes — fall back to the
+      // previous check-then-write. Weaker (the original TOCTOU window reopens) but keeps
+      // reserve working on those backends instead of hard-failing every upload. Surface
+      // this degraded mode once per process so operators know their backend can't fully
+      // guarantee collision safety under concurrent/retried creates for the same artifactId.
+      warnAboutConditionalWriteFallbackOnce();
+      const meta = await loadMeta(artifactId);
+      if (meta) {
+        throw Object.assign(new Error(`artifactId ${artifactId} already has an upload`), {
+          statusCode: 409,
+          status_code: 409,
+        });
+      }
+      await writeSidecar(artifactId, sidecar);
+    }
+
     cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum });
     // @tus/s3-store uses this as the object key for the multipart upload, so
     // the finished object lands at `<kind>/<artifactId><ext>`.
@@ -444,6 +493,22 @@ export async function createS3Storage(
     }
   };
 
+  const digestAll = async (
+    artifactId: string,
+    algorithm: "sha256" | "sha1" | "md5",
+  ): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
+    if (!meta) return null;
+    const key = artifactKey(artifactId, meta.kind, meta.ext);
+    try {
+      const res = await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+      return await digestBody(res.Body, algorithm);
+    } catch (err) {
+      if (isNotFound(err)) return null;
+      throw err;
+    }
+  };
+
   const getKind = async (artifactId: string): Promise<UploadKind | null> => {
     const meta = await loadMeta(artifactId);
     return meta ? meta.kind : null;
@@ -472,6 +537,7 @@ export async function createS3Storage(
     remove,
     readHeader,
     readAll,
+    digestAll,
     getKind,
     getRelatedTo,
     getChecksum,
@@ -498,6 +564,33 @@ async function bodyToBuffer(body: unknown): Promise<Buffer> {
   return Buffer.concat(chunks);
 }
 
+/**
+ * Stream an AWS SDK response body through a hash digest without buffering the
+ * whole thing into memory first — the streaming counterpart to
+ * `bodyToBuffer`, used by `digestAll`.
+ */
+async function digestBody(
+  body: unknown,
+  algorithm: "sha256" | "sha1" | "md5",
+): Promise<string> {
+  const hash = createHash(algorithm);
+  if (
+    body &&
+    typeof (body as { transformToByteArray?: unknown }).transformToByteArray ===
+      "function"
+  ) {
+    const arr = await (
+      body as { transformToByteArray(): Promise<Uint8Array> }
+    ).transformToByteArray();
+    hash.update(arr);
+    return hash.digest("hex");
+  }
+  for await (const chunk of body as AsyncIterable<Uint8Array>) {
+    hash.update(chunk);
+  }
+  return hash.digest("hex");
+}
+
 /** Whether an AWS SDK error represents a missing key/object (404-ish). */
 function isNotFound(err: unknown): boolean {
   const e = err as {
@@ -511,5 +604,55 @@ function isNotFound(err: unknown): boolean {
     e?.Code === "NoSuchKey" ||
     e?.Code === "NotFound" ||
     e?.$metadata?.httpStatusCode === 404
+  );
+}
+
+/** Whether a conditional `PutObjectCommand` (`IfNoneMatch`) failed because the object already exists. */
+function isPreconditionFailed(err: unknown): boolean {
+  const e = err as {
+    name?: string;
+    Code?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return (
+    e?.name === "PreconditionFailed" ||
+    e?.Code === "PreconditionFailed" ||
+    e?.$metadata?.httpStatusCode === 412
+  );
+}
+
+/** Whether the backend rejected the conditional-write header itself (some S3-compatible stores don't support it), as opposed to the condition failing. */
+function isConditionalWriteUnsupported(err: unknown): boolean {
+  const e = err as {
+    name?: string;
+    Code?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return (
+    e?.name === "NotImplemented" ||
+    e?.Code === "NotImplemented" ||
+    e?.$metadata?.httpStatusCode === 501
+  );
+}
+
+let warnedAboutConditionalWriteFallback = false;
+/**
+ * One-time-per-process warning when `reserveUpload` falls back to
+ * check-then-write because the configured S3-compatible backend doesn't
+ * support `IfNoneMatch`. That fallback reopens a genuine TOCTOU window
+ * (two concurrent/retried `reserveUpload` calls for the same artifactId can
+ * both pass the check before either writes, silently clobbering one
+ * another's sidecar) — there's no way to close it without a real distributed
+ * lock, so the best this library can do is make the degraded mode visible.
+ */
+function warnAboutConditionalWriteFallbackOnce(): void {
+  if (warnedAboutConditionalWriteFallback) return;
+  warnedAboutConditionalWriteFallback = true;
+  console.warn(
+    "[pulsevault] S3-compatible backend does not support conditional writes (IfNoneMatch); " +
+      "falling back to check-then-write for reserveUpload. This reopens a collision race " +
+      "between concurrent/retried creates for the same artifactId. If this matters for your " +
+      "deployment, use a backend that supports IfNoneMatch, or serialize artifactId creation " +
+      "in front of pulsevault (e.g. in your own /reserve endpoint).",
   );
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -43,8 +43,14 @@ export type ReserveUploadParams = {
    * "session" artifact (e.g. a video) authorize related artifacts uploaded in
    * the same session (its captions, or — under `uploadUnit: "beat"` — each
    * beat plus the pulse manifest) without minting a token per artifact.
-   * Purely bookkeeping for the storage layer; `pulsevault` does not enforce
-   * any relationship semantics beyond storing and returning it.
+   * The storage layer itself only stores and returns this value — it does not
+   * validate that the referenced artifact exists or was created by the same
+   * caller. The actual authorization check lives in `createCapabilityAuthorize`
+   * (`lib/capability-token.ts`), which treats a request's `relatedTo` as
+   * authorized whenever it matches the presented token's own signed
+   * `artifactId` claim. That's safe only because a token can't be forged or
+   * guessed (HMAC-signed) — do not read this field as "unauthenticated
+   * metadata with no security relevance."
    */
   relatedTo?: string;
   /**

--- a/test/checksum.test.mjs
+++ b/test/checksum.test.mjs
@@ -89,10 +89,10 @@ test("createChecksumValidator throws a clear error when checksum is requested bu
   );
 });
 
-test("createS3ChecksumValidator verifies against storage.readAll", async () => {
+test("createS3ChecksumValidator verifies against storage.digestAll", async () => {
   const bytes = Buffer.from("s3 object bytes");
   const digest = createHash("sha256").update(bytes).digest("hex");
-  const fakeStorage = { readAll: async () => bytes };
+  const fakeStorage = { digestAll: async (_id, algorithm) => createHash(algorithm).update(bytes).digest("hex") };
 
   const validator = createS3ChecksumValidator(fakeStorage);
   await assert.doesNotReject(() =>

--- a/test/deeplinks.test.mjs
+++ b/test/deeplinks.test.mjs
@@ -1,0 +1,66 @@
+// Fast unit tests for `buildUploadLink`'s server-URL validation — no Fastify
+// server, no filesystem. PROTOCOL.md §3 requires a client to reject any
+// non-https `server` origin except the narrow localhost/private-IP dev
+// exception; this validates the one place that constructs the link enforces
+// the same rule server-side, instead of relying entirely on every client
+// to reimplement the check correctly.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildUploadLink } from "../dist/lib/deeplinks.js";
+
+const ARTIFACT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+test("builds a link for an https server", () => {
+  const link = buildUploadLink({ server: "https://vault.example.org/pulsevault", artifactId: ARTIFACT_ID });
+  assert.ok(link.startsWith("pulsecam://?"));
+  const params = new URLSearchParams(link.slice("pulsecam://?".length));
+  assert.equal(params.get("server"), "https://vault.example.org/pulsevault");
+  assert.equal(params.get("artifactId"), ARTIFACT_ID);
+  assert.equal(params.get("v"), "1");
+});
+
+test("includes the token when provided, omits it when not", () => {
+  const withToken = buildUploadLink({
+    server: "https://vault.example.org/pulsevault",
+    artifactId: ARTIFACT_ID,
+    token: "secret",
+  });
+  assert.ok(new URLSearchParams(withToken.split("?")[1]).get("token") === "secret");
+
+  const withoutToken = buildUploadLink({ server: "https://vault.example.org/pulsevault", artifactId: ARTIFACT_ID });
+  assert.equal(new URLSearchParams(withoutToken.split("?")[1]).get("token"), null);
+});
+
+test("allows http://localhost for local dev", () => {
+  assert.doesNotThrow(() =>
+    buildUploadLink({ server: "http://localhost:3030/pulsevault", artifactId: ARTIFACT_ID }),
+  );
+});
+
+test("allows a private-IP-literal http origin for local dev", () => {
+  for (const host of ["127.0.0.1", "10.0.0.5", "192.168.1.20", "172.16.0.1", "100.64.0.1", "169.254.1.1"]) {
+    assert.doesNotThrow(
+      () => buildUploadLink({ server: `http://${host}:3030/pulsevault`, artifactId: ARTIFACT_ID }),
+      `expected ${host} to be allowed over http`,
+    );
+  }
+});
+
+test("rejects a plaintext http server that isn't localhost/private-IP", () => {
+  assert.throws(() => buildUploadLink({ server: "http://vault.example.org/pulsevault", artifactId: ARTIFACT_ID }));
+});
+
+test("rejects a public IP over http (not fooled by looking like an IP literal)", () => {
+  assert.throws(() => buildUploadLink({ server: "http://8.8.8.8/pulsevault", artifactId: ARTIFACT_ID }));
+});
+
+test("rejects a hostname that merely contains 'localhost'", () => {
+  assert.throws(() =>
+    buildUploadLink({ server: "http://localhost.evil.example/pulsevault", artifactId: ARTIFACT_ID }),
+  );
+});
+
+test("rejects a malformed server URL", () => {
+  assert.throws(() => buildUploadLink({ server: "not a url", artifactId: ARTIFACT_ID }));
+});

--- a/test/plugin.test.mjs
+++ b/test/plugin.test.mjs
@@ -168,6 +168,20 @@ test("second reserve for same artifactId returns 409", async () => {
   }
 });
 
+test("two truly concurrent reserves for the same artifactId: exactly one 201, one 409", async () => {
+  const ctx = await startApp();
+  try {
+    const [a, b] = await Promise.all([
+      tusCreate(ctx.baseUrl, { artifactId: ID1, filename: "clip.mp4", size: 1024 }),
+      tusCreate(ctx.baseUrl, { artifactId: ID1, filename: "clip.mp4", size: 1024 }),
+    ]);
+    const statuses = [a.status, b.status].sort();
+    assert.deepEqual(statuses, [201, 409]);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
 test("non-allowed extension is rejected at create", async () => {
   const ctx = await startApp();
   try {
@@ -233,6 +247,137 @@ test("authorize rejection blocks create, GET, and DELETE", async () => {
 
     const del = await fetch(artifactUrl(ctx, ID1), { method: "DELETE" });
     assert.equal(del.status, 403);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("authorize rejection blocks PATCH and HEAD on an existing upload, and sees the real artifactId", async () => {
+  // Regression test: `authorize` must actually run (with the correct
+  // artifactId) for the patch/head phase, not be silently skipped because the
+  // artifactId couldn't be recovered from the tus URL.
+  const authorizedPhases = [];
+  const ctx = await startApp({
+    pluginOptions: {
+      authorize: async (_req, { phase, artifactId }) => {
+        authorizedPhases.push({ phase, artifactId });
+        if (phase === "patch") {
+          throw Object.assign(new Error("no patch"), { statusCode: 403 });
+        }
+      },
+    },
+  });
+  try {
+    const create = await tusCreate(ctx.baseUrl, {
+      artifactId: ID1,
+      filename: "clip.mp4",
+      size: 1024,
+    });
+    assert.equal(create.status, 201);
+    const location = create.headers.get("location");
+
+    const patch = await tusPatch(location, 0, makeMp4(1024));
+    assert.equal(patch.status, 403, "authorize must reject the PATCH, not silently allow it");
+
+    const head = await tusHead(location);
+    assert.equal(head.status, 403, "authorize must reject the HEAD too");
+
+    const patchCalls = authorizedPhases.filter((c) => c.phase === "patch");
+    assert.ok(patchCalls.length > 0, "authorize must actually run for the patch phase");
+    for (const call of patchCalls) {
+      assert.equal(call.artifactId, ID1, "authorize must see the real artifactId, not the kind prefix or undefined");
+    }
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("a crafted multi-segment PATCH URL cannot smuggle bytes into a different artifact than authorize() checked", async () => {
+  // Regression test for a URL-parsing divergence: `authorize()`'s artifactId
+  // must always be resolved the same way `@tus/server` itself resolves the
+  // file it will actually read/write — the *last* `/`-delimited URL segment,
+  // not the first one after `/upload/`. Fastify's `/upload/*` route accepts
+  // extra trailing segments, so without this, an attacker holding a valid
+  // token for their OWN artifact could append a victim's real (but
+  // ordinarily unguessable-without-the-pairing-link) tus id as a second path
+  // segment: authorize() would see and approve the attacker's own id (first
+  // segment), while the PATCH body actually landed on the victim's file
+  // (the true last segment, per `@tus/server`'s own resolution).
+  const authorizeCalls = [];
+  const ctx = await startApp({
+    pluginOptions: {
+      authorize: async (_req, ctx) => {
+        authorizeCalls.push(ctx);
+        if (ctx.phase === "create") return; // simulate two independently-authorized sessions
+        if (ctx.artifactId !== ID1) {
+          throw Object.assign(new Error("forbidden"), { statusCode: 403 });
+        }
+      },
+    },
+  });
+  try {
+    // ID1 = "attacker's own artifact" (authorize approves it); ID2 = "victim's artifact"
+    // (authorize would reject it) — both created via a legitimate POST first.
+    const victimCreate = await tusCreate(ctx.baseUrl, { artifactId: ID2, filename: "clip.mp4", size: 1024 });
+    const attackerCreate = await tusCreate(ctx.baseUrl, { artifactId: ID1, filename: "clip.mp4", size: 1024 });
+    assert.equal(victimCreate.status, 201);
+    assert.equal(attackerCreate.status, 201);
+
+    const attackerSegment = attackerCreate.headers.get("location").split("/upload/")[1];
+    const victimSegment = victimCreate.headers.get("location").split("/upload/")[1];
+    const craftedUrl = `${ctx.baseUrl}${PREFIX}/upload/${attackerSegment}/${victimSegment}`;
+
+    const patch = await tusPatch(craftedUrl, 0, makeMp4(1024));
+    assert.equal(patch.status, 403, "must be rejected, not silently write to the victim's artifact");
+
+    const patchCall = authorizeCalls.find((c) => c.phase === "patch");
+    assert.equal(patchCall.artifactId, ID2, "authorize must see the artifactId @tus/server will actually operate on");
+
+    const victimBytes = await fs.readFile(path.join(ctx.workspaceDir, "video", `${ID2}.mp4`)).catch(() => null);
+    assert.equal(victimBytes.length, 0, "victim's file must be untouched (still 0 bytes from create)");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("createCapabilityAuthorize: PATCH without a valid token is rejected, not silently accepted", async () => {
+  // The artifactId is not secret (it's embedded in the pairing link/QR code
+  // by design) — the token is what's supposed to gate writing bytes into an
+  // upload. This exercises the exact bypass scenario the fix above closes.
+  const secret = "test-secret";
+  const issuer = "https://vault.example.test";
+  const lookupSecret = (kid) => (kid === "k1" ? secret : null);
+  const ctx = await startApp({
+    pluginOptions: {
+      authorize: createCapabilityAuthorize(lookupSecret, { issuer }),
+    },
+  });
+  try {
+    const token = issueCapabilityToken(ID1, secret, { keyId: "k1", issuer });
+    const create = await tusCreate(ctx.baseUrl, {
+      artifactId: ID1,
+      filename: "clip.mp4",
+      size: 1024,
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    assert.equal(create.status, 201);
+    const location = create.headers.get("location");
+
+    // No credential presented at all -> 401 (PROTOCOL.md §5.2), not a silent pass-through.
+    const noToken = await tusPatch(location, 0, makeMp4(1024));
+    assert.equal(noToken.status, 401, "PATCH with no token must be rejected");
+
+    const unrelatedToken = issueCapabilityToken("cccccccc-cccc-4ccc-8ccc-cccccccccccc", secret, {
+      keyId: "k1",
+      issuer,
+    });
+    const wrongToken = await tusPatch(location, 0, makeMp4(1024), {
+      Authorization: `Bearer ${unrelatedToken}`,
+    });
+    assert.equal(wrongToken.status, 403, "PATCH with a token for a different artifact must be rejected");
+
+    const ok = await tusPatch(location, 0, makeMp4(1024), { Authorization: `Bearer ${token}` });
+    assert.equal(ok.status, 204, "PATCH with the legitimate token must still succeed");
   } finally {
     await ctx.teardown();
   }

--- a/test/s3-storage.test.mjs
+++ b/test/s3-storage.test.mjs
@@ -192,6 +192,16 @@ test("second reserve for same artifactId returns 409", async () => {
   }
 });
 
+// No genuinely-concurrent equivalent of `plugin.test.mjs`'s "two truly concurrent
+// reserves" test here: `reserveUpload`'s collision guard uses `PutObjectCommand`'s
+// `IfNoneMatch: "*"` to close the race atomically, but `s3rver` (this suite's local S3
+// double) doesn't enforce conditional writes — it silently accepts both concurrent puts,
+// so a test written the same way would pass against real AWS S3/R2 but fail here for a
+// reason unrelated to the code under test. The local-filesystem adapter's equivalent test
+// (`plugin.test.mjs`) exercises the same technique (atomic create-if-absent) against a
+// primitive (`fs.writeFile` with the `wx` flag) that this test runner's environment does
+// enforce, and is the real regression check for the underlying race.
+
 test("createS3Mp4Sniffer rejects non-MP4 bytes and removes the object", async () => {
   const ctx = await startApp({ withSniffer: true });
   const id = randomUUID();


### PR DESCRIPTION
## Summary

Two related bugs let `authorize()` be checked against a different artifactId than the one a `PATCH`/`HEAD` request actually operated on, because the URL parser used for the authorize-hook context diverged from how `@tus/server` itself resolves a request's file id:

- The parser never successfully extracted a UUID for the real `<kind>/<artifactId><ext>` id shape, so the "no artifactId, so allow" fallback silently ran for every such request regardless of `authorize` configuration.
- Even fixed, it still took the *first* URL segment after `/upload/` while `@tus/server`'s own routing takes the *last* — exploitable via a crafted multi-segment URL (Fastify's wildcard route accepts extra trailing segments) to have `authorize()` approve one artifact while the request body lands on a different one.

Both are fixed by resolving the id through the exact parser the actual upload-completion path uses. Regression tests reproduce both failure modes directly against a running server.

Along the way, this also:
- Streams checksum digests instead of buffering whole files into memory (relevant when `maxUploadSize: Infinity` is combined with checksum validation)
- Hardens `reserveUpload`'s collision guard on both storage adapters and surfaces the S3 conditional-write fallback as a startup warning
- Enforces the https-only `server` rule in `buildUploadLink` itself, not just in client-side documentation
- Adds two new normative `PROTOCOL.md` requirements (`§4.3` Location validation, `§4.4` consistent request routing) generalizing the fixes for any Pulse-compatible implementation
- Reworks the Fastify reference demo (`examples/rn-demo`) to actually exercise the library's documented feature set — real capability tokens instead of a static shared secret, checksum validation, `onArtifactEvent` wired to a live feed, uploads grouped by recording session via `relatedTo`, and a redesigned responsive pairing page with the README's own protocol diagrams rendered inline

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 93/93 passing, including 3 new regression tests for the authorize bugs
- [x] `npm run e2e` — full create → PATCH → HEAD → GET flow against the rn-demo server, now using real signed capability tokens
- [x] Manually verified the rn-demo changes against a real device over LAN (pairing, multi-beat upload, checksum verification, captions matching, live event feed, mobile layout)