### PR TITLE
feat: per-session uploadUnit override on pairing link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,13 @@ if you've evaluated against an intermediate build.
   purely advertised via `/capabilities`; the operator declares which upload
   strategy this deployment expects, the client branches on it. Not enforced
   by the plugin.
+- **`buildUploadLink({ uploadUnit })`** (PROTOCOL.md §3, §8) — optional
+  per-session override of the deployment-wide `uploadUnit`, carried on the
+  pairing link itself instead of only `/capabilities`. Lets an operator run
+  `"beat"` and `"merged"` sessions concurrently (staged rollout, A/B test,
+  per-tenant policy) without racing a client's separate `/capabilities` fetch
+  against a single, deployment-wide value. Fully backward compatible: omit it
+  and a client falls back to `/capabilities` exactly as before.
 - **`onArtifactEvent` plugin option** — one low-frequency hook (authorize
   rejection, completion, validation rejection — never per chunk) covering
   both ops metrics and a compliance audit trail from a single integration

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -74,7 +74,7 @@ the integer from `protocolVersion`.
 A server presents a pairing link or QR code of the form:
 
 ```
-pulsecam://?v=1&artifactId=<uuid>&server=<origin>&token=<opaque>
+pulsecam://?v=1&artifactId=<uuid>&server=<origin>&token=<opaque>&uploadUnit=<beat|merged>
 ```
 
 - `v` (REQUIRED): the deep-link schema version. A client MUST refuse and
@@ -96,6 +96,17 @@ pulsecam://?v=1&artifactId=<uuid>&server=<origin>&token=<opaque>
   `artifactId` (or a session it anchors, §5.4), not a standing general
   credential — see §5.4 for the recommended (but not required) capability-
   token shape.
+- `uploadUnit` (OPTIONAL, `"beat"` or `"merged"`): per-session override of the
+  deployment-wide value reported by `GET /capabilities` (§2, §8). When
+  present, a client MUST use this value for the session anchored to this
+  link instead of whatever `/capabilities` currently reports, and MUST NOT
+  perform a separate `/capabilities` fetch just to decide merge/upload
+  strategy for it. When absent, a client MUST fall back to `/capabilities`
+  exactly as before this field existed — an operator that never sets it sees
+  no change in client behavior. This lets one deployment run "beat" and
+  "merged" sessions concurrently (e.g. a staged rollout) without racing a
+  single, deployment-wide `/capabilities` value against whichever moment a
+  client happened to fetch it.
 
 A client SHOULD display the server's origin (and, where feasible, its TLS
 certificate fingerprint) to the user before uploading anything, rather than
@@ -274,7 +285,9 @@ clear, specific message rather than a generic failure.
 A pulse (a short composed of one or more beats) MAY be uploaded as a single
 pre-merged video (`uploadUnit: "merged"`) or as individual per-beat artifacts
 plus a manifest (`uploadUnit: "beat"`) — the operator declares which via
-`/capabilities` (§2); this document does not prefer one over the other.
+`/capabilities` (§2), optionally overridden per session via the pairing
+link's `uploadUnit` param (§3); this document does not prefer one over the
+other.
 
 Under `uploadUnit: "beat"`, a client uploads each beat under its own
 `artifactId`, plus one manifest artifact (`kind: "project"`, a JSON document

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ Maximum upload size in bytes. Use `Infinity` for no cap.
 
 A client reads this at pairing time, before doing any merge or upload work, and branches accordingly. See `PROTOCOL.md` §8 for the full contract.
 
+Need both strategies live at once instead of one fixed value for the whole deployment? Pass `uploadUnit` to [`buildUploadLink`](#deep-link-helper) per session — it overrides `/capabilities` for that pairing only, with no server-side option to change.
+
 ### `decoratorName`
 
 Name of the Fastify decorator that exposes the storage adapter on the instance. Defaults to `"pulseVault"`. Override when registering the plugin more than once in the same process.
@@ -736,9 +738,12 @@ const uploadLink = buildUploadLink({
   server: "https://example.com/pulsevault",
   artifactId: randomUUID(), // generate server-side; skip POST /reserve on the app
   token: "secret", // optional — forwarded to your authorize hook; see Capability tokens
+  uploadUnit: "merged", // optional — see "Upload unit" below
 });
-// pulsecam://?v=1&artifactId=...&server=https%3A%2F%2Fexample.com%2Fpulsevault&token=secret
+// pulsecam://?v=1&artifactId=...&server=https%3A%2F%2Fexample.com%2Fpulsevault&token=secret&uploadUnit=merged
 ```
+
+`uploadUnit` on the link is a **per-session override** of whatever `GET /capabilities` currently reports (PROTOCOL.md §3, §8). Omit it and nothing changes — the client falls back to `/capabilities` exactly as before. Set it when you want "beat" and "merged" sessions live at the same time (staged rollout, A/B test, per-tenant policy) instead of one fixed value for the whole deployment — `/capabilities` can only ever report one current value, and a client reading it separately from opening the link is racing whatever the server happened to be serving at that moment, not the value this specific session was paired under.
 
 ## Tests
 

--- a/examples/rn-demo/public/index.html
+++ b/examples/rn-demo/public/index.html
@@ -187,6 +187,17 @@ sequenceDiagram
       <div class="panel">
         <img id="qrUpload" width="200" height="200" style="display: block; margin: 0 auto 1rem; border-radius: 8px; background: #fff; padding: 10px;" />
         <a id="openBtnUpload" class="btn btn-primary" href="#">Open in Pulse app</a>
+
+        <label for="uploadUnitOverride">
+          Upload unit for this link
+          <span class="mono" style="text-transform: none; font-weight: 400;" title="Per-link override — carried on the pairing link itself (PROTOCOL.md §3, §8), independent of the deployment-wide toggle in the status bar above. Lets you pair two devices to 'beat' and 'merged' sessions at the same time.">(overrides the status-bar toggle, this link only)</span>
+        </label>
+        <select id="uploadUnitOverride" class="btn btn-ghost" style="margin-bottom: 0.6rem;">
+          <option value="">Use server default (from /capabilities)</option>
+          <option value="beat">Force "beat" for this link</option>
+          <option value="merged">Force "merged" for this link</option>
+        </select>
+
         <button id="refreshUpload" class="btn btn-ghost">↻ Generate new pairing link</button>
         <details>
           <summary>Link details</summary>
@@ -194,6 +205,8 @@ sequenceDiagram
           <p class="mono" id="serverUrl"></p>
           <label>Artifact ID (session anchor)</label>
           <p class="mono" id="uploadArtifactId"></p>
+          <label>Upload unit on this link</label>
+          <p class="mono" id="uploadUnitOnLink"></p>
           <label>Deep link</label>
           <p class="mono" id="deeplinkUpload"></p>
         </details>
@@ -241,11 +254,12 @@ sequenceDiagram
       }
 
       function renderStatusBar(auth) {
+        window.__lastAuth = auth ?? window.__lastAuth;
         const caps = window.__caps;
         if (!caps) return;
         const chips = [
           `<span class="chip"><span class="dot success"></span>Protocol <b>v${caps.protocolVersion}</b></span>`,
-          `<span class="chip">Upload unit <b>${caps.uploadUnit}</b></span>`,
+          `<span class="chip" title="Deployment-wide default from /pulsevault/capabilities. Fixed at server startup (UPLOAD_UNIT env var) — use the per-link override below to test the other mode without restarting.">Upload unit default <b>${caps.uploadUnit}</b></span>`,
           window.__storage ? `<span class="chip">Storage <b>${window.__storage}</b></span>` : "",
           auth
             ? `<span class="chip"><span class="dot ${auth.authMode ? "success" : "off"}"></span>Auth <b>${auth.authMode ? `capability tokens (${auth.keyId})` : "open"}</b></span>`
@@ -255,7 +269,9 @@ sequenceDiagram
       }
 
       async function loadDeeplinks() {
-        const data = await fetch("/deeplinks").then((r) => r.json());
+        const override = document.getElementById("uploadUnitOverride").value;
+        const qs = override ? `?uploadUnit=${override}` : "";
+        const data = await fetch(`/deeplinks${qs}`).then((r) => r.json());
         window.__storage = data.storage;
 
         document.getElementById("serverUrl").textContent = window.location.origin;
@@ -263,6 +279,13 @@ sequenceDiagram
         document.getElementById("deeplinkUpload").textContent = data.upload;
         document.getElementById("openBtnUpload").href = data.upload;
         document.getElementById("qrUpload").src = data.qrUpload;
+
+        // Read straight off the generated link rather than trusting `override` blindly — this is
+        // what the link actually carries, i.e. exactly what the app will honor.
+        const linkUploadUnit = new URL(data.upload).searchParams.get("uploadUnit");
+        document.getElementById("uploadUnitOnLink").textContent = linkUploadUnit
+          ? `${linkUploadUnit} (per-link override)`
+          : `${window.__caps ? window.__caps.uploadUnit : "?"} (from /capabilities, no override on this link)`;
 
         renderStatusBar(data);
 
@@ -349,6 +372,9 @@ sequenceDiagram
       loadPulses();
       loadEvents();
       document.getElementById("refreshUpload").addEventListener("click", loadDeeplinks);
+      // Changing the override regenerates immediately — no reason to make the user also hit
+      // "Generate new pairing link" to see the effect of their own selection.
+      document.getElementById("uploadUnitOverride").addEventListener("change", loadDeeplinks);
       document.getElementById("refreshPulses").addEventListener("click", loadPulses);
       // Live-ish feed: poll rather than hold a socket open, since this is a demo page, not
       // something that needs to survive a flaky connection.

--- a/examples/rn-demo/server.mjs
+++ b/examples/rn-demo/server.mjs
@@ -95,6 +95,20 @@ function recordEvent(event) {
   if (recentEvents.length > MAX_EVENTS) recentEvents.length = MAX_EVENTS;
 }
 
+// ---------------------------------------------------------------------------
+// Upload-unit deployment default (README "Upload unit") — purely advertisory
+// via `GET /pulsevault/capabilities`; the plugin never enforces "beat" vs
+// "merged", it just reports whichever value this server passes at
+// registration. The plugin bakes this in as a fixed option captured once at
+// `register()` time — there's no live setter for it, so changing this
+// deployment-wide default means restarting with a different env var
+// (`UPLOAD_UNIT=merged npm start`), not a runtime toggle. To test both
+// "beat" and "merged" without restarting, use the per-link `uploadUnit`
+// override on `GET /deeplinks` / `buildUploadLink` instead (PROTOCOL.md §3,
+// §8) — the pairing page's "Upload unit for this link" selector drives it.
+// ---------------------------------------------------------------------------
+const uploadUnitDefault = process.env.UPLOAD_UNIT === "merged" ? "merged" : "beat";
+
 const app = Fastify({
   logger: true,
   bodyLimit: 16 * 1024 * 1024, // max single PATCH chunk (RN app sends 1 MB chunks)
@@ -431,6 +445,13 @@ app.get(
 // so it stays the source of truth. `server` must include the plugin's
 // `prefix` ("/pulsevault") — the client builds every request as
 // `${server}/<path>` with no prefix concept of its own.
+//
+// `?uploadUnit=beat|merged` lets this *one* pairing link override the
+// deployment-wide default set above — demonstrates running "beat" and
+// "merged" sessions concurrently (README "Upload unit") instead of one fixed
+// value for every pairing. Omit it and behavior is unchanged: the link
+// carries no override, and the client falls back to whatever `/capabilities`
+// reports, same as before this param existed.
 app.get("/deeplinks", async (req, reply) => {
   // In the open (no-auth) case, keep deriving `server` from request headers —
   // convenient, and there's no issuer consistency requirement to protect.
@@ -442,6 +463,11 @@ app.get("/deeplinks", async (req, reply) => {
   const host = req.headers["x-forwarded-host"] ?? req.headers.host;
   const server = PULSEVAULT_SECRET ? `${ISSUER}/pulsevault` : `${proto}://${host}/pulsevault`;
   const artifactId = randomUUID();
+
+  const requestedUploadUnit = req.query?.uploadUnit;
+  if (requestedUploadUnit !== undefined && requestedUploadUnit !== "beat" && requestedUploadUnit !== "merged") {
+    return reply.code(400).send({ error: '`uploadUnit` query param must be "beat" or "merged"' });
+  }
 
   const token = PULSEVAULT_SECRET
     ? issueCapabilityToken(artifactId, PULSEVAULT_SECRET, {
@@ -455,6 +481,7 @@ app.get("/deeplinks", async (req, reply) => {
     server,
     artifactId,
     ...(token && { token }),
+    ...(requestedUploadUnit && { uploadUnit: requestedUploadUnit }),
   });
 
   const qrUpload = await QRCode.toDataURL(upload, {
@@ -512,6 +539,7 @@ await app.register(pulseVault, {
   prefix: "/pulsevault",
   storage: pulseStorage,
   maxUploadSize: 5 * 1024 * 1024 * 1024, // 5 GiB
+  uploadUnit: uploadUnitDefault,
   // Accept MP4 videos, Pulse draft bundles (.pulse) + diagnostic zips, and SRT captions.
   allowedExtensions: { video: [".mp4"], project: [".pulse", ".zip"], captions: [".srt"] },
   // validatePayload runs for every kind, with ctx.kind telling you which.

--- a/src/lib/deeplinks.ts
+++ b/src/lib/deeplinks.ts
@@ -16,6 +16,19 @@ export type UploadLinkOptions = {
    * step. Generate with `crypto.randomUUID()`.
    */
   artifactId: string;
+  /**
+   * Per-session override of the deployment-wide `uploadUnit` advertised via
+   * `GET /capabilities` (PROTOCOL.md §8). Omit to let the client fall back to
+   * whatever `/capabilities` reports — the same behavior as before this field
+   * existed. Set this when an operator wants "beat" and "merged" sessions
+   * live at the same time (e.g. different pairing flows, a/b testing, a
+   * gradual rollout) rather than one fixed value for the whole deployment:
+   * `/capabilities` can only ever report one current value, and a client
+   * that reads it separately from opening the link is racing whatever the
+   * server was serving at that moment, not the value this specific session
+   * was paired under.
+   */
+  uploadUnit?: 'beat' | 'merged';
 };
 
 /** Deep-link wire format version. Bump when the param shape changes incompatibly. */
@@ -72,11 +85,16 @@ export function buildUploadLink(opts: UploadLinkOptions): string {
     );
   }
 
+  if (opts.uploadUnit !== undefined && opts.uploadUnit !== 'beat' && opts.uploadUnit !== 'merged') {
+    throw new Error(`buildUploadLink: \`uploadUnit\` must be "beat" or "merged" (got "${opts.uploadUnit}")`);
+  }
+
   const params = new URLSearchParams({
     v: LINK_VERSION,
     artifactId: opts.artifactId,
     server: opts.server,
   });
   if (opts.token) params.set('token', opts.token);
+  if (opts.uploadUnit) params.set('uploadUnit', opts.uploadUnit);
   return `pulsecam://?${params.toString()}`;
 }

--- a/test/deeplinks.test.mjs
+++ b/test/deeplinks.test.mjs
@@ -64,3 +64,28 @@ test("rejects a hostname that merely contains 'localhost'", () => {
 test("rejects a malformed server URL", () => {
   assert.throws(() => buildUploadLink({ server: "not a url", artifactId: ARTIFACT_ID }));
 });
+
+test("includes uploadUnit when provided, omits it when not", () => {
+  const withUnit = buildUploadLink({
+    server: "https://vault.example.org/pulsevault",
+    artifactId: ARTIFACT_ID,
+    uploadUnit: "merged",
+  });
+  assert.equal(new URLSearchParams(withUnit.split("?")[1]).get("uploadUnit"), "merged");
+
+  const withoutUnit = buildUploadLink({ server: "https://vault.example.org/pulsevault", artifactId: ARTIFACT_ID });
+  assert.equal(new URLSearchParams(withoutUnit.split("?")[1]).get("uploadUnit"), null);
+});
+
+test("accepts both uploadUnit values", () => {
+  for (const uploadUnit of ["beat", "merged"]) {
+    const link = buildUploadLink({ server: "https://vault.example.org/pulsevault", artifactId: ARTIFACT_ID, uploadUnit });
+    assert.equal(new URLSearchParams(link.split("?")[1]).get("uploadUnit"), uploadUnit);
+  }
+});
+
+test("rejects an invalid uploadUnit", () => {
+  assert.throws(() =>
+    buildUploadLink({ server: "https://vault.example.org/pulsevault", artifactId: ARTIFACT_ID, uploadUnit: "bogus" }),
+  );
+});


### PR DESCRIPTION
## Summary
- `buildUploadLink({ uploadUnit })` lets a pairing link carry a per-session override of the deployment-wide `uploadUnit` reported by `GET /capabilities` (PROTOCOL.md §3, §8)
- Omitting it changes nothing: the client still falls back to `/capabilities` exactly as before
- rn-demo pairing page gets a selector to force `beat`/`merged` for one link without restarting the server

## Test plan
- [x] `npm test` (deeplinks.test.mjs) covers accept/reject of `uploadUnit`
- [x] Manually verify the rn-demo pairing page override against a paired app