### PR TITLE
fastify-demo: security & delivery middleware + fast-upload tuning for opensource-server

### DIFF
--- a/examples/fastify-demo/deploy/README.md
+++ b/examples/fastify-demo/deploy/README.md
@@ -1,0 +1,86 @@
+# Running `fastify-demo` on mieweb/opensource-server
+
+Notes for deploying this demo into an [opensource-server](https://github.com/mieweb/opensource-server)
+container (Proxmox LXC, systemd `/sbin/init`, fronted by a shared edge nginx),
+tuned for **fast uploads**. Container in the example: 4 vCPU / 4 GB RAM / 50 GB
+rootfs, one **HTTP** service `internal :3000 → pulsevaultdemo.os.mieweb.org` and
+a **TCP** service on `:22` for SSH.
+
+## Install & run as a service (don't rely on a bare `npm start`)
+
+The container's entrypoint is `/sbin/init`, so run the demo under **systemd** —
+a bare `npm start` in an SSH session dies when the session closes or the
+container reboots.
+
+```bash
+# inside the container, over SSH
+git clone https://github.com/mieweb/pulsevault /opt/pulsevault
+cd /opt/pulsevault
+npm ci && npm run build            # builds dist/ that the demo imports via file:../..
+cd examples/fastify-demo && npm ci
+
+cp deploy/pulsevaultdemo.service /etc/systemd/system/
+# edit WorkingDirectory in the unit if you cloned elsewhere
+systemctl daemon-reload
+systemctl enable --now pulsevaultdemo
+systemctl status pulsevaultdemo
+journalctl -u pulsevaultdemo -f
+```
+
+`npm start` still works for a quick manual run; the unit just adds
+restart-on-crash, boot persistence, and the production env below.
+
+## Environment (set in the unit or the Container Manager dashboard)
+
+| Var | Default | Why |
+|-----|---------|-----|
+| `NODE_ENV` | — | `production` |
+| `HOST` / `PORT` | `0.0.0.0` / `3000` | matches the HTTP service's internal port |
+| `LOG_LEVEL` | `info` | set `warn` in prod — per-PATCH request logging is real CPU + rootfs I/O |
+| `MAX_RSS_MB` | `3072` | load-shed (503) ceiling; size to the container's RAM |
+| `UPLOAD_RATE_MAX` | `6000`/min | per-IP budget for `/pulsevault/upload` + `/pulsevault/artifacts` |
+| `DEFAULT_RATE_MAX` | `300`/min | per-IP budget for everything else |
+| `CORS_ORIGIN` | reflect any | set to lock cross-origin access down |
+
+## What the edge nginx already does for you (verified from the platform config)
+
+The generated per-container nginx config is already upload-friendly — **you do
+not need to change anything there**:
+
+- `proxy_request_buffering off` + `proxy_buffering off` → PATCH bodies **stream**
+  straight through; no whole-body buffering at the edge.
+- `client_max_body_size 2G` → generous per-request ceiling.
+- HTTP/1.1 to the backend, HTTP/2 + HTTP/3 (QUIC) to clients.
+- Sets `X-Forwarded-For/-Proto/-Host` + `X-Real-IP` → this demo runs with
+  `trustProxy: true` so rate-limiting keys on the **real** client IP (otherwise
+  every client shares the single proxy-IP bucket) and forwarded proto/host work.
+
+## Platform constraints that DO affect uploads — know these
+
+1. **60 s proxy timeouts** (`proxy_connect/send/read_timeout 60s`). Each TUS
+   `PATCH` must complete within 60 s. Size the client's chunk so one chunk
+   finishes well inside 60 s on the target network. TUS resumability recovers a
+   cut-off chunk, but repeated 60 s cut-offs stall throughput.
+
+2. **ModSecurity (OWASP CRS) is ON at the edge.** Two implications:
+   - It buffers + inspects the request body up to `SecRequestBodyLimit`
+     (~12.5 MB by default), which partially re-introduces buffering the
+     `proxy_request_buffering off` above removed. Keep chunks modest (≤ ~10 MB)
+     so each PATCH is inspected once and passed.
+   - CRS rules scan bodies for attack patterns and **can false-positive on
+     binary/video bytes → intermittent `403`s**. If you see sporadic upload
+     `403`s, it's almost certainly the WAF, not this server. Ask the
+     opensource-server admins to exclude `/pulsevault/upload` from request-body
+     inspection (or disable ModSecurity for this container's upload path).
+
+3. **Uploads land on the 50 GB rootfs** under `data/`. Old uploads accumulate —
+   prune `data/` (and the `data/.pulsevault/` sidecars) periodically, or attach
+   a larger/dedicated volume for a real deployment.
+
+## Fast-upload checklist
+
+- [x] `trustProxy` on + generous per-IP rate budget for the upload path (done in `server.mjs`)
+- [x] `LOG_LEVEL=warn`, `NODE_ENV=production` (in the unit)
+- [ ] Client chunk size tuned to finish a PATCH in < 60 s and stay < ~10 MB (WAF)
+- [ ] Confirm no ModSecurity `403`s on a real large upload; escalate to admins if so
+- [ ] Prune / mount storage for `data/` if uploads are retained

--- a/examples/fastify-demo/deploy/pulsevaultdemo.service
+++ b/examples/fastify-demo/deploy/pulsevaultdemo.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=PulseVault Fastify demo (pulsevaultdemo)
+Documentation=https://github.com/mieweb/pulsevault
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Point this at wherever you cloned pulsevault inside the LXC container.
+WorkingDirectory=/opt/pulsevault/examples/fastify-demo
+ExecStart=/usr/bin/env node server.mjs
+# The container's HTTP service maps internal :3000 -> pulsevaultdemo.os.mieweb.org.
+Environment=NODE_ENV=production
+Environment=HOST=0.0.0.0
+Environment=PORT=3000
+# Drop the per-request log line on hot upload paths (CPU + rootfs write I/O).
+Environment=LOG_LEVEL=warn
+# Match the container's RAM allocation (4 GB -> ~3 GB RSS ceiling for load-shedding).
+Environment=MAX_RSS_MB=3072
+# Optional: lock CORS to a single origin instead of reflecting any.
+# Environment=CORS_ORIGIN=https://pulsevaultdemo.os.mieweb.org
+Restart=always
+RestartSec=2
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/fastify-demo/package-lock.json
+++ b/examples/fastify-demo/package-lock.json
@@ -6,9 +6,15 @@
     "": {
       "name": "pulsevault-fastify-demo",
       "dependencies": {
+        "@fastify/compress": "^9.0.0",
+        "@fastify/cors": "^11.2.0",
+        "@fastify/etag": "^6.1.0",
+        "@fastify/helmet": "^13.0.2",
         "@fastify/rate-limit": "^11.1.0",
+        "@fastify/static": "^9.1.3",
         "@fastify/swagger": "^9.7.0",
         "@fastify/swagger-ui": "^6.0.0",
+        "@fastify/under-pressure": "^9.0.3",
         "@mieweb/pulsevault": "file:../..",
         "fastify": "^5.8.5",
         "qrcode": "^1.5.4"
@@ -29,7 +35,6 @@
         "@types/node": "^25.6.0",
         "express": "^5.2.1",
         "fastify": "^5.8.5",
-        "s3rver": "^3.7.1",
         "typescript": "^6.0.2"
       },
       "engines": {
@@ -81,6 +86,50 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/compress": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/compress/-/compress-9.0.0.tgz",
+      "integrity": "sha512-PZRg+ut5xd/ubsGPWfoPNryoCOtEdHboIWpDieTUHov1gKdLitF8mRmT3JbqNnRbelQXSNXUsIpakAEKR6AcTQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "fastify-plugin": "^5.0.0",
+        "mime-db": "^1.52.0",
+        "minipass": "^7.0.4",
+        "peek-stream": "^1.1.3",
+        "readable-stream": "^4.5.2"
+      }
+    },
+    "node_modules/@fastify/cors": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.2.0.tgz",
+      "integrity": "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
     "node_modules/@fastify/error": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
@@ -96,6 +145,25 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@fastify/etag": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@fastify/etag/-/etag-6.1.0.tgz",
+      "integrity": "sha512-95fxJ1YHSh1p76+tXyFvluy/H1G1Z+f7fSlv8CQxAFCuGIr/DgtwAYAfZIG//WuKZ7UB4TBLJOX14ZaIPqEirQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0"
+      }
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
       "version": "5.0.3",
@@ -131,6 +199,26 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@fastify/helmet": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/helmet/-/helmet-13.0.2.tgz",
+      "integrity": "sha512-tO1QMkOfNeCt9l4sG/FiWErH4QMm+RjHzbMTrgew1DYOQ2vb/6M1G2iNABBrD7Xq6dUk+HLzWW8u+rmmhQHifA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "helmet": "^8.0.0"
+      }
     },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
@@ -301,6 +389,26 @@
         "yaml": "^2.4.1"
       }
     },
+    "node_modules/@fastify/under-pressure": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/under-pressure/-/under-pressure-9.0.3.tgz",
+      "integrity": "sha512-uWzyFn9ThgGgynxyoX/kqgLtPtNBXXvQgN3U8fSRPNBS1y5mEZC/uCBRx03hXm9PDsQwTGN7qt83ItsHVQ0L4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -319,6 +427,18 @@
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
@@ -421,6 +541,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
@@ -432,6 +572,36 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/camelcase": {
       "version": "5.3.1",
@@ -497,6 +667,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -547,17 +723,86 @@
       "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
       "license": "MIT"
     },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/duplexify/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexify/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/duplexify/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -731,6 +976,18 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.2.0.tgz",
+      "integrity": "sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -750,6 +1007,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -774,6 +1051,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
     },
     "node_modules/json-schema-ref-resolver": {
       "version": "3.0.0",
@@ -887,6 +1170,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -924,6 +1216,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/openapi-types": {
@@ -993,6 +1294,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
+      }
+    },
     "node_modules/pino": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
@@ -1039,6 +1351,21 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -1077,6 +1404,22 @@
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -1134,6 +1477,26 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/safe-regex2": {
@@ -1240,6 +1603,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -1284,6 +1662,46 @@
       "integrity": "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g==",
       "license": "MIT"
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/toad-cache": {
       "version": "3.7.4",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.4.tgz",
@@ -1301,6 +1719,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/which-module": {
       "version": "2.0.1",
@@ -1320,6 +1744,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/examples/fastify-demo/package.json
+++ b/examples/fastify-demo/package.json
@@ -8,9 +8,15 @@
     "dev": "node --env-file-if-exists=.env --watch server.mjs"
   },
   "dependencies": {
+    "@fastify/compress": "^9.0.0",
+    "@fastify/cors": "^11.2.0",
+    "@fastify/etag": "^6.1.0",
+    "@fastify/helmet": "^13.0.2",
     "@fastify/rate-limit": "^11.1.0",
+    "@fastify/static": "^9.1.3",
     "@fastify/swagger": "^9.7.0",
     "@fastify/swagger-ui": "^6.0.0",
+    "@fastify/under-pressure": "^9.0.3",
     "@mieweb/pulsevault": "file:../..",
     "fastify": "^5.8.5",
     "qrcode": "^1.5.4"

--- a/examples/fastify-demo/server.mjs
+++ b/examples/fastify-demo/server.mjs
@@ -56,20 +56,34 @@ const host = process.env.HOST ?? "0.0.0.0";
 const uploadUnit = process.env.UPLOAD_UNIT === "segment" ? "segment" : "merged";
 
 const app = Fastify({
-  logger: true,
-  bodyLimit: 16 * 1024 * 1024, // max single PATCH chunk (RN app sends 1 MB chunks)
+  // Behind the opensource-server edge nginx (which sets X-Forwarded-For/-Proto/
+  // -Host). Trust it so `request.ip` is the real client rather than the shared
+  // proxy IP — otherwise every client lands in one rate-limit bucket — and so
+  // forwarded proto/host are honored.
+  trustProxy: true,
+  // `LOG_LEVEL=warn` in production drops the per-request log line, which on a
+  // fast upload (many PATCHes) is real CPU + rootfs write I/O; "info" locally.
+  logger: { level: process.env.LOG_LEVEL ?? "info" },
+  // NOTE: not a TUS chunk cap. The PATCH body is streamed straight to
+  // @tus/server on a hijacked socket, bypassing Fastify body parsing, so this
+  // never sees it. It only bounds a *parsed* body (none in this demo). The real
+  // per-request ceiling is the edge nginx `client_max_body_size` (2G); total
+  // upload size is governed by `maxUploadSize` below.
+  bodyLimit: 16 * 1024 * 1024,
 });
 
 // --- Security & delivery middleware ---
 // All registered before any route so they cover the demo's own routes and the
 // TUS/artifact routes the plugin mounts alike.
 
-// Shed load with a 503 (instead of falling over) when the process is under
-// pressure — the right posture for an upload/ingest server. Also exposes a
-// liveness route at GET /health. Thresholds are generous so normal use never trips.
+// Shed load with a 503 (instead of falling over) when the process is genuinely
+// under pressure. Also exposes a liveness route at GET /health. maxRssBytes is
+// sized to the container (default assumes ~4 GB RAM → 3 GB) — TUS streams chunks
+// to disk so RSS stays low, and a too-low threshold would false-503 uploads.
+// Override MAX_RSS_MB to match the container's allocation.
 await app.register(underPressure, {
   maxEventLoopDelay: 1000,
-  maxRssBytes: 900 * 1024 * 1024,
+  maxRssBytes: Number(process.env.MAX_RSS_MB ?? 3072) * 1024 * 1024,
   maxEventLoopUtilization: 0.98,
   exposeStatusRoute: "/health",
 });
@@ -123,12 +137,22 @@ await app.register(fastifyCompress, { global: true });
 // hook never sees them); this covers the HTML / JSON / VTT routes.
 await app.register(fastifyEtag);
 
-// Registered before any route so every one of them — the demo's own and the
-// TUS/artifact routes the plugin mounts — is covered by a global per-IP
-// limit (OPERATIONS.md "Rate limiting" recommends exactly this). Generous
-// enough for one phone's normal HEAD/PATCH resume retries, not for a scraper
-// hammering /videos or /pulsevault/artifacts/:id.
-await app.register(fastifyRateLimit, { max: 300, timeWindow: "1 minute" });
+// Global per-IP limit — meaningful now that trustProxy makes `request.ip` the
+// real client (behind the edge nginx it would otherwise be one shared bucket).
+// The TUS upload path and artifact playback get a much larger budget on purpose:
+// a fast chunked upload is many PATCHes (at 1 MB chunks a flat 300/min would cap
+// throughput to ~5 MB/s), and range-scrubbing a video is many GETs. The tight
+// default still guards the crawl-heavy /videos and /subtitles routes
+// (OPERATIONS.md "Rate limiting"). Tune the ceilings via env for your traffic.
+const UPLOAD_RATE_MAX = Number(process.env.UPLOAD_RATE_MAX ?? 6000);
+const DEFAULT_RATE_MAX = Number(process.env.DEFAULT_RATE_MAX ?? 300);
+await app.register(fastifyRateLimit, {
+  timeWindow: "1 minute",
+  max: (req) =>
+    req.url.startsWith("/pulsevault/upload") || req.url.startsWith("/pulsevault/artifacts")
+      ? UPLOAD_RATE_MAX
+      : DEFAULT_RATE_MAX,
+});
 
 // Swagger MUST be registered before any route (including the plugin's) so
 // their schemas are picked up — the pulsevault plugin ships full OpenAPI

--- a/examples/fastify-demo/server.mjs
+++ b/examples/fastify-demo/server.mjs
@@ -14,6 +14,12 @@ import Fastify from "fastify";
 import fastifyRateLimit from "@fastify/rate-limit";
 import fastifySwagger from "@fastify/swagger";
 import fastifySwaggerUI from "@fastify/swagger-ui";
+import fastifyStatic from "@fastify/static";
+import fastifyCors from "@fastify/cors";
+import fastifyHelmet from "@fastify/helmet";
+import fastifyCompress from "@fastify/compress";
+import fastifyEtag from "@fastify/etag";
+import underPressure from "@fastify/under-pressure";
 import QRCode from "qrcode";
 import pulseVault, { createLocalStorage, buildUploadLink } from "@mieweb/pulsevault";
 
@@ -24,7 +30,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const html = readFileSync(path.join(__dirname, "public/index.html"), "utf8");
 const videosHtml = readFileSync(path.join(__dirname, "public/videos.html"), "utf8");
-const favicon = readFileSync(path.join(__dirname, "public/favicon.png"));
 const dataDir = path.join(__dirname, "data");
 
 // Resolve a path under dataDir and refuse anything that escapes it — the
@@ -55,6 +60,69 @@ const app = Fastify({
   bodyLimit: 16 * 1024 * 1024, // max single PATCH chunk (RN app sends 1 MB chunks)
 });
 
+// --- Security & delivery middleware ---
+// All registered before any route so they cover the demo's own routes and the
+// TUS/artifact routes the plugin mounts alike.
+
+// Shed load with a 503 (instead of falling over) when the process is under
+// pressure — the right posture for an upload/ingest server. Also exposes a
+// liveness route at GET /health. Thresholds are generous so normal use never trips.
+await app.register(underPressure, {
+  maxEventLoopDelay: 1000,
+  maxRssBytes: 900 * 1024 * 1024,
+  maxEventLoopUtilization: 0.98,
+  exposeStatusRoute: "/health",
+});
+
+// Standard security headers. The CSP is tailored to what the demo pages
+// actually load — React/htm from esm.sh and mermaid from jsdelivr (as inline
+// module scripts) plus inline <style>. `crossOriginResourcePolicy` is relaxed
+// to "cross-origin" so, once CORS (below) allows it, a page on another origin
+// can embed /pulsevault/artifacts/:id as a <video>.
+await app.register(fastifyHelmet, {
+  contentSecurityPolicy: {
+    directives: {
+      "default-src": ["'self'"],
+      "script-src": ["'self'", "'unsafe-inline'", "https://esm.sh", "https://cdn.jsdelivr.net"],
+      "style-src": ["'self'", "'unsafe-inline'"],
+      "img-src": ["'self'", "data:"],
+      "media-src": ["'self'"],
+      "connect-src": ["'self'", "https://esm.sh", "https://cdn.jsdelivr.net"],
+    },
+  },
+  crossOriginResourcePolicy: { policy: "cross-origin" },
+});
+
+// CORS so a browser client / the Pulse app on another origin can drive the TUS
+// upload + playback flow. `exposedHeaders` is the load-bearing part: without it
+// the browser can't read Location/Upload-Offset and resumable uploads break.
+// Open by default for demo ease; set CORS_ORIGIN to lock it down for a deployment.
+await app.register(fastifyCors, {
+  origin: process.env.CORS_ORIGIN ?? true,
+  methods: ["GET", "POST", "PATCH", "HEAD", "DELETE", "OPTIONS"],
+  exposedHeaders: [
+    "Location",
+    "Tus-Resumable",
+    "Upload-Offset",
+    "Upload-Length",
+    "Upload-Metadata",
+    "Tus-Version",
+    "Tus-Extension",
+    "Tus-Max-Size",
+    "Upload-Expires",
+  ],
+});
+
+// gzip/br for text responses (the /videos JSON, HTML pages, /subtitles VTT).
+// Artifact bytes are streamed on a hijacked socket by the plugin, so they
+// bypass this onSend hook entirely — video is never re-compressed here.
+await app.register(fastifyCompress, { global: true });
+
+// ETag + conditional-GET (304) for the demo's own responses. Artifact bytes
+// already get ETag/range via @fastify/send inside the plugin (hijacked, so this
+// hook never sees them); this covers the HTML / JSON / VTT routes.
+await app.register(fastifyEtag);
+
 // Registered before any route so every one of them — the demo's own and the
 // TUS/artifact routes the plugin mounts — is covered by a global per-IP
 // limit (OPERATIONS.md "Rate limiting" recommends exactly this). Generous
@@ -84,6 +152,15 @@ await app.register(fastifySwaggerUI, {
   uiConfig: { docExpansion: "list", deepLinking: false },
 });
 
+// Serve everything under public/ (favicon today, any CSS/JS/assets you add
+// later) with correct content-types + caching. `index: false` so it doesn't
+// register its own GET / and collide with the explicit pairing-page route below.
+await app.register(fastifyStatic, {
+  root: path.join(__dirname, "public"),
+  prefix: "/",
+  index: false,
+});
+
 // Serve pairing page before the plugin so it isn't swallowed by /pulsevault/artifacts/:artifactId
 app.get("/", { schema: { tags: ["demo"], summary: "Pairing page (HTML)" } }, (_req, reply) =>
   reply.type("text/html").send(html));
@@ -92,9 +169,8 @@ app.get("/", { schema: { tags: ["demo"], summary: "Pairing page (HTML)" } }, (_r
 app.get("/library", { schema: { tags: ["demo"], summary: "Uploads page (HTML)" } }, (_req, reply) =>
   reply.type("text/html").send(videosHtml));
 
-// The Pulse app icon, resized — referenced by <link rel="icon"> on the page.
-app.get("/favicon.png", { schema: { tags: ["demo"], summary: "Favicon (PNG)" } }, (_req, reply) =>
-  reply.type("image/png").send(favicon));
+// The Pulse app icon (referenced by <link rel="icon"> on the pages) is now
+// served straight from public/favicon.png by @fastify/static above.
 
 // Reserve an artifactId for an upload. The server owns ID generation so it
 // can later attach auth tokens, quotas, or other server-side state here.


### PR DESCRIPTION
## What

Two related passes over the **no-auth `fastify-demo`** (that example only; no change to the pulsevault library):

1. **Security & delivery middleware** — `@fastify/static`, `cors`, `helmet`, `compress`, `etag`, `under-pressure`.
2. **Fast-upload tuning for the mieweb/opensource-server runtime** it's deployed on (Proxmox LXC + systemd, behind a shared ModSecurity-enabled edge nginx).

## 1. Middleware

| Plugin | Role |
|---|---|
| `@fastify/static` | serve `public/` (favicon + future assets); replaces manual `readFileSync` |
| `@fastify/cors` | cross-origin TUS upload + playback (`exposedHeaders` carries the tus headers the browser must read) |
| `@fastify/helmet` | security headers + a CSP tailored to the demo pages (esm.sh + jsdelivr module scripts, inline `<style>`), CORP relaxed to `cross-origin` |
| `@fastify/compress` | gzip/br for text responses only (video streams on a hijacked socket, never re-compressed) |
| `@fastify/etag` | conditional GET (304) for the demo's own routes |
| `@fastify/under-pressure` | `503` load-shedding + `/health` |

## 2. Fast-upload tuning (researched from the opensource-server config)

The edge nginx is already upload-friendly (`proxy_request_buffering off`, `client_max_body_size 2G`, sets `X-Forwarded-*`). The demo now matches it:

- **`trustProxy: true`** — key rate-limiting on the real client IP from `X-Forwarded-For`. Without it every client shares the one proxy-IP bucket and the global 300/min **throttles all uploads collectively**.
- **Rate limit** — `/pulsevault/upload` + `/pulsevault/artifacts` get a large per-IP budget (`UPLOAD_RATE_MAX`, default 6000/min). A fast chunked upload is many PATCHes; at 1 MB chunks a flat 300/min caps throughput to **~5 MB/s**. Crawl-heavy `/videos`/`/subtitles` keep the tight default.
- **`under-pressure`** `maxRssBytes` sized to the container (`MAX_RSS_MB`, default 3 GB) so an upload burst isn't false-`503`'d.
- **`LOG_LEVEL`** (warn in prod) — per-PATCH request logging is real CPU + rootfs I/O.
- Corrected the `bodyLimit` comment: the TUS PATCH is hijacked and streamed to `@tus/server`, so Fastify body parsing never sees it.

### `deploy/`
- `pulsevaultdemo.service` — systemd unit (the container's entrypoint is `/sbin/init`; a bare `npm start` doesn't survive reboot).
- `README.md` — the platform constraints that gate uploads: the **60 s proxy timeout** (chunk sizing) and the **ModSecurity WAF** (binary-upload `403` risk → ask admins to waive `/pulsevault/upload` request-body inspection).

## Verified end-to-end (against the running demo)

- helmet headers + tailored CSP; `/docs` (swagger-ui) still loads under it; `/health` OK
- `/favicon.png` via `@fastify/static`; `GET /` gzips + `304`s
- CORS preflight on `/pulsevault/upload` exposes the tus header set
- Rate-limit load test: **unique-IP burst → 0×429** (per-IP keying via trustProxy), same-IP default route → throttled, **playback path → 0×429** (higher budget)
- Full **tus create → PATCH → playback** returns **byte-identical** video (compress/etag don't touch the hijacked stream)

`npm audit`: 0 vulnerabilities. `fastify-demo` only; `fastify-auth-demo` untouched.
