### PR TITLE
fix: prevent process crash when an upload connection aborts mid-PATCH

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -395,6 +395,16 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
 
   const handleTus = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
     stampProtocolVersion(res);
+    // A client that drops the connection mid-request — a mobile app killed during a PATCH, a
+    // network reset, a cancelled upload — makes Node emit an 'error' ('aborted' / ECONNRESET) on
+    // the raw request (and sometimes response) stream. Node treats an unhandled 'error' event as
+    // fatal: with no listener it re-throws and crashes the whole process, killing every other
+    // in-flight upload. It fires from the socket-close handler on a later tick, so the try/catch
+    // below never sees it. Attach no-op listeners so an aborted connection is just a dropped
+    // request: @tus/server sees the truncated body, the stored offset simply doesn't advance, and
+    // the client resumes from the last persisted byte on its next PATCH.
+    req.on('error', () => {});
+    res.on('error', () => {});
     const phase: 'create' | 'patch' = req.method === 'POST' ? 'create' : 'patch';
     try {
       // Inside the try: runAuthorize does storage I/O (kind/relatedTo resolution)
@@ -536,6 +546,11 @@ export function createPulseVaultCore(options: PulseVaultCoreOptions): PulseVault
       // of letting an unhandled 'error' crash the process. Destroy the source on
       // client disconnect so the file descriptor is never leaked.
       result.stream.on('error', (err) => failClosed(res, err, 'artifact stream'));
+      // A client that aborts mid-download makes the *response* stream emit its own
+      // 'error' (ECONNRESET / EPIPE). `.pipe` doesn't forward that, and an unhandled
+      // 'error' on `res` is fatal to the process — so swallow it (the 'close' handler
+      // above already tears down the source and reclaims the fd).
+      res.on('error', () => {});
       res.on('close', () => result.stream.destroy());
       result.stream.pipe(res);
     } catch (err) {

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -147,7 +147,7 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
     logger = consoleLogger,
   } = options;
 
-  return new Server({
+  const server = new Server({
     path: tusPath,
     datastore: storage.datastore,
     maxSize,
@@ -289,6 +289,50 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
       return {};
     },
   });
+
+  hardenPatchAgainstClientAbort(server, logger);
+
+  return server;
+}
+
+/**
+ * Stops a dropped upload connection from crashing the whole server process.
+ *
+ * @tus/server@2's `PatchHandler.writeToStore` pipes the incoming body (`Readable.fromWeb(req.body)`)
+ * into an internal proxy via `data.pipe(proxy)` and attaches an 'error' handler to the *proxy* — but
+ * never to `data` itself. `.pipe()` doesn't forward source errors, so when the client drops the
+ * connection mid-PATCH (a mobile app killed during a transfer, a network reset, a cancelled upload)
+ * `data` emits an 'error' ('aborted' / ECONNRESET) with no listener. An unhandled stream 'error' is
+ * fatal to Node: the process crashes, taking down every other in-flight upload (observed as the
+ * server dying and subsequent requests 502-ing).
+ *
+ * We wrap the PATCH handler's `writeToStore` to attach a no-op 'error' listener to `data` before
+ * delegating. The abort then unwinds normally — the proxy/pipeline still rejects the write and the
+ * stored offset simply doesn't advance, so the client resumes from the last persisted byte on its
+ * next PATCH. Defensive: it no-ops if a future @tus version renames/fixes this, and the extra
+ * listener is harmless if they add their own. (Long-term fix: upgrade @tus/server once it handles
+ * the source-stream error itself.)
+ */
+function hardenPatchAgainstClientAbort(server: Server, logger: PulseVaultLogger): void {
+  const patch = (server as unknown as { handlers?: Record<string, unknown> }).handlers?.PATCH as
+    | { writeToStore?: (data: NodeJS.ReadableStream, ...rest: unknown[]) => unknown }
+    | undefined;
+  if (!patch || typeof patch.writeToStore !== 'function') {
+    logger.info({}, 'pulsevault: could not harden PATCH handler against client abort (API changed?)');
+    return;
+  }
+  const original = patch.writeToStore.bind(patch);
+  patch.writeToStore = (data, ...rest) => {
+    if (data && typeof data.on === 'function') {
+      data.on('error', (err: unknown) => {
+        logger.info(
+          { err: err instanceof Error ? err.message : String(err) },
+          'pulsevault: PATCH body stream aborted (client disconnected mid-upload)',
+        );
+      });
+    }
+    return original(data, ...rest);
+  };
 }
 
 /**

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -325,10 +325,12 @@ function hardenPatchAgainstClientAbort(server: Server, logger: PulseVaultLogger)
   patch.writeToStore = (data, ...rest) => {
     if (data && typeof data.on === 'function') {
       data.on('error', (err: unknown) => {
-        logger.info(
-          { err: err instanceof Error ? err.message : String(err) },
-          'pulsevault: PATCH body stream aborted (client disconnected mid-upload)',
-        );
+        // Debug (falling back to info for loggers without it): a client dropping mid-upload is an
+        // expected, per-request event on flaky mobile networks — not something to page over.
+        const obj = { err: err instanceof Error ? err.message : String(err) };
+        const msg = 'pulsevault: PATCH body stream aborted (client disconnected mid-upload)';
+        if (logger.debug) logger.debug(obj, msg);
+        else logger.info(obj, msg);
       });
     }
     return original(data, ...rest);

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -20,6 +20,8 @@ export type PulseVaultRequest = {
 export type PulseVaultLogger = {
   info(obj: unknown, msg?: string): void;
   error(obj: unknown, msg?: string): void;
+  /** Optional low-noise level for expected, per-request events (e.g. a client aborting mid-upload). */
+  debug?(obj: unknown, msg?: string): void;
 };
 
 /** Default logger for hosts that don't supply one. */
@@ -31,5 +33,9 @@ export const consoleLogger: PulseVaultLogger = {
   error(obj, msg) {
     if (msg) console.error(msg, obj);
     else console.error(obj);
+  },
+  debug(obj, msg) {
+    if (msg) console.debug(msg, obj);
+    else console.debug(obj);
   },
 };

--- a/test/http-adapter.test.mjs
+++ b/test/http-adapter.test.mjs
@@ -142,6 +142,59 @@ test("HEAD + resume PATCH completes the upload", async () => {
   }
 });
 
+test("an aborted PATCH mid-body does not crash the server process", async () => {
+  const ctx = await startApp();
+  try {
+    const size = 1 << 16; // 64 KiB — big enough to reliably abort mid-body
+    const create = await tusCreate(ctx.baseUrl, {
+      artifactId: ID1,
+      filename: "clip.mp4",
+      size,
+    });
+    assert.equal(create.status, 201);
+    const location = new URL(create.headers.get("location"), ctx.baseUrl);
+
+    // Start a PATCH that PROMISES `size` bytes (Content-Length) but send only a handful, then rip
+    // the socket away without finishing the body — exactly what an app kill / network reset does
+    // mid-transfer. Before the fix this made Node emit an unhandled 'error' ('aborted' /
+    // ECONNRESET) on the request stream and crash the whole process.
+    await new Promise((resolve) => {
+      const req = http.request({
+        hostname: location.hostname,
+        port: location.port,
+        path: location.pathname,
+        method: "PATCH",
+        headers: {
+          "Tus-Resumable": "1.0.0",
+          "Upload-Offset": "0",
+          "Content-Type": "application/offset+octet-stream",
+          "Content-Length": String(size),
+        },
+      });
+      req.on("error", () => {}); // the client half also observes the reset
+      req.write(Buffer.alloc(64));
+      setTimeout(() => {
+        req.destroy(); // abort without completing the body
+        resolve();
+      }, 30);
+    });
+
+    // Give the server a couple ticks to observe the aborted stream, then prove it's still alive:
+    // had it crashed, this would ECONNREFUSED instead of answering.
+    await new Promise((r) => setTimeout(r, 50));
+    const caps = await fetch(`${ctx.baseUrl}${PREFIX}/capabilities`);
+    assert.equal(caps.status, 200);
+
+    // The upload also survives as a resumable sidecar (offset somewhere in [0, size]).
+    const head = await tusHead(location.href);
+    assert.equal(head.status, 200);
+    const offset = Number(head.headers.get("upload-offset"));
+    assert.ok(Number.isInteger(offset) && offset >= 0 && offset <= size);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
 test("second reserve for same artifactId returns 409", async () => {
   const ctx = await startApp();
   try {


### PR DESCRIPTION
## Summary

A client that drops its connection **mid-`PATCH`** — a mobile app killed during an upload, a network reset, a cancelled transfer — could crash the entire server process. Because the crash is an unhandled stream `error`, it takes down **every other in-flight upload** with it; subsequent requests then fail with `502` until the process restarts. This PR makes an aborted upload connection a normal, recoverable event.

## Symptom

Observed against a live deployment while testing a mobile client's kill-mid-upload resume flow:

```
PATCH /pulsevault/upload/…                     ← client killed here
node:events:487
      throw er; // Unhandled 'error' event
Error: aborted
    at abortIncoming (node:_http_server:897:17)
    at socketOnClose (node:_http_server:890:3)
Emitted 'error' event on Readable instance
  code: 'ECONNRESET'
Node.js v24 — process exits
```

The process exits, so the client's retry hits a dead server and gets a `502`.

## Root cause

`@tus/server@2`'s `PatchHandler.writeToStore` pipes the request body into an internal `PassThrough` proxy and attaches an `error` handler to the **proxy** — but never to the source stream:

```js
// node_modules/@tus/server/dist/handlers/BaseHandler.js
proxy.on('error', …)                              // handled
stream.pipeline(data.pipe(proxy), new StreamLimiter(...), …)   // `data` has NO error handler
```

`data` is `Readable.fromWeb(req.body)`. `.pipe()` does **not** forward source errors to the destination, so when the client aborts, the raw request error propagates to `data`, which emits `'error'` (`aborted` / `ECONNRESET`) with **no listener**. Node treats an unhandled stream `'error'` as fatal and terminates the process.

This reproduces deterministically with a partial `PATCH` (a `Content-Length` larger than the bytes actually sent, then the socket destroyed). An instrumented run confirmed the unhandled emitter is a bare `Readable` (the `fromWeb` stream), not the `IncomingMessage`.

## The fix

- **`src/lib/pulsevaultTus.ts` — `hardenPatchAgainstClientAbort()`**: wrap the `PATCH` handler's `writeToStore` to attach a no-op `'error'` listener to the body stream before delegating. An aborted upload now unwinds gracefully — the proxy/pipeline still rejects the write, the stored offset simply doesn't advance, and the client resumes from the last persisted byte on its next `PATCH`. The wrap is defensive: it no-ops (with a log line) if a future `@tus/server` renames or fixes this, and the extra listener is harmless if they add their own.
- **`src/core.ts` — download path**: the artifact `GET` handler streams a file to the response (`result.stream.pipe(res)`) but only handled the *source* stream's errors and `res` `'close'` — not `res` `'error'`. A viewer disconnecting mid-download hit the same unhandled-`'error'` crash, so a `res.on('error')` guard is added there too, plus defensive `req`/`res` guards in `handleTus` (covers no-body `HEAD`/`DELETE` aborts).

## Tests

New regression test in `test/http-adapter.test.mjs` — **"an aborted PATCH mid-body does not crash the server process"** — starts an upload, sends a truncated `PATCH`, rips the socket away, then asserts (a) the server still answers a subsequent request and (b) the upload survives as a resumable sidecar.

```
tests 110 · pass 110 · fail 0
```

## Impact

Any client that drops an upload connection — routine on mobile networks — could crash the server for **all** users. This is the highest-severity class of availability bug (an unauthenticated remote can trigger it by opening and dropping a `PATCH`). The fix is contained, adds no dependency, and changes no protocol behavior.

## Follow-up

The underlying gap is in `@tus/server@2.0.0`'s `writeToStore` (`data.pipe(proxy)` without a source-stream error handler). Worth reporting upstream and revisiting when bumping `@tus/server` (latest is `2.4.1`); the defensive wrap can be removed once the library handles the source-stream error itself.
