### PR TITLE
Hard-reject unresolvable artifactIds on PATCH/HEAD; fix §5.1 and authorize-phase docs

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -197,7 +197,7 @@ ones.
 ### 5.1 Token transport
 
 A client MUST send the pairing token as `Authorization: Bearer <token>` on
-every `POST`/`PATCH`/`DELETE` request to `{prefix}/upload*`, and SHOULD also
+every `POST`/`PATCH`/`HEAD`/`DELETE` request to `{prefix}/upload*`, and SHOULD also
 send it as `?token=` on `GET` requests to a watch/playback URL (some servers
 validate playback links without requiring a header, e.g. for browser
 playback). See §4.3 for why the resource URL these requests target must

--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ Upload filenames are keyed by UUID, so `immutable: true` is safe when `maxAge` i
 
 Optional async hook called before TUS create/patch, before GET resolve, and before DELETE. Throw to reject — a `statusCode` or `status_code` number on the thrown error is used as the HTTP status (default `403`).
 
+Phase mapping: `"create"` is the initial TUS `POST`; `"patch"` covers **every other request on the upload routes** — `PATCH` chunks, `HEAD` offset queries, **and the in-flight cancel `DELETE {prefix}/upload/<id>`**; `"resolve"` is `GET {prefix}/artifacts/<id>`; `"delete"` fires **only** for the finalized-artifact route `DELETE {prefix}/artifacts/<id>`. If you gate deletion on `phase === "delete"` alone, you are not gating upload cancellation — that arrives as `"patch"`.
+
 ```ts
 type PulseVaultAuthorize = (
   // PulseVaultRequest only requires `.headers` — under the Fastify plugin

--- a/src/core.ts
+++ b/src/core.ts
@@ -350,7 +350,20 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
       stashPulseVaultContext(req, { artifactId, kind, relatedTo });
     }
 
-    if (!authorize || !artifactId) {
+    if (!authorize) {
+      return { ok: true, artifactId, kind, relatedTo };
+    }
+
+    if (!artifactId && phase === 'patch') {
+      // PROTOCOL.md §5.2: failing to resolve the artifactId for an in-flight
+      // upload request is an authorization failure — reject, don't fall
+      // through to "no artifactId to check, so allow".
+      logger.info({ url: req.url, phase }, 'pulsevault authorize rejected: unresolvable artifactId');
+      writeJson(res, 403, pulseVaultError('Unable to resolve artifact for authorization'));
+      return { ok: false };
+    }
+
+    if (!artifactId) {
       return { ok: true, artifactId, kind, relatedTo };
     }
 

--- a/test/plugin.test.mjs
+++ b/test/plugin.test.mjs
@@ -292,6 +292,38 @@ test("authorize rejection blocks PATCH and HEAD on an existing upload, and sees 
   }
 });
 
+test("PATCH/HEAD with an unresolvable upload id is a hard 403 when authorize is configured (PROTOCOL.md §5.2)", async () => {
+  // Regression test: when the artifactId cannot be recovered from the tus
+  // URL, authorization-context resolution failure must be treated as an
+  // authorization failure — never "no artifactId to check, so allow".
+  const authorizedIds = [];
+  const ctx = await startApp({
+    pluginOptions: {
+      authorize: async (_req, { artifactId }) => {
+        authorizedIds.push(artifactId);
+      },
+    },
+  });
+  try {
+    // Valid base64url characters, but decodes to garbage with no UUID inside,
+    // so `artifactIdFromTusUrl` cannot resolve an artifactId for it.
+    const bogus = `${ctx.baseUrl}${PREFIX}/upload/not-a-real-upload-id`;
+
+    const patch = await tusPatch(bogus, 0, makeMp4(1024));
+    assert.equal(patch.status, 403, "unresolvable PATCH target must be rejected, not silently allowed");
+
+    const head = await tusHead(bogus);
+    assert.equal(head.status, 403, "unresolvable HEAD target must be rejected too");
+
+    assert.ok(
+      authorizedIds.every((id) => id !== undefined),
+      "authorize must never be invoked with an undefined artifactId",
+    );
+  } finally {
+    await ctx.teardown();
+  }
+});
+
 test("a crafted multi-segment PATCH URL cannot smuggle bytes into a different artifact than authorize() checked", async () => {
   // Regression test for a URL-parsing divergence: `authorize()`'s artifactId
   // must always be resolved the same way `@tus/server` itself resolves the


### PR DESCRIPTION
## Summary

- **fix(auth):** `runAuthorize` silently allowed `PATCH`/`HEAD` (and the in-flight cancel `DELETE`, which runs as phase `patch`) when the artifactId could not be recovered from the tus resource URL — despite PROTOCOL.md §5.2 requiring that resolution failure be treated as an authorization failure, and despite the CHANGELOG already claiming that behavior. When an `authorize` hook is configured, an unresolvable artifactId on the patch phase now gets a hard 403 before the request reaches the tus handler. Practical exploitability was nil (an id `core.ts` can't parse also can't resolve to a real upload inside `@tus/server`), but this closes the gap between documented and actual behavior.
- **regression test:** bogus upload ids on PATCH/HEAD must 403, and `authorize` must never be invoked with an undefined artifactId.
- **docs (PROTOCOL.md §5.1):** the token MUST list omitted `HEAD`, but the reference server rejects token-less HEAD and the Pulse client sends the token on every request — a third-party client implemented strictly from the spec could never resume. `HEAD` added.
- **docs (README):** documented the authorize phase mapping explicitly — the in-flight cancel `DELETE` on the upload routes arrives as phase `"patch"`; `"delete"` only fires for the finalized-artifact route. Operators gating deletion on `"delete"` alone were not gating upload cancellation.

## Testing

- `npm run build` clean, `npm test`: **97/97 pass** (96 existing + the new regression test).

Fixes #29 is not included here — this PR contains only the code/doc fixes; the release + PR-gated CI tracked in #29 can follow it.