### PR TITLE
fix(tus): return a relative Location so uploads work behind TLS-terminating proxies

### DIFF
--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -189,9 +189,12 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
 
       return storage.reserveUpload({ artifactId, filename, ext, kind, relatedTo, checksum });
     },
-    generateUrl(_req, { proto, host, path: tusBasePath, id }) {
+    // Relative Location (RFC 7231 §7.1.2) so the upload URL is correct behind
+    // any TLS-terminating proxy without trusting spoofable X-Forwarded-*
+    // headers; clients resolve it against the request URL they already used.
+    generateUrl(_req, { path: tusBasePath, id }) {
       const encoded = Buffer.from(id, 'utf8').toString('base64url');
-      return `${proto}://${host}${tusBasePath}/${encoded}`;
+      return `${tusBasePath}/${encoded}`;
     },
     getFileIdFromRequest(_req, lastPath) {
       if (!lastPath) {

--- a/test/artifact-kinds.test.mjs
+++ b/test/artifact-kinds.test.mjs
@@ -88,7 +88,7 @@ async function uploadFull(ctx, { artifactId, idKey = "artifactId", filename, kin
     relatedTo,
   });
   assert.equal(create.status, 201, `create ${filename}`);
-  const location = create.headers.get("location");
+  const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
   assert.ok(location, "location header");
   const patch = await tusPatch(location, 0, payload);
   assert.equal(patch.status, 204, `patch ${filename}`);

--- a/test/express-adapter.test.mjs
+++ b/test/express-adapter.test.mjs
@@ -63,7 +63,7 @@ test("express: full TUS upload + GET round-trips through app.use(prefix, core.ha
       size: body.length,
     });
     assert.equal(create.status, 201);
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
 
     const patch = await tusPatch(location, 0, body);
     assert.equal(patch.status, 204);

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -85,8 +85,11 @@ export async function uploadFull(
     headers,
   });
   assert.equal(create.status, 201, "create");
-  const location = create.headers.get("location");
-  assert.ok(location, "location header");
+  const rawLocation = create.headers.get("location");
+  assert.ok(rawLocation, "location header");
+  // The server returns a relative Location; resolve it against the base URL
+  // the same way real tus clients resolve it against the request URL.
+  const location = new URL(rawLocation, baseUrl).href;
   const patch = await tusPatch(location, 0, payload, headers);
   assert.equal(patch.status, 204, "patch");
   return { body: payload, location };

--- a/test/http-adapter.test.mjs
+++ b/test/http-adapter.test.mjs
@@ -117,7 +117,7 @@ test("HEAD + resume PATCH completes the upload", async () => {
       filename: "clip.mp4",
       size: body.length,
     });
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
     const half = body.length / 2;
 
     const p1 = await tusPatch(location, 0, body.subarray(0, half));
@@ -294,7 +294,7 @@ test("createMp4Sniffer rejects non-MP4 bytes and removes the artifact", async ()
       size: fake.length,
     });
     assert.equal(create.status, 201);
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
 
     const patch = await tusPatch(location, 0, fake);
     assert.ok(
@@ -377,7 +377,7 @@ test("checksum validator accepts a matching digest and rejects a mismatched one"
       size: body.length,
       checksum: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     });
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
     const patch = await tusPatch(location, 0, body);
     assert.equal(patch.status, 422, "mismatched checksum is rejected");
   } finally {

--- a/test/plugin.test.mjs
+++ b/test/plugin.test.mjs
@@ -121,7 +121,7 @@ test("HEAD + resume PATCH completes the upload", async () => {
       filename: "clip.mp4",
       size: body.length,
     });
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
     const half = body.length / 2;
 
     const p1 = await tusPatch(location, 0, body.subarray(0, half));
@@ -274,7 +274,7 @@ test("authorize rejection blocks PATCH and HEAD on an existing upload, and sees 
       size: 1024,
     });
     assert.equal(create.status, 201);
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
 
     const patch = await tusPatch(location, 0, makeMp4(1024));
     assert.equal(patch.status, 403, "authorize must reject the PATCH, not silently allow it");
@@ -393,7 +393,7 @@ test("createCapabilityAuthorize: PATCH without a valid token is rejected, not si
       headers: { Authorization: `Bearer ${token}` },
     });
     assert.equal(create.status, 201);
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
 
     // No credential presented at all -> 401 (PROTOCOL.md §5.2), not a silent pass-through.
     const noToken = await tusPatch(location, 0, makeMp4(1024));
@@ -455,7 +455,7 @@ test("createMp4Sniffer rejects non-MP4 bytes and removes the artifact", async ()
       size: fake.length,
     });
     assert.equal(create.status, 201);
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
 
     const patch = await tusPatch(location, 0, fake);
     assert.ok(
@@ -652,7 +652,7 @@ test("checksum validator accepts a matching digest and rejects a mismatched one"
       size: body.length,
       checksum: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     });
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
     const patch = await tusPatch(location, 0, body);
     assert.equal(patch.status, 422, "mismatched checksum is rejected");
 

--- a/test/s3-storage.test.mjs
+++ b/test/s3-storage.test.mjs
@@ -146,7 +146,7 @@ test("HEAD + resume PATCH completes the multipart upload", async () => {
       filename: "clip.mp4",
       size: body.length,
     });
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
     const half = body.length / 2;
 
     const p1 = await tusPatch(location, 0, body.subarray(0, half));
@@ -217,7 +217,7 @@ test("createS3Mp4Sniffer rejects non-MP4 bytes and removes the object", async ()
       size: fake.length,
     });
     assert.equal(create.status, 201);
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
 
     const patch = await tusPatch(location, 0, fake);
     assert.ok(
@@ -282,7 +282,7 @@ test("createS3ChecksumValidator accepts a matching digest and rejects a mismatch
       size: body.length,
       checksum: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
     });
-    const location = create.headers.get("location");
+    const location = new URL(create.headers.get("location"), baseUrl).href;
     const patch = await tusPatch(location, 0, body);
     assert.equal(patch.status, 422, "mismatched checksum is rejected");
   } finally {


### PR DESCRIPTION
## Problem

Deployed behind an HTTPS reverse proxy (nginx/Caddy terminating TLS), the tus create response returned an absolute `Location` with an `http://` scheme. `@tus/server` only reads `X-Forwarded-Proto`/`X-Forwarded-Host` when constructed with `respectForwardedHeaders: true` — which was never set — so `proto` always fell back to `http`. Clients that pin every upload request to the paired server's origin (scheme included) reject the mismatched URL with *"Server returned an upload location on an unexpected origin"*, breaking uploads on any proxied deployment even when the proxy forwards the right headers.

## Fix

`generateUrl` now returns a **relative** `Location` (`<basePath>/upload/<id>`), valid per RFC 7231 §7.1.2. Clients resolve it against the request URL they already used, so the resulting upload URL is correct behind any proxy with zero configuration — and the server never has to trust spoofable `X-Forwarded-*` headers when it's directly exposed.

## Tests

- Shared `uploadFull` helper and per-suite call sites now resolve the `Location` against the base URL, mirroring how real tus clients resolve it against the request URL.
- S3 presigned-redirect assertions are untouched — those `Location`s are genuinely absolute.
- Full suite: **100/100 passing**.

Verified end-to-end against a production deployment where the `http://` Location was reproducible via `POST /pulsevault/upload` through the HTTPS proxy.