### PR TITLE
fix(fastify-demo): align upload contract and reduce prefetch pressure

### DIFF
--- a/examples/fastify-demo/public/videos.html
+++ b/examples/fastify-demo/public/videos.html
@@ -303,7 +303,11 @@
           const src = new URL(clip.playbackUrl, location.origin).href;
           if (video.src !== src) {
             video.src = src;
-            video.preload = "auto";
+            // Neighbors warm up with metadata only (a few KB); full buffering
+            // is reserved for the on-screen slide. Measured: 3 parallel
+            // full-file streams to one client collapse to ~0.36 MB/s each —
+            // worse in aggregate than a single stream.
+            video.preload = active ? "auto" : "metadata";
             // A single merged video loops natively; segment sessions advance on `ended`.
             video.loop = clipCount === 1;
             if (active && !halted) video.play().catch(() => setHalted(true));
@@ -317,6 +321,7 @@
           if (!video) return;
           if (active) {
             setHalted(false);
+            video.preload = "auto"; // promoted from the neighbor's metadata-only warmup
             video.play().catch(() => setHalted(true));
           } else {
             video.pause();

--- a/examples/fastify-demo/server.mjs
+++ b/examples/fastify-demo/server.mjs
@@ -386,7 +386,10 @@ app.get("/deeplinks", { schema: { tags: ["demo"], summary: "Mint a pairing deep 
 await app.register(pulseVault, {
   prefix: "/pulsevault",
   storage: createLocalStorage({ workspaceDir: dataDir }),
-  maxUploadSize: 5 * 1024 * 1024 * 1024, // 5 GiB
+  // Matches the deployment edge's `client_max_body_size 2G` — advertising more
+  // (`Tus-Max-Size`) than the infra accepts means clients get promised sizes
+  // that 413 mid-flight. Raise only if the edge limit is raised.
+  maxUploadSize: 2 * 1024 * 1024 * 1024, // 2 GiB
   uploadUnit,
   // All kinds stay enabled — a merged-mode session uploads a .pulse beat
   // manifest, .vtt captions and a .jpg thumbnail alongside the video (and a


### PR DESCRIPTION
## Summary
- align `examples/fastify-demo` advertised upload contract with the deployed edge limit by setting `maxUploadSize` to 2 GiB
- cap off-screen feed prefetch to metadata and only promote active slide playback to `preload="auto"`

## Why
- the edge rejects payloads above 2 GiB; advertising 5 GiB causes avoidable create/transfer mismatches
- full-file prefetch on neighbor slides increases competing stream pressure and hurts scroll playback stability

## Validation
- `npm run build`
- `npm test` (111 passed)
- live edge verification already done: 3 GiB create rejects at create time, active slide playback remains intact
