### PR TITLE
license: switch to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,45 +1,21 @@
-@mieweb/pulsevault - Source Available License
+MIT License
 
-Copyright (c) 2026 Medical Informatics Engineering, LLC. All rights reserved.
+Copyright (c) 2026 Medical Informatics Engineering, LLC
 
-This software and associated documentation files (the "Software") are the
-proprietary property of Medical Informatics Engineering, LLC. ("MIE").
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-OPEN SOURCE / NON-COMMERCIAL USE
-
-Permission is hereby granted, free of charge, to any person or organization
-obtaining a copy of this Software, to use, copy, modify, merge, and distribute
-the Software for non-commercial purposes, subject to the following conditions:
-
-1. Attribution Required: The above copyright notice, this permission notice,
-   and clear attribution to Medical Informatics Engineering, LLC. shall be
-   included in all copies or substantial portions of the Software.
-
-2. Open Source Requirement: If you distribute the Software or any derivative
-   works, you must do so under an open source license approved by the Open
-   Source Initiative (OSI) and make the source code publicly available.
-
-3. Non-Commercial Use Only: This license does not grant permission to use the
-   Software for commercial purposes. "Commercial purposes" means any use
-   intended for or directed toward commercial advantage or monetary
-   compensation.
-
-COMMERCIAL USE
-
-For commercial use, including but not limited to:
-- Use in proprietary/closed-source products
-- Use in products or services sold for profit
-- Use by for-profit organizations for internal business operations
-
-You must obtain a separate commercial license from Medical Informatics
-Engineering, LLC. Contact: https://www.mieweb.com or helpdesk@mieweb.com
-
-NO WARRANTY
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-MEDICAL INFORMATICS ENGINEERING, LLC. OR ITS AFFILIATES BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
-OR OTHER DEALINGS IN THE SOFTWARE.
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Resumable video uploads via the [TUS protocol](https://tus.io/), with filesystem-first local storage and deep link helpers for the [Pulse](https://github.com/mieweb/pulse) mobile app. Ships as a Fastify plugin (`@mieweb/pulsevault`) and as a framework-agnostic core (`@mieweb/pulsevault/core`) for Express, Meteor, or plain `http.createServer` — see [Non-Fastify hosts](#non-fastify-hosts-express-meteor-plain-http).
 
-**Licensing note**: this package is currently Source Available (free for non-commercial use; see [License](#license)) — a move to a fully OSI-approved open source license is planned but not yet landed. If you're evaluating this for adoption, read [License](#license) before investing evaluation time.
-
 See also: [`PROTOCOL.md`](PROTOCOL.md) (the wire contract, independent of this implementation — read this if you're building a Pulse-compatible server *without* this package) and [`OPERATIONS.md`](OPERATIONS.md) (scaling, secrets, retention, monitoring).
 
 Self-hosted video capture for places that can't ship recordings to a vendor. Pulse records the walkthrough on the phone; Pulsevault receives it inside the backend you already run, behind your auth, on your storage. Pair a device by QR code and upload over TUS so two-minute captures from the floor survive signal drops and device restarts.
@@ -786,8 +784,6 @@ Under `@mieweb/pulsevault/core` there's no decorator (no Fastify instance to han
 
 ## License
 
-Source Available — free for non-commercial use under the terms in [LICENSE](LICENSE), which also requires that redistributions be published under an OSI-approved open source license. Commercial use requires a separate license from Medical Informatics Engineering, LLC — contact [helpdesk@mieweb.com](mailto:helpdesk@mieweb.com) or [mieweb.com](https://www.mieweb.com).
+MIT — see [LICENSE](LICENSE).
 
-A move to a fully OSI-approved open source license for this package itself is planned, to remove this friction for adopters entirely — tracked as a follow-up, not yet decided which license.
-
-Copyright © 2026 Medical Informatics Engineering, LLC. All rights reserved.
+Copyright © 2026 Medical Informatics Engineering, LLC.

--- a/examples/express-demo/package-lock.json
+++ b/examples/express-demo/package-lock.json
@@ -14,11 +14,11 @@
     "../..": {
       "name": "@mieweb/pulsevault",
       "version": "0.1.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MIT",
       "dependencies": {
         "@fastify/send": "^4.1.0",
-        "@tus/file-store": "^2.0.0",
-        "@tus/server": "^2.0.0",
+        "@tus/file-store": "2.0.0",
+        "@tus/server": "2.0.0",
         "fastify-plugin": "^5.1.0"
       },
       "devDependencies": {

--- a/examples/meteor-demo/package-lock.json
+++ b/examples/meteor-demo/package-lock.json
@@ -16,7 +16,7 @@
     "../..": {
       "name": "@mieweb/pulsevault",
       "version": "0.1.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MIT",
       "dependencies": {
         "@fastify/send": "^4.1.0",
         "@tus/file-store": "2.0.0",

--- a/examples/rn-demo/package-lock.json
+++ b/examples/rn-demo/package-lock.json
@@ -16,7 +16,7 @@
     "../..": {
       "name": "@mieweb/pulsevault",
       "version": "0.1.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MIT",
       "dependencies": {
         "@fastify/send": "^4.1.0",
         "@tus/file-store": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@mieweb/pulsevault",
       "version": "0.1.0",
-      "license": "SEE LICENSE IN LICENSE",
+      "license": "MIT",
       "dependencies": {
         "@fastify/send": "^4.1.0",
         "@tus/file-store": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "contributors": [
     "morepriyam (https://github.com/morepriyam)"
   ],
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mieweb/pulsevault.git"


### PR DESCRIPTION
## Summary
- Replaces the custom source-available/non-commercial `LICENSE` with standard MIT.
- Updates `package.json`'s `license` field from `SEE LICENSE IN LICENSE` to `MIT`.
- Removes the now-outdated "Licensing note" and "planned but not yet decided" follow-up language from the README's intro and License section.
- Regenerates the root and example lockfiles so their mirrored `license` field matches.

## Test plan
- [x] `npm test` — 93/93 passing