### PR TITLE
chore(fastify-auth-demo): default to port 3000

### DIFF
--- a/examples/fastify-auth-demo/.env.example
+++ b/examples/fastify-auth-demo/.env.example
@@ -9,7 +9,7 @@
 # Demo server
 # ---------------------------------------------------------------------------
 # Port / host the demo listens on.
-PORT=3002
+PORT=3000
 HOST=0.0.0.0
 
 # Deployment-wide upload-unit default advertised via
@@ -51,7 +51,7 @@ PULSEVAULT_KEY_ID=demo-1
 # will actually reach this server at (a token's `issuer` claim is checked for
 # exact string equality, not derived per-request). Find your LAN IP with
 # `ipconfig getifaddr en0` (macOS) or `hostname -I` (Linux), e.g.:
-#   PULSEVAULT_ISSUER=http://192.168.1.23:3002
+#   PULSEVAULT_ISSUER=http://192.168.1.23:3000
 # If left unset, the server falls back to http://localhost:PORT (and prints
 # the same LAN-IP hint at startup) — fine for a desktop browser on this same
 # machine, but a phone on the same WiFi won't be able to redeem its tokens.

--- a/examples/fastify-auth-demo/Dockerfile
+++ b/examples/fastify-auth-demo/Dockerfile
@@ -27,7 +27,7 @@ COPY --chown=node:node examples/fastify-auth-demo/public ./public
 # Uploaded videos land here; a named volume mounts over it.
 RUN mkdir -p data && chown -R node:node /app/examples/fastify-auth-demo
 USER node
-EXPOSE 3002
+EXPOSE 3000
 # npm start = `prisma migrate deploy && node server.mjs` — the schema is
 # applied against the compose Postgres before the server boots.
 CMD ["npm", "start"]

--- a/examples/fastify-auth-demo/compose.yaml
+++ b/examples/fastify-auth-demo/compose.yaml
@@ -3,8 +3,8 @@
 # Run (from this directory):
 #   PULSEVAULT_SECRET=$(openssl rand -hex 32) docker compose up --build
 #
-# Then open http://localhost:3002/ and create a dashboard account.
-# For phones on your LAN, also set PULSEVAULT_ISSUER=http://<lan-ip>:3002 —
+# Then open http://localhost:3000/ and create a dashboard account.
+# For phones on your LAN, also set PULSEVAULT_ISSUER=http://<lan-ip>:3000 —
 # capability tokens are issuer-bound by exact string match (PROTOCOL.md §5.4).
 # Compose also reads these variables from a `.env` file here (see .env.example).
 #
@@ -38,14 +38,14 @@ services:
       context: ../..
       dockerfile: examples/fastify-auth-demo/Dockerfile
     ports:
-      - "${PORT:-3002}:3002"
+      - "${PORT:-3000}:3000"
     environment:
       HOST: 0.0.0.0
-      PORT: 3002
+      PORT: 3000
       DATABASE_URL: postgres://pulsevault:pulsevault@db:5432/pulsevault
       PULSEVAULT_SECRET: ${PULSEVAULT_SECRET:?required — generate with `openssl rand -hex 32`}
       PULSEVAULT_KEY_ID: ${PULSEVAULT_KEY_ID:-demo-1}
-      PULSEVAULT_ISSUER: ${PULSEVAULT_ISSUER:-http://localhost:3002}
+      PULSEVAULT_ISSUER: ${PULSEVAULT_ISSUER:-http://localhost:3000}
       UPLOAD_UNIT: ${UPLOAD_UNIT:-merged}
       # Security & delivery middleware knobs (optional — see .env.example).
       CORS_ORIGIN: ${CORS_ORIGIN:-}
@@ -55,7 +55,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3002/pulsevault/capabilities').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/pulsevault/capabilities').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/examples/fastify-auth-demo/server.mjs
+++ b/examples/fastify-auth-demo/server.mjs
@@ -44,7 +44,7 @@ const html = readFileSync(path.join(__dirname, "public/index.html"), "utf8");
 const libraryHtml = readFileSync(path.join(__dirname, "public/library.html"), "utf8");
 const dataDir = path.join(__dirname, "data");
 
-const port = Number(process.env.PORT ?? 3002);
+const port = Number(process.env.PORT ?? 3000);
 const host = process.env.HOST ?? "0.0.0.0";
 
 // ---------------------------------------------------------------------------
@@ -335,8 +335,8 @@ await app.register(fastifyHelmet, {
       "connect-src": ["'self'", "https://esm.sh", "https://cdn.jsdelivr.net"],
       // Helmet turns on `upgrade-insecure-requests` by default, which makes the
       // browser upgrade same-origin fetches to HTTPS. Browsers exempt localhost,
-      // but over a LAN IP (http://<ip>:3002) it upgrades /deeplinks, /videos, etc.
-      // to https://<ip>:3002 — which has no TLS — so those requests fail and the
+      // but over a LAN IP (http://<ip>:3000) it upgrades /deeplinks, /videos, etc.
+      // to https://<ip>:3000 — which has no TLS — so those requests fail and the
       // page never renders. Disable it so the demo works over plain HTTP on a
       // LAN. In prod the TLS-terminating edge serves everything over HTTPS
       // anyway, so nothing is lost.


### PR DESCRIPTION
## What

Make **3000** the canonical port throughout the Fastify auth demo instead of 3002, so a plain `docker compose up --build` comes up on `http://localhost:3000` with no extra flags.

## Why

3000 is the port people reach for by default; 3002 required knowing/overriding it. This makes the demo's published port, in-container port, healthcheck, `EXPOSE`, issuer default, and the `server.mjs` fallback all agree on 3000.

## Changes

| File | Change |
|---|---|
| `compose.yaml` | port map `${PORT:-3000}:3000`, container `PORT: 3000`, `PULSEVAULT_ISSUER` default `http://localhost:3000`, healthcheck → `:3000`, header comments |
| `Dockerfile` | `EXPOSE 3000` |
| `.env.example` | `PORT=3000` + LAN-IP example comment |
| `server.mjs` | `PORT` fallback default → 3000, CSP LAN-IP comment |

Both the published and in-container port are 3000 (not a host-side remap), so logs, healthcheck, and `EXPOSE` read 3000 consistently.

## Verification

Ran `docker compose up -d --build` locally:

- Port mapping `0.0.0.0:3000->3000/tcp`; app container **healthy** on first probe
- Boot log: `running on http://localhost:3000/` · `issuer=http://localhost:3000`
- `/` → 200, `/library` (feed) → 200, `/videos` → 401 (auth-gated when signed out), `/pulsevault/capabilities` → 200
- `:3002` → no listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)