### PR TITLE
feat(examples): opt-in cluster mode for the fastify demos

### DIFF
--- a/examples/fastify-auth-demo/.env.example
+++ b/examples/fastify-auth-demo/.env.example
@@ -33,6 +33,18 @@ UPLOAD_UNIT=merged
 # MAX_RSS_MB=3072
 
 # ---------------------------------------------------------------------------
+# Clustering (opt-in — only read under the compose.cluster.yaml override or
+# `npm run start:cluster`; see cluster.mjs). Ignored by the single-process
+# default.
+# ---------------------------------------------------------------------------
+# Workers to fork. Defaults to the host core count; pin it under a CPU limit —
+# os.availableParallelism() ignores a cgroup CPU quota and would over-fork.
+# WEB_CONCURRENCY=4
+# Whole-box RSS budget, split across workers into each worker's MAX_RSS_MB.
+# Use this instead of MAX_RSS_MB when clustering (MAX_RSS_MB is per-process).
+# TOTAL_RSS_MB=3072
+
+# ---------------------------------------------------------------------------
 # Capability-token auth (the library's secure-by-default option — see
 # PROTOCOL.md §5.4 / README "Capability tokens"). This demo runs with auth
 # ALWAYS on: the server refuses to boot without PULSEVAULT_SECRET.

--- a/examples/fastify-auth-demo/cluster.mjs
+++ b/examples/fastify-auth-demo/cluster.mjs
@@ -1,0 +1,173 @@
+// Node built-in `cluster` wrapper for the fastify-auth-demo.
+//
+// server.mjs is a single-threaded Node process — it uses ONE CPU core no
+// matter how many the box has (see OPERATIONS.md "Horizontal scaling"). This
+// wrapper forks one worker per core; the kernel load-balances incoming
+// connections across them. It matters more here than in ../fastify-demo: this
+// demo re-hashes every finished video (createChecksumValidator, a full-file
+// SHA-256) before markReady, which is CPU-bound and today serializes on one
+// core — clustering lets N videos hash in parallel. `node server.mjs` still
+// runs a single process; this wrapper is additive.
+//
+// Safe with the LOCAL storage adapter: every worker on THIS box shares the
+// same `data/` filesystem, so a resumable TUS PATCH/HEAD landing on a
+// different worker still finds the partial bytes + @tus/file-store offset on
+// disk. Across SEPARATE machines you'd need sticky sessions, shared NFS/EFS,
+// or the S3/R2 adapter.
+//
+// Per-worker caveats specific to the AUTH demo (in-memory / connection state
+// is NOT shared across workers):
+//   - Postgres via Prisma: EACH worker opens its own connection pool. Prisma's
+//     default pool with no `connection_limit` is `num_cpus * 2 + 1`, so on an
+//     8-core box that's ~17 × 8 workers = ~136 connections — past Postgres's
+//     default max_connections (100). Set a small per-client limit on
+//     DATABASE_URL, e.g. `...&connection_limit=5` (5 × 8 = 40), or raise the
+//     server's max_connections. This wrapper warns at boot if it's unset.
+//   - The /events feed (recentEvents ring buffer) lives in ONE worker's
+//     memory, so /events only shows events from whichever worker served that
+//     poll — cosmetically inconsistent; uploads are unaffected. Back it with a
+//     shared store (Redis/Postgres) if you need a coherent feed.
+//   - reconcileArtifactIndex() runs once PER WORKER at boot (idempotent upserts
+//     + a deleteMany) — a small, harmless thundering herd for typical data
+//     sizes; move it to the primary (below) if your artifact table is large.
+//   - @fastify/rate-limit is in-memory per-IP, so the effective limit is
+//     roughly `max × WEB_CONCURRENCY`. Use Redis for a hard global limit.
+//
+// Migrations run ONCE, in the primary shell, before any worker forks — the
+// `start:cluster` script is `prisma migrate deploy && node cluster.mjs`. Do
+// NOT run migrations inside workers.
+//
+// Run:
+//   npm run start:cluster                   # prisma migrate deploy, then cluster
+//   WEB_CONCURRENCY=6 npm run start:cluster # leave 2 cores for HLS/ffmpeg
+//   TOTAL_RSS_MB=12000 npm run start:cluster
+
+import cluster from 'node:cluster';
+import os from 'node:os';
+import process from 'node:process';
+
+const log = (msg) => console.log(`[cluster] ${msg}`);
+const cores = os.availableParallelism();
+
+// One worker per core by default. Override with WEB_CONCURRENCY — drop it below
+// the core count once CPU-heavy HLS/ffmpeg transcoding shares this box. (Better
+// still, run HLS workers as a separate pool pulling from a queue once you're on
+// S3/R2 — then this can stay at the full core count.)
+const workers = Math.max(1, Math.trunc(Number(process.env.WEB_CONCURRENCY ?? cores)));
+
+if (cluster.isPrimary) {
+  log(`primary ${process.pid} starting ${workers} worker(s) on a ${cores}-core host`);
+
+  // Prisma connection-pool sanity check: without a per-client limit, N workers
+  // can blow past Postgres's max_connections (see the header note).
+  if (process.env.DATABASE_URL && !/[?&]connection_limit=/.test(process.env.DATABASE_URL)) {
+    log(
+      `WARNING: DATABASE_URL has no connection_limit — ${workers} workers may exhaust ` +
+        `Postgres max_connections. Append e.g. "?connection_limit=5" (or raise max_connections).`,
+    );
+  }
+
+  // under-pressure's maxRssBytes (MAX_RSS_MB in server.mjs) is PER PROCESS.
+  // Give TOTAL_RSS_MB (the whole box's budget) and we split it per worker;
+  // otherwise we warn. Note Postgres runs elsewhere (compose/RDS), so the
+  // budget here is for the Node workers only.
+  const workerEnv = {};
+  const totalRssMb = Number(process.env.TOTAL_RSS_MB ?? 0);
+  if (totalRssMb > 0) {
+    const perWorker = Math.max(512, Math.floor(totalRssMb / workers));
+    workerEnv.MAX_RSS_MB = String(perWorker); // overrides any inherited MAX_RSS_MB
+    log(`RSS budget: ${totalRssMb} MB ÷ ${workers} = ${perWorker} MB/worker`);
+  } else if (process.env.MAX_RSS_MB) {
+    log(
+      `note: MAX_RSS_MB=${process.env.MAX_RSS_MB} is PER WORKER now ` +
+        `(×${workers} = ${Number(process.env.MAX_RSS_MB) * workers} MB total). ` +
+        `Set TOTAL_RSS_MB to split a whole-box budget instead.`,
+    );
+  } else {
+    log(
+      `note: no RSS budget set — under-pressure defaults to 3072 MB PER WORKER ` +
+        `(×${workers} = ${3072 * workers} MB). Set TOTAL_RSS_MB=<box budget> to split it.`,
+    );
+  }
+
+  // --- respawn with a crash-loop guard -------------------------------------
+  // A dead worker is replaced. But this demo `process.exit(1)`s on missing
+  // PULSEVAULT_SECRET / DATABASE_URL, so a misconfig makes every worker die
+  // instantly — respawning forever would be a fork bomb. Bail after too many
+  // rapid crashes with a non-zero exit that surfaces the real problem.
+  const MIN_HEALTHY_MS = 10_000;
+  const MAX_RAPID_CRASHES = workers * 2 + 4;
+  let shuttingDown = false;
+  let rapidCrashes = 0;
+
+  const fork = () => {
+    const worker = cluster.fork(workerEnv);
+    worker.startedAt = Date.now();
+    return worker;
+  };
+
+  for (let i = 0; i < workers; i++) fork();
+
+  cluster.on('exit', (worker, code, signal) => {
+    if (shuttingDown) {
+      if (Object.keys(cluster.workers).length === 0) {
+        log('all workers drained — exiting');
+        process.exit(0);
+      }
+      return;
+    }
+    const upMs = Date.now() - (worker.startedAt ?? 0);
+    if (upMs < MIN_HEALTHY_MS) {
+      rapidCrashes++;
+      if (rapidCrashes > MAX_RAPID_CRASHES) {
+        console.error(
+          `[cluster] ${rapidCrashes} workers crashed within ${MIN_HEALTHY_MS / 1000}s of boot — ` +
+            `likely a startup/config error (missing PULSEVAULT_SECRET / DATABASE_URL, ` +
+            `port already in use, unreachable Postgres). Giving up.`,
+        );
+        process.exit(1);
+      }
+    } else {
+      rapidCrashes = 0; // a worker that ran healthily resets the counter
+    }
+    console.warn(
+      `[cluster] worker ${worker.process.pid} exited (code=${code ?? '-'} signal=${signal ?? '-'}) — respawning`,
+    );
+    fork();
+  });
+
+  // --- graceful shutdown ----------------------------------------------------
+  // Drain in-flight uploads/playbacks, then force-kill stragglers after a grace
+  // window (a cut-off TUS upload is resumable via HEAD). A second signal kills
+  // immediately.
+  const GRACE_MS = Number(process.env.SHUTDOWN_GRACE_MS ?? 15_000);
+  const shutdown = (signal) => {
+    if (shuttingDown) {
+      log(`second ${signal} — force-killing now`);
+      for (const worker of Object.values(cluster.workers)) worker.kill('SIGKILL');
+      process.exit(1);
+    }
+    shuttingDown = true;
+    const live = Object.values(cluster.workers);
+    log(`${signal} — draining ${live.length} worker(s), ${GRACE_MS / 1000}s grace`);
+    for (const worker of live) worker.disconnect();
+    setTimeout(() => {
+      log('grace elapsed — force-killing remaining workers');
+      for (const worker of Object.values(cluster.workers)) worker.kill('SIGKILL');
+      process.exit(0);
+    }, GRACE_MS).unref();
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+} else {
+  // Worker. The process manager (systemd control-group, Docker) also delivers
+  // SIGTERM/SIGINT straight to us; ignore it so the primary orchestrates a
+  // drain via disconnect() instead of terminating immediately and cutting off
+  // in-flight uploads. The primary's post-grace SIGKILL is the backstop.
+  process.on('SIGTERM', () => {});
+  process.on('SIGINT', () => {});
+
+  // Boot the unmodified demo server. It calls app.listen() on the shared port;
+  // cluster hands each worker a load-balanced share of the connections.
+  await import('./server.mjs');
+}

--- a/examples/fastify-auth-demo/compose.cluster.yaml
+++ b/examples/fastify-auth-demo/compose.cluster.yaml
@@ -1,0 +1,39 @@
+# PulseVault auth demo — OPT-IN clustering override.
+#
+# Layer this over compose.yaml to run the app under Node's `cluster` module
+# (one worker per core) instead of the single-process default. This demo
+# re-hashes every finished video (full-file SHA-256) before markReady, which is
+# CPU-bound and otherwise serializes on one core; clustering hashes N videos in
+# parallel. See cluster.mjs for the full rationale and per-worker caveats.
+#
+# Run (from this directory):
+#   PULSEVAULT_SECRET=$(openssl rand -hex 32) \
+#     docker compose -f compose.yaml -f compose.cluster.yaml up --build
+#
+# It stays a separate file, not the default, because clustering only pays off
+# on a CPU-bound single-box deploy and needs two things the single-process
+# default doesn't: a bounded Prisma pool per worker and an explicit worker
+# count (both set below). Plain `docker compose up` stays single-process.
+
+services:
+  app:
+    # `exec node` makes node PID 1, so Docker's SIGTERM reaches the cluster
+    # primary directly and cluster.mjs can drain in-flight uploads before its
+    # workers die (a plain `npm run` wrapper would swallow the signal). The
+    # migration still runs ONCE, in this shell, before any worker forks — never
+    # inside a worker. prisma is a runtime dependency, so it survives the
+    # image's `--omit=dev` and resolves at node_modules/.bin.
+    command: ["sh", "-c", "node_modules/.bin/prisma migrate deploy && exec node cluster.mjs"]
+    environment:
+      # Each worker opens its OWN Prisma pool (default num_cpus*2+1). Without a
+      # cap, N workers blow past Postgres's default max_connections (100). Keep
+      # connection_limit × WEB_CONCURRENCY under that, or raise max_connections.
+      DATABASE_URL: postgres://pulsevault:pulsevault@db:5432/pulsevault?connection_limit=5
+      # Workers to fork. Pin it explicitly: os.availableParallelism() reads the
+      # CPU affinity mask, NOT a cgroup CPU quota, so an unpinned count over-
+      # forks under `deploy.resources.limits.cpus`. 4 is a safe demo default.
+      WEB_CONCURRENCY: ${WEB_CONCURRENCY:-4}
+      # Whole-box RSS budget; cluster.mjs splits it across workers into each
+      # worker's under-pressure MAX_RSS_MB (overriding the inherited per-process
+      # value). Size it to the container, not to one worker.
+      TOTAL_RSS_MB: ${TOTAL_RSS_MB:-3072}

--- a/examples/fastify-auth-demo/compose.yaml
+++ b/examples/fastify-auth-demo/compose.yaml
@@ -10,6 +10,10 @@
 #
 # Postgres data (`pgdata`) and uploaded videos (`vaultdata`) persist in named
 # volumes across restarts; `docker compose down -v` wipes both.
+#
+# This runs one single-threaded Node process (one core). To use all cores on a
+# CPU-bound box, layer the opt-in clustering override on top:
+#   docker compose -f compose.yaml -f compose.cluster.yaml up --build
 
 services:
   db:

--- a/examples/fastify-auth-demo/package.json
+++ b/examples/fastify-auth-demo/package.json
@@ -5,6 +5,7 @@
   "description": "Production-shaped Fastify demo for @mieweb/pulsevault — Better Auth dashboard, Prisma + Postgres, capability tokens always on, Docker Compose stack",
   "scripts": {
     "start": "prisma migrate deploy && node --env-file-if-exists=.env server.mjs",
+    "start:cluster": "prisma migrate deploy && node --env-file-if-exists=.env cluster.mjs",
     "dev": "prisma migrate deploy && node --env-file-if-exists=.env --watch server.mjs",
     "db:up": "docker compose up -d db --wait"
   },

--- a/examples/fastify-demo/cluster.mjs
+++ b/examples/fastify-demo/cluster.mjs
@@ -1,0 +1,156 @@
+// Node built-in `cluster` wrapper for the fastify-demo.
+//
+// server.mjs is a single-threaded Node process — it uses ONE CPU core no
+// matter how many the box has (see OPERATIONS.md "Horizontal scaling"). This
+// wrapper forks one worker per core; the kernel load-balances incoming
+// connections across them, so every core does upload/playback work instead of
+// one. `node server.mjs` still runs a single process — this wrapper is
+// additive and the server never imports it.
+//
+// Safe with the LOCAL storage adapter: every worker on THIS box shares the
+// same `data/` filesystem, so a resumable TUS PATCH/HEAD that lands on a
+// different worker than the one that created the upload still finds the
+// partial bytes + @tus/file-store offset on disk (local.ts falls back to
+// reading the sidecar on an in-memory cache miss, and the create collision
+// guard is an atomic `wx` write — both cross-process safe). That "shared
+// filesystem" condition OPERATIONS.md calls out is automatically met within
+// one machine. Across SEPARATE machines you'd still need sticky sessions, a
+// shared NFS/EFS mount, or — the real answer — the S3/R2 adapter.
+//
+// Per-worker caveats (in-memory state is NOT shared across workers):
+//   - @fastify/rate-limit is an in-memory per-IP store, so the effective
+//     limit is roughly `max × WEB_CONCURRENCY`. Point it at Redis for a hard
+//     global limit.
+//   - @fastify/under-pressure measures each worker's own event loop / RSS —
+//     which is what you want — but MAX_RSS_MB is therefore PER WORKER (see
+//     TOTAL_RSS_MB below).
+//
+// Run:
+//   node cluster.mjs                        # one worker per core
+//   npm run start:cluster                   # same, loads .env
+//   WEB_CONCURRENCY=6 node cluster.mjs      # leave 2 cores for HLS/ffmpeg
+//   TOTAL_RSS_MB=12000 node cluster.mjs     # split a whole-box RSS budget
+
+import cluster from 'node:cluster';
+import os from 'node:os';
+import process from 'node:process';
+
+const log = (msg) => console.log(`[cluster] ${msg}`);
+const cores = os.availableParallelism();
+
+// One worker per core by default. Override with WEB_CONCURRENCY — drop it below
+// the core count once CPU-heavy HLS/ffmpeg transcoding shares this box, so
+// transcoding and web serving aren't fighting over the same cores. (Better
+// still, run HLS workers as a separate process pool pulling from a queue once
+// you're on S3/R2 — then this can stay at the full core count.)
+const workers = Math.max(1, Math.trunc(Number(process.env.WEB_CONCURRENCY ?? cores)));
+
+if (cluster.isPrimary) {
+  log(`primary ${process.pid} starting ${workers} worker(s) on a ${cores}-core host`);
+
+  // under-pressure's maxRssBytes (MAX_RSS_MB in server.mjs) is measured PER
+  // PROCESS. With N workers, a single MAX_RSS_MB lets the box believe it has
+  // N× its real memory. Give TOTAL_RSS_MB (the whole box's budget) and we split
+  // it per worker and pass it down via the worker env; otherwise we just warn.
+  const workerEnv = {};
+  const totalRssMb = Number(process.env.TOTAL_RSS_MB ?? 0);
+  if (totalRssMb > 0) {
+    const perWorker = Math.max(512, Math.floor(totalRssMb / workers));
+    workerEnv.MAX_RSS_MB = String(perWorker); // overrides any inherited MAX_RSS_MB
+    log(`RSS budget: ${totalRssMb} MB ÷ ${workers} = ${perWorker} MB/worker`);
+  } else if (process.env.MAX_RSS_MB) {
+    log(
+      `note: MAX_RSS_MB=${process.env.MAX_RSS_MB} is PER WORKER now ` +
+        `(×${workers} = ${Number(process.env.MAX_RSS_MB) * workers} MB total). ` +
+        `Set TOTAL_RSS_MB to split a whole-box budget instead.`,
+    );
+  } else {
+    log(
+      `note: no RSS budget set — under-pressure defaults to 3072 MB PER WORKER ` +
+        `(×${workers} = ${3072 * workers} MB). Set TOTAL_RSS_MB=<box budget> to split it.`,
+    );
+  }
+
+  // --- respawn with a crash-loop guard -------------------------------------
+  // A dead worker is replaced so a crash never permanently loses a core. But if
+  // workers die almost immediately and repeatedly, that's a startup/config
+  // error (port in use, bad env), not a transient crash — respawning forever
+  // would be a fork bomb, so the primary gives up with a non-zero exit instead.
+  const MIN_HEALTHY_MS = 10_000;
+  const MAX_RAPID_CRASHES = workers * 2 + 4;
+  let shuttingDown = false;
+  let rapidCrashes = 0;
+
+  const fork = () => {
+    const worker = cluster.fork(workerEnv);
+    worker.startedAt = Date.now();
+    return worker;
+  };
+
+  for (let i = 0; i < workers; i++) fork();
+
+  cluster.on('exit', (worker, code, signal) => {
+    if (shuttingDown) {
+      if (Object.keys(cluster.workers).length === 0) {
+        log('all workers drained — exiting');
+        process.exit(0);
+      }
+      return;
+    }
+    const upMs = Date.now() - (worker.startedAt ?? 0);
+    if (upMs < MIN_HEALTHY_MS) {
+      rapidCrashes++;
+      if (rapidCrashes > MAX_RAPID_CRASHES) {
+        console.error(
+          `[cluster] ${rapidCrashes} workers crashed within ${MIN_HEALTHY_MS / 1000}s of boot — ` +
+            `likely a startup/config error (port already in use, bad env). Giving up.`,
+        );
+        process.exit(1);
+      }
+    } else {
+      rapidCrashes = 0; // a worker that ran healthily resets the counter
+    }
+    console.warn(
+      `[cluster] worker ${worker.process.pid} exited (code=${code ?? '-'} signal=${signal ?? '-'}) — respawning`,
+    );
+    fork();
+  });
+
+  // --- graceful shutdown ----------------------------------------------------
+  // Stop accepting new connections and let in-flight uploads/playbacks drain,
+  // then force-kill any stragglers after a grace window. A cut-off TUS upload
+  // is resumable via HEAD, so even the force-kill isn't data loss. A second
+  // signal skips the wait and kills immediately (handy for Ctrl-C in dev).
+  const GRACE_MS = Number(process.env.SHUTDOWN_GRACE_MS ?? 15_000);
+  const shutdown = (signal) => {
+    if (shuttingDown) {
+      log(`second ${signal} — force-killing now`);
+      for (const worker of Object.values(cluster.workers)) worker.kill('SIGKILL');
+      process.exit(1);
+    }
+    shuttingDown = true;
+    const live = Object.values(cluster.workers);
+    log(`${signal} — draining ${live.length} worker(s), ${GRACE_MS / 1000}s grace`);
+    for (const worker of live) worker.disconnect();
+    setTimeout(() => {
+      log('grace elapsed — force-killing remaining workers');
+      for (const worker of Object.values(cluster.workers)) worker.kill('SIGKILL');
+      process.exit(0);
+    }, GRACE_MS).unref();
+  };
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
+} else {
+  // Worker. The process manager (systemd control-group, Docker) also delivers
+  // SIGTERM/SIGINT straight to us; ignore it so the primary can orchestrate a
+  // drain via disconnect() instead of the default "terminate immediately",
+  // which would cut off in-flight uploads. The primary's post-grace SIGKILL is
+  // the backstop. (A clean per-worker close would need server.mjs to export
+  // app.close(); ignoring + primary-drain avoids modifying the demo server.)
+  process.on('SIGTERM', () => {});
+  process.on('SIGINT', () => {});
+
+  // Boot the unmodified demo server. It calls app.listen() on the shared port;
+  // cluster hands each worker a load-balanced share of the connections.
+  await import('./server.mjs');
+}

--- a/examples/fastify-demo/package.json
+++ b/examples/fastify-demo/package.json
@@ -5,6 +5,7 @@
   "description": "Minimal Fastify demo for @mieweb/pulsevault — no auth, local storage, QR pairing for the Pulse app",
   "scripts": {
     "start": "node --env-file-if-exists=.env server.mjs",
+    "start:cluster": "node --env-file-if-exists=.env cluster.mjs",
     "dev": "node --env-file-if-exists=.env --watch server.mjs",
     "bench": "node scripts/upload-benchmark.mjs"
   },


### PR DESCRIPTION
## What

Adds an **opt-in** Node `cluster` wrapper to both fastify example apps so they can use every core on a CPU-bound box, instead of the single-threaded default that pins them to one core.

`node server.mjs` is unchanged — clustering is purely additive and never imported by the server. Turn it on with `npm run start:cluster` (or the compose override).

## Changes

- **`fastify-demo` + `fastify-auth-demo`** — new `cluster.mjs` forking one worker per core, plus a `start:cluster` script. Includes:
  - `WEB_CONCURRENCY` (worker count) and `TOTAL_RSS_MB` (whole-box RSS budget, split per worker into under-pressure's `MAX_RSS_MB`) knobs
  - a crash-loop guard so a misconfig (missing secret, port in use) exits non-zero instead of fork-bombing
  - graceful SIGTERM/SIGINT drain — in-flight uploads/playbacks finish before workers die, and a cut-off TUS upload is resumable via HEAD anyway
- **`fastify-auth-demo`** — `compose.cluster.yaml` override to run clustered under Docker: bounded per-worker Prisma pool (`connection_limit=5` so N workers don't blow past Postgres `max_connections`), pinned `WEB_CONCURRENCY` (cgroup CPU quotas aren't visible to `availableParallelism()`), and migrations run once in the primary shell — never inside a worker. Plus `.env.example` / `compose.yaml` docs.

Clustering is safe with the local storage adapter (workers share the `data/` filesystem, so resumable TUS lands correctly on any worker). Per-worker caveats (in-memory rate-limit, the `/events` ring buffer) are documented inline in `cluster.mjs`.

## Test plan

- [ ] `npm run start:cluster` in each demo forks the expected worker count and serves uploads/playback
- [ ] `docker compose -f compose.yaml -f compose.cluster.yaml up --build` (auth demo) boots clustered, migrations run once
- [ ] SIGTERM drains in-flight uploads within the grace window

🤖 Generated with [Claude Code](https://claude.com/claude-code)