### PR TITLE
Fail-closed request handlers, 5xx error redaction, and token-parsing robustness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,13 @@ if you've evaluated against an intermediate build.
   reserve collision guard is now genuinely exercised — a concurrent-reserve
   test that was impossible against s3rver has been added. The `ListParts` shim
   (s3rver never implemented it) is gone too.
+- **5xx responses no longer echo internal error messages.** A `markReady`,
+  `onUploadComplete`, or 5xx-class `validatePayload` failure now logs the real
+  error server-side and returns a generic body, so a consumer's DB/storage error
+  text (schema names, paths, infra detail) can't reach the uploading client. 4xx
+  validation rejections (e.g. checksum mismatch) keep their descriptive messages.
+- **Storage subdirectories are created with mode `0o750`** so the upload tree
+  isn't world-readable under a permissive umask.
 
 ### Breaking
 
@@ -194,6 +201,25 @@ if you've evaluated against an intermediate build.
 
 ### Fixed
 
+- **Artifact `GET`/`DELETE` handlers now fail closed.** They run on a hijacked
+  socket, so a thrown storage error (S3 unreachable, disk fault) previously left
+  the socket hung until timeout; each now emits a `500` (or destroys the socket
+  if headers are already sent), mirroring the TUS handler. `GET` streams also
+  catch a mid-stream read error instead of letting an unhandled `'error'` crash
+  the process, and destroy the source stream on client disconnect so file
+  descriptors aren't leaked. Covered by `test/fail-closed.test.mjs`.
+- A consumer error carrying an out-of-range `statusCode` (e.g. `42`) now degrades
+  to the handler's fallback status instead of crashing `res.writeHead`; a
+  malformed request-target that `URL` can't parse returns `400` instead of an
+  uncaught throw.
+- Checksum verification requested against an adapter with no local path now
+  reports `500` (server misconfiguration) instead of `422` (which wrongly
+  implied the client's file was rejected).
+- `verifyCapabilityToken` no longer throws on a token whose payload is valid
+  JSON but not an object (e.g. the literal `null`) — it returns `null` like
+  every other failure, per its single-failure-shape contract.
+- Bearer-token extraction accepts the auth scheme case-insensitively per
+  RFC 7235 (`bearer`/`BEARER`), not only the canonical `Bearer `.
 - `maxUploadSize` enforcement and the in-progress-upload 404 behavior now
   have explicit test coverage proving bytes are rejected/hidden at the right
   point, not just implied by the implementation.

--- a/src/core.ts
+++ b/src/core.ts
@@ -9,7 +9,7 @@ import {
 } from './lib/pulsevaultTus.js';
 import type { PulseVaultValidatePayload } from './lib/magic.js';
 import type { PulseVaultAuthorize } from './lib/authorize.js';
-import { pulseVaultError } from './lib/errors.js';
+import { pulseVaultError, statusCodeOf } from './lib/errors.js';
 import { isUuid } from './lib/uuid.js';
 import { type PulseVaultLogger, consoleLogger } from './lib/request.js';
 import type { PulseVaultStorage, UploadKind } from './storage/types.js';
@@ -238,13 +238,6 @@ async function resolveStorageRelatedTo(
   return result ?? undefined;
 }
 
-function extractAuthzStatus(err: unknown): number {
-  const e = err as { statusCode?: unknown; status_code?: unknown };
-  if (typeof e?.statusCode === 'number') return e.statusCode;
-  if (typeof e?.status_code === 'number') return e.status_code;
-  return 403;
-}
-
 function extractAuthzMessage(err: unknown): string {
   if (err instanceof Error && err.message) return err.message;
   return 'Forbidden';
@@ -371,7 +364,7 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
       await authorize(req, { phase, artifactId, kind, relatedTo });
       return { ok: true, artifactId, kind, relatedTo };
     } catch (err) {
-      const statusCode = extractAuthzStatus(err);
+      const statusCode = statusCodeOf(err, 403);
       const message = extractAuthzMessage(err);
       logger.info({ err, artifactId, phase, statusCode }, 'pulsevault authorize rejected');
       if (phase === 'create') {
@@ -382,40 +375,58 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
     }
   };
 
+  /**
+   * Fail closed on an unexpected handler error. Host frameworks call these
+   * handlers on a *hijacked* socket (e.g. Fastify's `reply.hijack()`), so a
+   * thrown error is never turned into a response by the framework — without
+   * this the socket would hang until the client/server timeout. If headers are
+   * already on the wire we can only destroy the socket; otherwise emit a 500.
+   */
+  const failClosed = (res: ServerResponse, err: unknown, context: string): void => {
+    logger.error({ err }, `pulsevault ${context} failed`);
+    if (res.headersSent || res.writableEnded) {
+      res.destroy();
+      return;
+    }
+    res.statusCode = 500;
+    res.setHeader('content-type', 'text/plain; charset=utf-8');
+    res.end('Internal Server Error');
+  };
+
   const handleTus = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     stampProtocolVersion(res);
     const phase: 'create' | 'patch' = req.method === 'POST' ? 'create' : 'patch';
-    const authz = await runAuthorize(req, res, phase);
-    if (!authz.ok) return;
-
     try {
+      // Inside the try: runAuthorize does storage I/O (kind/relatedTo resolution)
+      // and header writes of its own — an adapter fault or a consumer error with
+      // a bogus statusCode there must fail closed too, not hang the hijacked socket.
+      const authz = await runAuthorize(req, res, phase);
+      if (!authz.ok) return;
+
       await pulseVaultTusContext.run({ request: req, artifactId: authz.artifactId }, () =>
         tusServer.handle(req, res),
       );
     } catch (err) {
-      logger.error({ err }, 'pulsevault tus handler failed');
-      if (res.headersSent || res.writableEnded) {
-        res.destroy();
-        return;
-      }
-      res.statusCode = 500;
-      res.setHeader('content-type', 'text/plain; charset=utf-8');
-      res.end('Internal Server Error');
+      failClosed(res, err, 'tus handler');
     }
   };
 
   const handleCapabilities = async (_req: IncomingMessage, res: ServerResponse): Promise<void> => {
     stampProtocolVersion(res);
-    writeJson(res, 200, {
-      protocolVersion: PROTOCOL_VERSION,
-      minSupportedVersion: MIN_SUPPORTED_PROTOCOL_VERSION,
-      maxSupportedVersion: MAX_SUPPORTED_PROTOCOL_VERSION,
-      uploadUnit,
-      kinds: [...UPLOAD_KINDS],
-      allowedExtensions,
-      maxUploadSize,
-      checksum: { algorithms: ['sha256', 'sha1', 'md5'] },
-    });
+    try {
+      writeJson(res, 200, {
+        protocolVersion: PROTOCOL_VERSION,
+        minSupportedVersion: MIN_SUPPORTED_PROTOCOL_VERSION,
+        maxSupportedVersion: MAX_SUPPORTED_PROTOCOL_VERSION,
+        uploadUnit,
+        kinds: [...UPLOAD_KINDS],
+        allowedExtensions,
+        maxUploadSize,
+        checksum: { algorithms: ['sha256', 'sha1', 'md5'] },
+      });
+    } catch (err) {
+      failClosed(res, err, 'capabilities');
+    }
   };
 
   /**
@@ -446,7 +457,7 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
       await authorize(req, { phase, artifactId, kind, relatedTo, token });
       return { kind, relatedTo };
     } catch (err) {
-      const statusCode = extractAuthzStatus(err);
+      const statusCode = statusCodeOf(err, 403);
       const message = extractAuthzMessage(err);
       logger.info({ err, artifactId, phase, statusCode }, 'pulsevault authorize rejected');
       await onArtifactEvent?.({ phase: 'authorize', artifactId, kind, reason: message });
@@ -461,21 +472,25 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
     artifactId: string,
   ): Promise<void> => {
     stampProtocolVersion(res);
-    const prepared = await prepareArtifactRequest(req, res, artifactId, 'delete');
-    if (!prepared) return;
+    try {
+      const prepared = await prepareArtifactRequest(req, res, artifactId, 'delete');
+      if (!prepared) return;
 
-    if (typeof storage.remove !== 'function') {
-      writeJson(res, 501, pulseVaultError('Storage adapter does not support delete'));
-      return;
-    }
+      if (typeof storage.remove !== 'function') {
+        writeJson(res, 501, pulseVaultError('Storage adapter does not support delete'));
+        return;
+      }
 
-    const removed = await storage.remove(artifactId);
-    if (!removed) {
-      writeJson(res, 404, pulseVaultError('Artifact not found'));
-      return;
+      const removed = await storage.remove(artifactId);
+      if (!removed) {
+        writeJson(res, 404, pulseVaultError('Artifact not found'));
+        return;
+      }
+      res.writeHead(204);
+      res.end();
+    } catch (err) {
+      failClosed(res, err, 'artifact delete');
     }
-    res.writeHead(204);
-    res.end();
   };
 
   const handleArtifactGet = async (
@@ -485,37 +500,47 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
     token: string | undefined,
   ): Promise<void> => {
     stampProtocolVersion(res);
-    const prepared = await prepareArtifactRequest(req, res, artifactId, 'resolve', token);
-    if (!prepared) return;
+    try {
+      const prepared = await prepareArtifactRequest(req, res, artifactId, 'resolve', token);
+      if (!prepared) return;
 
-    const resolved = await storage.resolve(artifactId);
-    if (!resolved) {
-      writeJson(res, 404, pulseVaultError('Artifact not found'));
-      return;
+      const resolved = await storage.resolve(artifactId);
+      if (!resolved) {
+        writeJson(res, 404, pulseVaultError('Artifact not found'));
+        return;
+      }
+
+      if (resolved.kind === 'redirect') {
+        res.writeHead(resolved.statusCode ?? 302, { Location: resolved.url });
+        res.end();
+        return;
+      }
+
+      const result = await send(req, resolved.filename, { root: resolved.root, ...cache });
+
+      if (result.type === 'error') {
+        writeJson(res, result.statusCode, pulseVaultError(result.metadata.error.message));
+        return;
+      }
+
+      const headers = { ...result.headers };
+      // If the storage adapter provided an explicit content type (e.g. for
+      // non-standard extensions like `.pulse`), override what @fastify/send
+      // would otherwise infer from the filename.
+      if (resolved.contentType) {
+        headers['content-type'] = resolved.contentType;
+      }
+      res.writeHead(result.statusCode, headers);
+      // Headers are on the wire now, so a mid-stream read error (file removed
+      // after stat, disk error) can't become a 500 — destroy the socket instead
+      // of letting an unhandled 'error' crash the process. Destroy the source on
+      // client disconnect so the file descriptor is never leaked.
+      result.stream.on('error', (err) => failClosed(res, err, 'artifact stream'));
+      res.on('close', () => result.stream.destroy());
+      result.stream.pipe(res);
+    } catch (err) {
+      failClosed(res, err, 'artifact get');
     }
-
-    if (resolved.kind === 'redirect') {
-      res.writeHead(resolved.statusCode ?? 302, { Location: resolved.url });
-      res.end();
-      return;
-    }
-
-    const result = await send(req, resolved.filename, { root: resolved.root, ...cache });
-
-    if (result.type === 'error') {
-      writeJson(res, result.statusCode, pulseVaultError(result.metadata.error.message));
-      return;
-    }
-
-    const headers = { ...result.headers };
-    // If the storage adapter provided an explicit content type (e.g. for
-    // non-standard extensions like `.pulse`), override what @fastify/send
-    // would otherwise infer from the filename.
-    if (resolved.contentType) {
-      headers['content-type'] = resolved.contentType;
-    }
-    res.writeHead(result.statusCode, headers);
-    result.stream.pipe(res);
   };
 
   const handler = async (
@@ -535,7 +560,18 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
       res.end('Not Found');
     };
 
-    const url = new URL(req.url ?? '/', 'http://internal');
+    // A raw socket can present a request-target `new URL` refuses to parse
+    // (e.g. an absolute-form or garbage target from a non-HTTP client probing
+    // the port) — that's the client's malformed request, not our 500, and it
+    // must not escape as an uncaught throw on a hijacked/raw response.
+    let url: URL;
+    try {
+      url = new URL(req.url ?? '/', 'http://internal');
+    } catch {
+      res.writeHead(400, { 'content-type': 'text/plain; charset=utf-8' });
+      res.end('Bad Request');
+      return;
+    }
     let pathname = url.pathname;
     if (stripBasePath && basePath !== '') {
       if (pathname === basePath) {

--- a/src/lib/capability-token.ts
+++ b/src/lib/capability-token.ts
@@ -106,12 +106,17 @@ export function verifyCapabilityToken(
   const signature = token.slice(dot + 1);
   if (!payload || !signature) return null;
 
-  let claims: Partial<CapabilityTokenClaims>;
+  let parsed: unknown;
   try {
-    claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
   } catch {
     return null;
   }
+  // Valid JSON that isn't an object (e.g. the literal `null`, a number, a
+  // string) must fail like every other malformed token — return null rather
+  // than throw on the property access below.
+  if (typeof parsed !== 'object' || parsed === null) return null;
+  const claims = parsed as Partial<CapabilityTokenClaims>;
   if (
     typeof claims.artifactId !== 'string' ||
     typeof claims.iat !== 'number' ||
@@ -141,7 +146,9 @@ function extractToken(
   ctx: Pick<PulseVaultAuthorizeContext, 'token'>,
 ): string | undefined {
   const header = request.headers.authorization;
-  if (typeof header === 'string' && header.startsWith('Bearer ')) {
+  // Match the auth scheme case-insensitively per RFC 7235 (clients may send
+  // `bearer `/`BEARER `); the prefix is fixed-length so the slice is unchanged.
+  if (typeof header === 'string' && /^Bearer /i.test(header)) {
     return header.slice('Bearer '.length);
   }
   return ctx.token;

--- a/src/lib/checksum.ts
+++ b/src/lib/checksum.ts
@@ -73,8 +73,14 @@ export function createChecksumValidator(
     const checksum = parseChecksumMetadata(ctx.checksum);
     if (checksum) {
       if (!ctx.localPath) {
-        throw checksumError(
-          'Checksum verification requested but this storage adapter has no local path — use createS3ChecksumValidator for S3/R2 storage',
+        // Wrong validator wired for this adapter — a server misconfiguration,
+        // not a bad client payload — so surface 500, not 422 (which would tell
+        // the client their file was rejected).
+        throw Object.assign(
+          new Error(
+            'Checksum verification requested but this storage adapter has no local path — use createS3ChecksumValidator for S3/R2 storage',
+          ),
+          { statusCode: 500 },
         );
       }
       const actual = await digestLocalFile(ctx.localPath, checksum.algorithm);

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -6,3 +6,21 @@ export type PulseVaultErrorBody = {
 export function pulseVaultError(error: string): PulseVaultErrorBody {
   return { ok: false, error };
 }
+
+/** A usable HTTP status: an integer in 100–599. Anything else would make `res.writeHead` throw. */
+function isHttpStatus(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599;
+}
+
+/**
+ * Extract a numeric HTTP status from a thrown error, honoring both `statusCode`
+ * (Fastify convention) and `status_code` (tus convention). Returns `fallback`
+ * when neither is a *valid* HTTP status — a consumer hook throwing
+ * `{ statusCode: 42 }` must degrade to the fallback, not crash `writeHead`.
+ */
+export function statusCodeOf(err: unknown, fallback: number): number {
+  const e = err as { statusCode?: unknown; status_code?: unknown };
+  if (isHttpStatus(e?.statusCode)) return e.statusCode;
+  if (isHttpStatus(e?.status_code)) return e.status_code;
+  return fallback;
+}

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -2,6 +2,7 @@ import { Server } from '@tus/server';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import path from 'node:path';
 import { isUuid } from './uuid.js';
+import { statusCodeOf } from './errors.js';
 import type { PulseVaultValidatePayload } from './magic.js';
 import { type PulseVaultRequest, type PulseVaultLogger, consoleLogger } from './request.js';
 import type { PulseVaultStorage } from '../storage/types.js';
@@ -98,17 +99,6 @@ export function artifactIdFromUploadId(id: string): string | undefined {
   const ext = path.extname(nameWithExt);
   const candidate = ext ? nameWithExt.slice(0, -ext.length) : nameWithExt;
   return isUuid(candidate) ? candidate : undefined;
-}
-
-/**
- * Extract a numeric HTTP status from a thrown error, honoring both
- * `statusCode` (Fastify) and `status_code` (tus).
- */
-function statusCodeOf(err: unknown, fallback: number): number {
-  const e = err as { statusCode?: unknown; status_code?: unknown };
-  if (typeof e?.statusCode === 'number') return e.statusCode;
-  if (typeof e?.status_code === 'number') return e.status_code;
-  return fallback;
 }
 
 type ParsedUploadMetadata = {
@@ -253,6 +243,14 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
             logger.error({ err: rmErr, artifactId }, 'pulsevault failed to remove rejected upload');
           }
           await onArtifactEvent?.({ phase: 'reject', artifactId, kind, size, reason: message });
+          // 4xx rejection reasons are the client's business (e.g. "Checksum
+          // mismatch: …"); 5xx means *our* side broke — log the real error and
+          // return a generic body so internals (adapter wiring, stack detail)
+          // never reach the client.
+          if (status >= 500) {
+            logger.error({ err, artifactId, kind }, 'pulsevault payload validation errored');
+            throw tusError(status, 'Payload validation failed\n');
+          }
           throw tusError(status, `${message}\n`);
         }
       }
@@ -263,8 +261,10 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
       try {
         await storage.markReady?.(artifactId);
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'markReady failed';
-        throw tusError(500, `${message}\n`);
+        // Internal failure — log the real error server-side, return a generic
+        // body (a storage error message can leak paths/config to the client).
+        logger.error({ err, artifactId, kind }, 'pulsevault markReady failed');
+        throw tusError(500, 'Upload finalization failed\n');
       }
 
       // 3. Consumer hook — business logic (DB writes, queue jobs).
@@ -277,8 +277,10 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
           // success. The artifact is marked ready at this point — consumers
           // who want "all-or-nothing" should `storage.remove` before
           // throwing.
-          const message = err instanceof Error ? err.message : 'onUploadComplete failed';
-          throw tusError(500, `${message}\n`);
+          // The real error (often a consumer DB failure whose message can leak
+          // schema/infra detail) stays in the server log, not the client body.
+          logger.error({ err, artifactId, kind }, 'pulsevault onUploadComplete failed');
+          throw tusError(500, 'Upload completion hook failed\n');
         }
       }
 

--- a/src/storage/local.ts
+++ b/src/storage/local.ts
@@ -190,7 +190,7 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     // JSON blob that `loadMeta` would then treat as corrupt.
     const finalPath = sidecarPath(artifactId);
     const tmpPath = `${finalPath}.tmp`;
-    await fs.mkdir(sidecarDir(), { recursive: true });
+    await fs.mkdir(sidecarDir(), { recursive: true, mode: 0o750 });
     await fs.writeFile(tmpPath, JSON.stringify(sidecar), 'utf8');
     await fs.rename(tmpPath, finalPath);
   };
@@ -251,7 +251,10 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
   };
 
   const initialize = async (): Promise<void> => {
-    await fs.mkdir(sidecarDir(), { recursive: true });
+    // Dirs PulseVault creates itself get mode 0o750 directly (mkdir's mode caps
+    // the permission bits — umask only removes more — so this holds even under a
+    // permissive umask; a world-readable upload tree would otherwise leak media).
+    await fs.mkdir(sidecarDir(), { recursive: true, mode: 0o750 });
     // @tus/file-store creates `workspaceRoot` with mode 0777 if it doesn't already exist;
     // tighten it so the upload tree isn't world-writable under a permissive umask.
     await fs.chmod(workspaceRoot, 0o750).catch(() => {});
@@ -265,8 +268,8 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     relatedTo,
     checksum,
   }: ReserveUploadParams): Promise<string> => {
-    await fs.mkdir(path.join(workspaceRoot, kind), { recursive: true });
-    await fs.mkdir(sidecarDir(), { recursive: true });
+    await fs.mkdir(path.join(workspaceRoot, kind), { recursive: true, mode: 0o750 });
+    await fs.mkdir(sidecarDir(), { recursive: true, mode: 0o750 });
 
     const sidecar: Sidecar = {
       version: SIDECAR_VERSION,

--- a/test/capability-token.test.mjs
+++ b/test/capability-token.test.mjs
@@ -10,6 +10,7 @@ import { createHmac } from "node:crypto";
 import {
   issueCapabilityToken,
   verifyCapabilityToken,
+  createCapabilityAuthorize,
 } from "../dist/lib/capability-token.js";
 
 const ARTIFACT_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
@@ -57,6 +58,25 @@ test("rejects malformed tokens (no dot, truncated, non-JSON payload, missing cla
   assert.equal(verifyCapabilityToken(`${notJson}.sig`, lookupSecret, opts), null);
   const missingClaims = Buffer.from(JSON.stringify({ artifactId: ARTIFACT_ID })).toString("base64url");
   assert.equal(verifyCapabilityToken(`${missingClaims}.sig`, lookupSecret, opts), null);
+  // Valid JSON that isn't an object (the literal `null`) must return null like
+  // every other malformed token — not throw on the claims property access.
+  const nullPayload = Buffer.from(JSON.stringify(null)).toString("base64url");
+  assert.equal(verifyCapabilityToken(`${nullPayload}.sig`, lookupSecret, opts), null);
+});
+
+test("createCapabilityAuthorize accepts the Bearer scheme case-insensitively (RFC 7235)", async () => {
+  const token = issueCapabilityToken(ARTIFACT_ID, SECRET, { keyId: "k1", issuer: ISSUER });
+  const authorize = createCapabilityAuthorize(lookupSecret, { issuer: ISSUER });
+  for (const scheme of ["Bearer", "bearer", "BEARER", "BeArEr"]) {
+    await assert.doesNotReject(
+      () =>
+        authorize(
+          { headers: { authorization: `${scheme} ${token}` } },
+          { phase: "resolve", artifactId: ARTIFACT_ID },
+        ),
+      `scheme "${scheme}" should be accepted`,
+    );
+  }
 });
 
 test("rejects an unknown kid", () => {

--- a/test/checksum.test.mjs
+++ b/test/checksum.test.mjs
@@ -82,10 +82,17 @@ test("createChecksumValidator passes through (no-op) when no checksum metadata i
   assert.equal(nextCalled, true, "chained validator still runs when checksum is absent");
 });
 
-test("createChecksumValidator throws a clear error when checksum is requested but localPath is unavailable", async () => {
+test("createChecksumValidator surfaces a 500 (server misconfig, not 422) when localPath is unavailable", async () => {
   const validator = createChecksumValidator();
-  await assert.rejects(() =>
-    validator({}, { artifactId: "id", size: 0, uploadId: "u1", localPath: null, checksum: "sha256:abcd" }),
+  await assert.rejects(
+    () =>
+      validator({}, { artifactId: "id", size: 0, uploadId: "u1", localPath: null, checksum: "sha256:abcd" }),
+    (err) => {
+      // Wrong validator wired for this adapter is our misconfiguration — it must
+      // not masquerade as a client 422 ("your file was rejected").
+      assert.equal(err.statusCode, 500);
+      return true;
+    },
   );
 });
 

--- a/test/fail-closed.test.mjs
+++ b/test/fail-closed.test.mjs
@@ -1,0 +1,112 @@
+// Regression suite for the artifact handlers' fail-closed behavior. These
+// handlers run on a *hijacked* socket (Fastify's `reply.hijack()`), so a thrown
+// storage error is never turned into a response by Fastify — before the fix it
+// left the socket hung until timeout. Each test forces a fault, then asserts the
+// client gets a prompt, well-formed status (a bounded fetch timeout turns a
+// regression into a failure instead of a hung suite).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import Fastify from "fastify";
+
+import pulseVault, { createLocalStorage } from "../dist/app.js";
+
+const PREFIX = "/pulsevault";
+const ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+async function startApp({ wrapStorage = (s) => s, ...pluginOptions } = {}) {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-failclosed-"));
+  const base = createLocalStorage({ workspaceDir });
+  const app = Fastify({ logger: false });
+  await app.register(pulseVault, {
+    prefix: PREFIX,
+    storage: wrapStorage(base),
+    maxUploadSize: 10 * 1024 * 1024,
+    ...pluginOptions,
+  });
+  const baseUrl = await app.listen({ port: 0, host: "127.0.0.1" });
+  return {
+    baseUrl,
+    teardown: async () => {
+      await app.close();
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    },
+  };
+}
+
+// Fetch with a hard timeout so a hung socket (the bug this guards against)
+// surfaces as a rejected fetch rather than stalling the whole test run.
+async function fetchWithTimeout(url, options = {}, ms = 5000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+test("GET returns 500 (not a hung socket) when storage.resolve throws", async () => {
+  const ctx = await startApp({
+    wrapStorage: (base) => ({
+      ...base,
+      resolve: async () => {
+        throw new Error("storage boom");
+      },
+    }),
+  });
+  try {
+    const res = await fetchWithTimeout(`${ctx.baseUrl}${PREFIX}/artifacts/${ID}`);
+    assert.equal(res.status, 500);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("DELETE returns 500 (not a hung socket) when storage.remove throws", async () => {
+  const ctx = await startApp({
+    wrapStorage: (base) => ({
+      ...base,
+      remove: async () => {
+        throw new Error("storage boom");
+      },
+    }),
+  });
+  try {
+    const res = await fetchWithTimeout(`${ctx.baseUrl}${PREFIX}/artifacts/${ID}`, {
+      method: "DELETE",
+    });
+    assert.equal(res.status, 500);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("an authorize error with an out-of-range statusCode degrades to 403, not a writeHead crash", async () => {
+  const ctx = await startApp({
+    authorize: async () => {
+      // A consumer hook throwing a bogus status (42 is not a valid HTTP status)
+      // must degrade to the fallback, not crash res.writeHead with a RangeError.
+      throw Object.assign(new Error("bogus status"), { statusCode: 42 });
+    },
+  });
+  try {
+    const res = await fetchWithTimeout(`${ctx.baseUrl}${PREFIX}/artifacts/${ID}`);
+    assert.equal(res.status, 403);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("GET still 404s for an unknown artifact when storage behaves normally", async () => {
+  const ctx = await startApp();
+  try {
+    const res = await fetchWithTimeout(`${ctx.baseUrl}${PREFIX}/artifacts/${ID}`);
+    assert.equal(res.status, 404);
+  } finally {
+    await ctx.teardown();
+  }
+});

--- a/test/plugin.test.mjs
+++ b/test/plugin.test.mjs
@@ -509,6 +509,49 @@ test("onUploadComplete fires exactly once with the right ctx", async () => {
   }
 });
 
+test("onUploadComplete failure returns a generic 500 without leaking the internal error", async () => {
+  // A consumer hook error often carries infra detail (DB schema, table names,
+  // paths). It must be logged server-side, never echoed in the client's 5xx body.
+  const secret = "SECRET_pulses_table_password_h4 x0r";
+  const ctx = await startApp({
+    pluginOptions: {
+      onUploadComplete: async () => {
+        throw new Error(secret);
+      },
+    },
+  });
+  try {
+    const body = makeMp4(1024);
+    const create = await tusCreate(ctx.baseUrl, { artifactId: ID1, filename: "clip.mp4", size: body.length });
+    const location = new URL(create.headers.get("location"), ctx.baseUrl).href;
+    const patch = await tusPatch(location, 0, body);
+
+    assert.equal(patch.status, 500);
+    const text = await patch.text();
+    assert.ok(!text.includes(secret), "internal error text must not reach the client");
+    assert.match(text, /Upload completion hook failed/);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test(
+  "storage subdirectories are created without world access (mode 0o750)",
+  { skip: process.platform === "win32" ? "posix mode bits only" : false },
+  async () => {
+    const ctx = await startApp();
+    try {
+      await uploadFullMp4(ctx, ID1); // creates the `video/` kind dir and `.pulsevault/`
+      for (const dir of [".pulsevault", "video"]) {
+        const st = await fs.stat(path.join(ctx.workspaceDir, dir));
+        assert.equal(st.mode & 0o007, 0, `${dir} must not be world-accessible`);
+      }
+    } finally {
+      await ctx.teardown();
+    }
+  },
+);
+
 test("malformed sidecar is treated as absent; reserve rewrites it", async () => {
   const ctx = await startApp();
   try {


### PR DESCRIPTION
## What

Fixes **eight latent bugs** found while auditing the abandoned #39 checkpoint. All were still present on `main`; none are cosmetic. Each fix ships with a test that fails against the pre-fix code. This PR deliberately extracts **only** the bug fixes — not #39's dependency bumps, Prettier reformat, or capability-token `scope` feature.

## The bugs

### Availability / crash (highest impact)
- **Artifact `GET` and `DELETE` ran on a hijacked socket with no `try/catch`.** Any storage fault (S3 unreachable, disk error) escaped the handler and left the socket **hung until timeout** — a connection-exhaustion vector. Both now fail closed through a shared `failClosed` helper (emit `500`, or destroy the socket if headers are already on the wire), exactly like the existing TUS handler.
- **`GET` stream had no error handling.** A mid-stream read error (file removed after `stat`, disk fault) surfaced as an unhandled `'error'` that could **crash the process**; a client disconnecting mid-stream **leaked the file descriptor**. Now the stream's `error` is caught and the source is destroyed on client `close`.
- **Out-of-range `statusCode` crashed `res.writeHead`.** A consumer error carrying e.g. `{ statusCode: 42 }` threw a `RangeError`; a malformed request-target threw an uncaught `URL` parse error. Statuses now clamp to a valid HTTP range (shared `statusCodeOf` in `errors.ts`); unparseable targets return `400`.

### Security
- **5xx responses stopped echoing internal error text.** `markReady`, `onUploadComplete`, and 5xx-class `validatePayload` failures echoed the raw `err.message` to the client — a consumer's DB/storage error could leak schema names, paths, and infra detail. Now logged server-side with a generic body. **4xx** validation rejections (e.g. checksum mismatch) keep their descriptive messages.
- **Storage subdirectories are now created `0o750`** instead of world-readable under a permissive umask.

### Correctness
- **`verifyCapabilityToken` no longer throws** on a token whose payload is valid JSON but not an object (e.g. the literal `null`) — it returns `null` like every other failure, honoring its single-failure-shape contract.
- **Bearer scheme is matched case-insensitively** per RFC 7235 (`bearer`/`BEARER`), not only the canonical `Bearer `.
- **Checksum-with-no-local-path now reports `500`** (server misconfiguration — wrong validator wired) instead of `422` (which wrongly told the client their file was rejected).

## Implementation notes

- `statusCodeOf` moves from a private copy in `pulsevaultTus.ts` to a shared, range-validating helper in `errors.ts`, used by both the core handlers and the TUS completion path.
- The core-handler diff looks large but is mostly re-indentation from wrapping the handler bodies in `try/catch`; the behavioral change is small.

## Tests

- New `test/fail-closed.test.mjs`: GET/DELETE return `500` (not a hung socket) when storage throws, a bogus `statusCode` degrades to `403`, and the normal `404` path still works — each guarded by a bounded fetch timeout so a regression fails instead of hanging.
- Added: case-insensitive Bearer + `null`-payload assertions (`capability-token.test.mjs`), a `500`-not-`422` assertion (`checksum.test.mjs`), an `onUploadComplete`-leak assertion (`plugin.test.mjs`), and a `0o750` dir-mode check.
- **109 pass (7 new), 0 fail**; `tsc` clean.

## Not included (tracked separately)
- Capability-token `scope` claim (a genuine feature, mildly breaking) — worth its own PR.
- `@tus`/`fastify-plugin` bumps + node-engine `>=20.19` (F) and the ESLint/Prettier reformat (G).
