### PR TITLE
fix(fastify-demo): pairing page broke over LAN (CSP upgrade-insecure-requests)

### DIFF
--- a/examples/fastify-demo/server.mjs
+++ b/examples/fastify-demo/server.mjs
@@ -102,6 +102,14 @@ await app.register(fastifyHelmet, {
       "img-src": ["'self'", "data:"],
       "media-src": ["'self'"],
       "connect-src": ["'self'", "https://esm.sh", "https://cdn.jsdelivr.net"],
+      // Helmet turns on `upgrade-insecure-requests` by default, which makes the
+      // browser upgrade same-origin fetches to HTTPS. Browsers exempt localhost,
+      // but over a LAN IP (http://<ip>:3000) it upgrades /deeplinks, /videos, etc.
+      // to https://<ip>:3000 — which has no TLS — so those requests fail and the
+      // page never renders the pairing QR. Disable it so the demo works over plain
+      // HTTP on a LAN. In prod the TLS-terminating edge serves everything over
+      // HTTPS anyway, so nothing is lost.
+      "upgrade-insecure-requests": null,
     },
   },
   crossOriginResourcePolicy: { policy: "cross-origin" },


### PR DESCRIPTION
## Symptom
The pairing page renders at `http://localhost:3000` but is stuck "loading" (no QR/deeplinks) when opened over a **LAN IP** (`http://<ip>:3000`) — so pairing a phone to a laptop-hosted demo over LAN doesn't work.

## Cause
The helmet middleware (added earlier) enables **`upgrade-insecure-requests`** by default. Browsers **exempt `localhost`**, but on a LAN IP the browser upgrades the page's same-origin `/deeplinks`, `/videos`, `/capabilities` fetches to **`https://<ip>:3000`** — which has no TLS — so they fail and the React app never mounts the QR.

## Fix
Disable just that one directive (`"upgrade-insecure-requests": null`); every other tailored CSP directive stays. In production the TLS-terminating edge serves everything over HTTPS, so nothing is lost.

## Verified
CSP header before: `…object-src 'none';script-src-attr 'none';**upgrade-insecure-requests**`
After: same header **without** `upgrade-insecure-requests` — all other directives intact.

fastify-demo only.