### PR TITLE
feat(metadata): optional `name` display-title Upload-Metadata key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,15 @@ if you've evaluated against an intermediate build.
 
 ### Added
 
+- **`name`** — an optional `Upload-Metadata` key carrying a free-form UTF-8
+  display title for the artifact (e.g. the draft name typed on the capture
+  device). Trimmed and hard-capped server-side (512 chars), persisted to the
+  sidecar alongside `relatedTo`/`checksum`, and exposed via the new optional
+  `getName` storage method (and `ReserveUploadParams.name`). Display-only
+  metadata: it never influences storage paths, routing, or authorization, and
+  consumers must escape it for their own output context. Optional everywhere,
+  so older clients that don't send it and consumers that don't read it are
+  unaffected. Documented in `PROTOCOL.md` §4.1 as a non-normative extension.
 - **`kind: "captions"`** artifact type (default extension `.vtt`), running
   through the same generic `validatePayload`/`onUploadComplete` hooks as
   every other kind. WebVTT carries word-level inline cue timestamps

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -142,6 +142,7 @@ pairs) MUST be parsed for at least:
 | `kind` | No, defaults to `video` | `video`, `project`, `captions`, or `thumbnail`. |
 | `relatedTo` | No | UUID of another artifact this one belongs to (§8). |
 | `checksum` | No | `<algorithm>:<hex digest>` of the finished file (§6.3). |
+| `name` | No | Free-form UTF-8 display title for the artifact (e.g. the draft name typed on the capture device). Trimmed and length-capped by the server; persisted for consumers to label the artifact. Display metadata only — it MUST NOT influence storage paths, routing, or authorization, and consumers MUST escape it for their output context. |
 
 A client MUST always send `artifactId` (not only the legacy aliases) on new
 uploads. A server MUST continue accepting `videoid`/`projectid` as aliases

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -144,6 +144,11 @@ pairs) MUST be parsed for at least:
 | `checksum` | No | `<algorithm>:<hex digest>` of the finished file (§6.3). |
 | `name` | No | Free-form UTF-8 display title for the artifact (e.g. the draft name typed on the capture device). Trimmed and length-capped by the server; persisted for consumers to label the artifact. Display metadata only — it MUST NOT influence storage paths, routing, or authorization, and consumers MUST escape it for their output context. |
 
+Metadata values are base64 per the TUS spec; a free-form value such as `name`
+MUST be base64 of its **UTF-8** bytes. A client that base64-encodes a raw
+Latin-1 string (e.g. a browser `btoa()`) corrupts any non-ASCII title (accents,
+emoji), so encode the UTF-8 bytes explicitly.
+
 A client MUST always send `artifactId` (not only the legacy aliases) on new
 uploads. A server MUST continue accepting `videoid`/`projectid` as aliases
 for `artifactId` for back-compat with clients built against protocol

--- a/README.md
+++ b/README.md
@@ -536,6 +536,9 @@ The TUS `Upload-Metadata` header is a comma-separated list of `<key> <base64>` p
 | `kind` | No | `video` (default), `project`, or `captions`. Determines the storage subdir and which hooks fire. |
 | `relatedTo` | No | UUID of another artifact this one belongs to (e.g. a video's captions). Lets one capability token authorize a whole session. |
 | `checksum` | No | `<algorithm>:<hex digest>` of the finished file, verified by `createChecksumValidator`/`createS3ChecksumValidator` if configured. |
+| `name` | No | Free-form UTF-8 display title (e.g. the draft name typed on the capture device). Trimmed + length-capped, persisted to the sidecar, and readable via `storage.getName(artifactId)`. Display-only — never used for storage paths or authorization; escape it for your output context. |
+
+> Base64 the **UTF-8 bytes** of each value. `filename`/`kind`/`artifactId` are ASCII, but a free-form `name` can carry accents or emoji — a browser `btoa()` (Latin-1) corrupts those, so encode via `Buffer`/`TextEncoder` (or your platform's UTF-8-safe base64) for the `name` value.
 
 Example (`kind=captions`, linked to a video):
 
@@ -560,7 +563,7 @@ The local adapter writes uploads into flat kind-scoped subdirectories. Downstrea
 
 ```text
 <workspaceRoot>/
-  .pulsevault/<id>.json           # sidecar: { version, ext, filename, status, kind, relatedTo, checksum }
+  .pulsevault/<id>.json           # sidecar: { version, ext, filename, status, kind, relatedTo, checksum, name }
   video/<id><ext>                 # video upload bytes    (kind="video")
   video/<id><ext>.json            # @tus/file-store offset/metadata sidecar
   project/<id><ext>               # project bundle bytes  (kind="project")

--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ The local adapter writes uploads into flat kind-scoped subdirectories. Downstrea
 
 `status` is `"uploading"` between `reserveUpload` and the successful final PATCH; `"ready"` thereafter. `GET /artifacts/:id` only serves `"ready"` uploads. `kind` defaults to `"video"` when absent (back-compat with pre-kind sidecars).
 
-The adapter exposes `storage.workspaceRoot` (absolute, resolved from `workspaceDir`) so consumers can compute per-resource paths without re-implementing the layout. `storage.getKind(id)` returns `"video" | "project" | "captions" | null`; `storage.getRelatedTo(id)` and `storage.getChecksum(id)` return the corresponding sidecar fields, each `null` if absent/unknown.
+The adapter exposes `storage.workspaceRoot` (absolute, resolved from `workspaceDir`) so consumers can compute per-resource paths without re-implementing the layout. `storage.getKind(id)` returns `"video" | "project" | "captions" | null`; `storage.getRelatedTo(id)`, `storage.getChecksum(id)`, and `storage.getName(id)` return the corresponding sidecar fields, each `null` if absent/unknown.
 
 **Horizontal scaling**: this adapter requires sticky-session routing or a shared filesystem across instances — see `OPERATIONS.md`.
 
@@ -659,14 +659,14 @@ Credentials are optional — omit `accessKeyId`/`secretAccessKey` to use the AWS
 
 ```text
 <bucket>/
-  .pulsevault/<id>.json   # metadata sidecar: { version, ext, filename, status, kind, relatedTo, checksum }
+  .pulsevault/<id>.json   # metadata sidecar: { version, ext, filename, status, kind, relatedTo, checksum, name }
   video/<id><ext>         # finalized video object    (kind="video")
   project/<id><ext>       # finalized project object  (kind="project")
   captions/<id><ext>      # finalized captions object (kind="captions")
   <key>.info              # @tus/s3-store multipart bookkeeping (transient)
 ```
 
-`resolve()` only returns a presigned URL once the sidecar `status` is `"ready"` (after the final byte lands and `validatePayload` passes), so in-progress or rejected uploads are never served. `getKind(id)` returns the kind without a full resolve; `getRelatedTo(id)`/`getChecksum(id)` mirror the local adapter.
+`resolve()` only returns a presigned URL once the sidecar `status` is `"ready"` (after the final byte lands and `validatePayload` passes), so in-progress or rejected uploads are never served. `getKind(id)` returns the kind without a full resolve; `getRelatedTo(id)`/`getChecksum(id)`/`getName(id)` mirror the local adapter.
 
 ### Options
 
@@ -711,9 +711,9 @@ const storage: PulseVaultStorage = {
   async shutdown() {
     /* optional teardown */
   },
-  async reserveUpload({ artifactId, filename, ext, kind, relatedTo, checksum }) {
+  async reserveUpload({ artifactId, filename, ext, kind, relatedTo, checksum, name }) {
     // Called by the TUS naming function. Return the file id for the datastore.
-    await db.createArtifact({ artifactId, filename, kind, relatedTo, checksum, status: "uploading" });
+    await db.createArtifact({ artifactId, filename, kind, relatedTo, checksum, name, status: "uploading" });
     return `${kind}/${artifactId}${ext}`;
   },
   async resolve(artifactId): Promise<PulseVaultResolution | null> {
@@ -737,10 +737,12 @@ const storage: PulseVaultStorage = {
     const result = await db.deleteArtifact(artifactId);
     return result.deleted;
   },
-  // Optional — only needed if you use relatedTo/checksum-aware hooks/validators:
+  // Optional — relatedTo/checksum-aware hooks/validators, plus getName so a
+  // display title is available via storage.getName:
   async getKind(artifactId) { return (await db.findArtifact(artifactId))?.kind ?? null; },
   async getRelatedTo(artifactId) { return (await db.findArtifact(artifactId))?.relatedTo ?? null; },
   async getChecksum(artifactId) { return (await db.findArtifact(artifactId))?.checksum ?? null; },
+  async getName(artifactId) { return (await db.findArtifact(artifactId))?.name ?? null; },
 };
 ```
 
@@ -782,7 +784,7 @@ Runs a Node `--test` suite against the built plugin. Coverage includes:
 - `kind=project` and `kind=captions` happy paths — correct subdir, `Content-Type`, sidecar, `relatedTo` linking
 - Extension mismatch rejections in both directions
 - `artifactId`/`videoid`/`projectid` metadata aliases
-- `getKind()`/`getRelatedTo()`/`getChecksum()` storage methods
+- `getKind()`/`getRelatedTo()`/`getChecksum()`/`getName()` storage methods
 - Legacy sidecars (no `kind` field) default to `"video"`, readable through the new generic route with no data migration
 - Sidecar corruption recovery
 - `allowedExtensions` object form

--- a/examples/fastify-demo/server.mjs
+++ b/examples/fastify-demo/server.mjs
@@ -297,6 +297,10 @@ app.get("/videos", {
           artifactId,
           kind,
           filename: sidecar.filename ?? tusMeta?.metadata?.filename ?? artifactFile,
+          // Human-facing display title the client sent via `Upload-Metadata.name`
+          // (e.g. the draft name), or null if the upload carried no name. A UI
+          // should escape this — it's free-form, client-supplied text.
+          name: sidecar.name ?? null,
           ext,
           size: artifactStat.size,
           // Session anchor this artifact belongs to (a segment session's clips point at

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mieweb/pulsevault",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mieweb/pulsevault",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@fastify/send": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mieweb/pulsevault",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Resumable video uploads via TUS for Fastify (plugin) or any Node backend (framework-agnostic core), with a pluggable storage adapter and a filesystem-first local-storage default.",
   "type": "module",
   "main": "./dist/app.js",

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -101,12 +101,22 @@ export function artifactIdFromUploadId(id: string): string | undefined {
   return isUuid(candidate) ? candidate : undefined;
 }
 
+/**
+ * Defensive upper bound on the stored display `name`. The header is base64 and
+ * comma-joined with the other metadata; a runaway value would bloat every
+ * request and every sidecar. 512 chars is far more than any real title and
+ * still leaves generous headroom under typical proxy header limits. The client
+ * should cap first; this is belt-and-suspenders so the server never trusts it.
+ */
+const MAX_ARTIFACT_NAME_LENGTH = 512;
+
 type ParsedUploadMetadata = {
   artifactId: string;
   filename: string;
   kind: UploadKind;
   relatedTo?: string;
   checksum?: string;
+  name?: string;
 };
 
 /**
@@ -131,8 +141,11 @@ function parseUploadMetadata(
   const rawRelatedTo = (metadata?.relatedTo ?? '').trim();
   const relatedTo = isUuid(rawRelatedTo) ? rawRelatedTo : undefined;
   const checksum = (metadata?.checksum ?? '').trim() || undefined;
+  // Free-form display title. Trim, then hard-cap length so a hostile or buggy
+  // client can't bloat the sidecar; an all-whitespace/empty value is dropped.
+  const name = (metadata?.name ?? '').trim().slice(0, MAX_ARTIFACT_NAME_LENGTH) || undefined;
 
-  return { artifactId, filename, kind, relatedTo, checksum };
+  return { artifactId, filename, kind, relatedTo, checksum, name };
 }
 
 export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
@@ -152,7 +165,8 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
     datastore: storage.datastore,
     maxSize,
     namingFunction: async (_req, metadata) => {
-      const { artifactId, filename, kind, relatedTo, checksum } = parseUploadMetadata(metadata);
+      const { artifactId, filename, kind, relatedTo, checksum, name } =
+        parseUploadMetadata(metadata);
 
       if (!isUuid(artifactId)) {
         throw tusError(400, 'Upload-Metadata must include a valid `artifactId` UUID.\n');
@@ -177,7 +191,7 @@ export function createPulsevaultTusServer(options: PulsevaultTusOptions) {
         store.checksum = checksum;
       }
 
-      return storage.reserveUpload({ artifactId, filename, ext, kind, relatedTo, checksum });
+      return storage.reserveUpload({ artifactId, filename, ext, kind, relatedTo, checksum, name });
     },
     // Relative Location (RFC 7231 §7.1.2) so the upload URL is correct behind
     // any TLS-terminating proxy without trusting spoofable X-Forwarded-*

--- a/src/lib/pulsevaultTus.ts
+++ b/src/lib/pulsevaultTus.ts
@@ -143,7 +143,13 @@ function parseUploadMetadata(
   const checksum = (metadata?.checksum ?? '').trim() || undefined;
   // Free-form display title. Trim, then hard-cap length so a hostile or buggy
   // client can't bloat the sidecar; an all-whitespace/empty value is dropped.
-  const name = (metadata?.name ?? '').trim().slice(0, MAX_ARTIFACT_NAME_LENGTH) || undefined;
+  // Cap by code point (Array.from iterates code points) rather than by
+  // `.slice()`'s UTF-16 units, so a title truncated at the boundary can't be
+  // left with a split surrogate pair (a half-emoji / lone surrogate).
+  const name =
+    Array.from((metadata?.name ?? '').trim())
+      .slice(0, MAX_ARTIFACT_NAME_LENGTH)
+      .join('') || undefined;
 
   return { artifactId, filename, kind, relatedTo, checksum, name };
 }

--- a/src/storage/local.ts
+++ b/src/storage/local.ts
@@ -39,6 +39,8 @@ type Sidecar = {
   relatedTo?: string;
   /** Optional client-supplied checksum metadata. See `ReserveUploadParams.checksum`. */
   checksum?: string;
+  /** Optional human-facing display name. See `ReserveUploadParams.name`. */
+  name?: string;
 };
 
 const SIDECAR_VERSION = 1 as const;
@@ -53,6 +55,7 @@ type CachedMeta = {
   kind: UploadKind;
   relatedTo?: string;
   checksum?: string;
+  name?: string;
 };
 
 /** Map a file extension to the `Content-Type` the GET route should return. */
@@ -82,6 +85,7 @@ function sidecarToCachedMeta(sidecar: Sidecar, ready: boolean): CachedMeta {
     kind: sidecar.kind ?? 'video',
     relatedTo: sidecar.relatedTo,
     checksum: sidecar.checksum,
+    name: sidecar.name,
   };
 }
 
@@ -103,7 +107,7 @@ export type LocalStorageOptions = {
  *
  * ```text
  * <workspaceRoot>/
- *   .pulsevault/<artifactId>.json   # sidecar: { version, ext, filename, status, kind, relatedTo }
+ *   .pulsevault/<artifactId>.json   # sidecar: { version, ext, filename, status, kind, relatedTo, checksum, name }
  *   video/<artifactId><ext>         # finalized video bytes
  *   video/<artifactId><ext>.json    # @tus/file-store offset/metadata sidecar
  *   project/<artifactId><ext>       # finalized project bytes
@@ -137,6 +141,8 @@ export type LocalStorage = PulseVaultStorage & {
   getRelatedTo(artifactId: string): Promise<string | null>;
   /** Satisfies the optional `PulseVaultStorage.getChecksum` contract. */
   getChecksum(artifactId: string): Promise<string | null>;
+  /** Satisfies the optional `PulseVaultStorage.getName` contract. */
+  getName(artifactId: string): Promise<string | null>;
 };
 
 export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
@@ -232,6 +238,7 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
         kind,
         relatedTo: typeof parsed.relatedTo === 'string' ? parsed.relatedTo : undefined,
         checksum: typeof parsed.checksum === 'string' ? parsed.checksum : undefined,
+        name: typeof parsed.name === 'string' ? parsed.name : undefined,
       };
     } catch {
       // Malformed sidecar — treat as absent. `reserveUpload` will rewrite
@@ -267,6 +274,7 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     kind,
     relatedTo,
     checksum,
+    name,
   }: ReserveUploadParams): Promise<string> => {
     await fs.mkdir(path.join(workspaceRoot, kind), { recursive: true, mode: 0o750 });
     await fs.mkdir(sidecarDir(), { recursive: true, mode: 0o750 });
@@ -279,6 +287,7 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
       kind,
       relatedTo,
       checksum,
+      name,
     };
 
     // Collision guard: `wx` fails atomically with EEXIST if a sidecar already exists for
@@ -304,7 +313,7 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
       await writeSidecar(artifactId, sidecar);
     }
 
-    cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum });
+    cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum, name });
     // @tus/file-store joins this onto its configured `directory`, so the
     // actual file lands at `<workspaceRoot>/<kind>/<artifactId><ext>`.
     return artifactRelPath(artifactId, kind, ext);
@@ -385,6 +394,11 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     return meta?.checksum ?? null;
   };
 
+  const getName = async (artifactId: string): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
+    return meta?.name ?? null;
+  };
+
   return {
     datastore,
     workspaceRoot,
@@ -397,5 +411,6 @@ export function createLocalStorage(opts: LocalStorageOptions): LocalStorage {
     getKind,
     getRelatedTo,
     getChecksum,
+    getName,
   };
 }

--- a/src/storage/s3.ts
+++ b/src/storage/s3.ts
@@ -40,6 +40,8 @@ type Sidecar = {
   relatedTo?: string;
   /** Optional client-supplied checksum metadata. See `ReserveUploadParams.checksum`. */
   checksum?: string;
+  /** Optional human-facing display name. See `ReserveUploadParams.name`. */
+  name?: string;
 };
 
 const SIDECAR_VERSION = 1 as const;
@@ -56,6 +58,7 @@ type CachedMeta = {
   kind: UploadKind;
   relatedTo?: string;
   checksum?: string;
+  name?: string;
 };
 
 /** Map a file extension to the `Content-Type` the playback URL should return. */
@@ -85,6 +88,7 @@ function sidecarToCachedMeta(sidecar: Sidecar, ready: boolean): CachedMeta {
     kind: sidecar.kind ?? 'video',
     relatedTo: sidecar.relatedTo,
     checksum: sidecar.checksum,
+    name: sidecar.name,
   };
 }
 
@@ -177,6 +181,8 @@ export type S3Storage = PulseVaultStorage & {
   getRelatedTo(artifactId: string): Promise<string | null>;
   /** Satisfies the optional `PulseVaultStorage.getChecksum` contract. */
   getChecksum(artifactId: string): Promise<string | null>;
+  /** Satisfies the optional `PulseVaultStorage.getName` contract. */
+  getName(artifactId: string): Promise<string | null>;
 };
 
 /**
@@ -302,6 +308,7 @@ export async function createS3Storage(opts: S3StorageOptions): Promise<S3Storage
         kind,
         relatedTo: typeof parsed.relatedTo === 'string' ? parsed.relatedTo : undefined,
         checksum: typeof parsed.checksum === 'string' ? parsed.checksum : undefined,
+        name: typeof parsed.name === 'string' ? parsed.name : undefined,
       };
     } catch {
       // Malformed sidecar — treat as absent; `reserveUpload` rewrites it.
@@ -326,6 +333,7 @@ export async function createS3Storage(opts: S3StorageOptions): Promise<S3Storage
     kind,
     relatedTo,
     checksum,
+    name,
   }: ReserveUploadParams): Promise<string> => {
     const sidecar: Sidecar = {
       version: SIDECAR_VERSION,
@@ -335,6 +343,7 @@ export async function createS3Storage(opts: S3StorageOptions): Promise<S3Storage
       kind,
       relatedTo,
       checksum,
+      name,
     };
 
     // Fast-path rejection for the common case. Not atomic by itself (two concurrent
@@ -388,7 +397,7 @@ export async function createS3Storage(opts: S3StorageOptions): Promise<S3Storage
       await writeSidecar(artifactId, sidecar);
     }
 
-    cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum });
+    cacheSet(artifactId, { ext, ready: false, kind, relatedTo, checksum, name });
     // @tus/s3-store uses this as the object key for the multipart upload, so
     // the finished object lands at `<kind>/<artifactId><ext>`.
     return artifactKey(artifactId, kind, ext);
@@ -516,6 +525,11 @@ export async function createS3Storage(opts: S3StorageOptions): Promise<S3Storage
     return meta?.checksum ?? null;
   };
 
+  const getName = async (artifactId: string): Promise<string | null> => {
+    const meta = await loadMeta(artifactId);
+    return meta?.name ?? null;
+  };
+
   const shutdown = async (): Promise<void> => {
     client.destroy();
   };
@@ -533,6 +547,7 @@ export async function createS3Storage(opts: S3StorageOptions): Promise<S3Storage
     getKind,
     getRelatedTo,
     getChecksum,
+    getName,
     shutdown,
   };
 }

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -77,6 +77,16 @@ export type ReserveUploadParams = {
    * two separate HTTP requests).
    */
   checksum?: string;
+  /**
+   * Optional human-facing display name for the artifact, from
+   * `Upload-Metadata.name` (e.g. the draft/project title the user typed on the
+   * capture device). Free-form UTF-8, trimmed and length-capped upstream;
+   * persisted verbatim so a consumer can label the artifact without inventing a
+   * title from the opaque `artifactId`. Never used to build a filesystem path
+   * or object key — it's display metadata with no routing or security role, so
+   * consumers MUST escape it for their own output context (HTML, shell, etc.).
+   */
+  name?: string;
 };
 
 /**
@@ -151,4 +161,12 @@ export interface PulseVaultStorage {
    * `createChecksumValidator`/`createS3ChecksumValidator` at completion time.
    */
   getChecksum?(artifactId: string): Promise<string | null>;
+
+  /**
+   * Return the `name` display metadata stored at `reserveUpload` time, or
+   * `null` if the artifactId is unknown or no name was supplied. Convenience
+   * for consumers that read through the adapter API rather than the on-disk
+   * sidecar directly.
+   */
+  getName?(artifactId: string): Promise<string | null>;
 }

--- a/test/artifact-name.test.mjs
+++ b/test/artifact-name.test.mjs
@@ -101,6 +101,23 @@ test("name is trimmed and hard-capped at the server-side limit", async () => {
   }
 });
 
+test("caps by code point so a boundary emoji is never split into a lone surrogate", async () => {
+  const ctx = await startApp();
+  try {
+    // The emoji lands exactly on the MAX_NAME boundary; a UTF-16 `.slice()`
+    // would keep only its leading surrogate and drop a lone half.
+    const title = "x".repeat(MAX_NAME - 1) + "😀" + "tail";
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: ID2, name: title });
+    const stored = await ctx.storage.getName(ID2);
+    assert.equal(stored, "x".repeat(MAX_NAME - 1) + "😀");
+    // Emoji intact: MAX_NAME code points, and the string is well-formed UTF-16.
+    assert.equal(Array.from(stored).length, MAX_NAME);
+    assert.equal(stored.toWellFormed(), stored);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
 test("getName returns null for an unknown artifactId", async () => {
   const ctx = await startApp();
   try {

--- a/test/artifact-name.test.mjs
+++ b/test/artifact-name.test.mjs
@@ -1,0 +1,111 @@
+// Tests for the optional `name` Upload-Metadata key: a free-form, human-facing
+// display title (e.g. the draft name typed on the capture device) that rides
+// the create request, is persisted to the sidecar, and is exposed via
+// `storage.getName`. Covers: happy-path round-trip, UTF-8 fidelity, absent and
+// whitespace-only values dropping to no-name, and the server-side length cap.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import Fastify from "fastify";
+import pulseVault, { createLocalStorage } from "../dist/app.js";
+import { uploadFull } from "./helpers.mjs";
+
+const PREFIX = "/pulsevault";
+const ID1 = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ID2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const UNKNOWN = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+
+// Mirrors the server-side MAX_ARTIFACT_NAME_LENGTH in lib/pulsevaultTus.ts.
+const MAX_NAME = 512;
+
+async function startApp() {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "pv-name-test-"));
+  const storage = createLocalStorage({ workspaceDir });
+  const app = Fastify({ logger: false });
+  await app.register(pulseVault, {
+    prefix: PREFIX,
+    storage,
+    maxUploadSize: 10 * 1024 * 1024,
+  });
+  const baseUrl = await app.listen({ port: 0, host: "127.0.0.1" });
+  return {
+    storage,
+    baseUrl,
+    workspaceDir,
+    readSidecar: async (id) =>
+      JSON.parse(await fs.readFile(path.join(workspaceDir, ".pulsevault", `${id}.json`), "utf8")),
+    teardown: async () => {
+      await app.close();
+      await fs.rm(workspaceDir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("name metadata round-trips to the sidecar and getName", async () => {
+  const ctx = await startApp();
+  try {
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: ID1, name: "Morning rounds" });
+    const sidecar = await ctx.readSidecar(ID1);
+    assert.equal(sidecar.name, "Morning rounds");
+    assert.equal(await ctx.storage.getName(ID1), "Morning rounds");
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("UTF-8 names (accents, emoji) survive the base64 metadata round-trip", async () => {
+  const ctx = await startApp();
+  try {
+    const title = "Café ☕ — visite du matin 🎥";
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: ID1, name: title });
+    assert.equal(await ctx.storage.getName(ID1), title);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("no name metadata leaves the sidecar without a name and getName null", async () => {
+  const ctx = await startApp();
+  try {
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: ID1 });
+    const sidecar = await ctx.readSidecar(ID1);
+    assert.equal("name" in sidecar, false);
+    assert.equal(await ctx.storage.getName(ID1), null);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("whitespace-only name is dropped (treated as no name)", async () => {
+  const ctx = await startApp();
+  try {
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: ID1, name: "   \t  " });
+    assert.equal(await ctx.storage.getName(ID1), null);
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("name is trimmed and hard-capped at the server-side limit", async () => {
+  const ctx = await startApp();
+  try {
+    const padded = `  ${"x".repeat(MAX_NAME + 88)}  `;
+    await uploadFull(ctx.baseUrl, PREFIX, { artifactId: ID2, name: padded });
+    const stored = await ctx.storage.getName(ID2);
+    assert.equal(stored, "x".repeat(MAX_NAME));
+  } finally {
+    await ctx.teardown();
+  }
+});
+
+test("getName returns null for an unknown artifactId", async () => {
+  const ctx = await startApp();
+  try {
+    assert.equal(await ctx.storage.getName(UNKNOWN), null);
+  } finally {
+    await ctx.teardown();
+  }
+});

--- a/test/helpers.mjs
+++ b/test/helpers.mjs
@@ -30,12 +30,14 @@ export function makeMp4(size) {
 export async function tusCreate(
   baseUrl,
   prefix,
-  { artifactId, idKey = "artifactId", filename, size, kind, relatedTo, checksum, headers = {} },
+  { artifactId, idKey = "artifactId", filename, size, kind, relatedTo, checksum, name, headers = {} },
 ) {
   const parts = [`${idKey} ${b64(artifactId)}`, `filename ${b64(filename)}`];
   if (kind) parts.push(`kind ${b64(kind)}`);
   if (relatedTo) parts.push(`relatedTo ${b64(relatedTo)}`);
   if (checksum) parts.push(`checksum ${b64(checksum)}`);
+  // `name` may be any UTF-8 title; b64() already encodes via a utf8 Buffer.
+  if (name !== undefined) parts.push(`name ${b64(name)}`);
   return fetch(`${baseUrl}${prefix}/upload`, {
     method: "POST",
     headers: {
@@ -72,7 +74,7 @@ export async function tusHead(url) {
 export async function uploadFull(
   baseUrl,
   prefix,
-  { artifactId, filename = "clip.mp4", size = 1024, kind, relatedTo, checksum, body, headers } = {},
+  { artifactId, filename = "clip.mp4", size = 1024, kind, relatedTo, checksum, name, body, headers } = {},
 ) {
   const payload = body ?? makeMp4(size);
   const create = await tusCreate(baseUrl, prefix, {
@@ -82,6 +84,7 @@ export async function uploadFull(
     kind,
     relatedTo,
     checksum,
+    name,
     headers,
   });
   assert.equal(create.status, 201, "create");


### PR DESCRIPTION
## Add an optional `name` display-title to `Upload-Metadata`

Carries a free-form, human-facing artifact title (e.g. the draft name typed on the capture device) from create → sidecar → consumer, so a downstream service can label an artifact instead of inventing a title from the opaque `artifactId`.

### What
- Parse a `name` `Upload-Metadata` key; **trim + hard-cap at 512** server-side; drop empty/whitespace to no-name.
- Thread it through `ReserveUploadParams`; persist in the **local and S3** sidecars alongside `relatedTo`/`checksum`.
- Expose via a new optional `getName` storage method (both adapters).

### Docs
- `PROTOCOL.md` §4.1 metadata table + a note that free-form values must be **UTF-8** base64 (a browser `btoa()` alone corrupts accents/emoji).
- README metadata table + sidecar layout; CHANGELOG entry under `[Unreleased] → Added`.

### Tests
Round-trip to sidecar + `getName`; UTF-8 fidelity (accents/emoji); absent and whitespace-only → no name; length cap; unknown id. `npm test` → **117/117** green.

### Compatibility
Optional everywhere — clients that don't send `name` and consumers that don't read it are unaffected. A non-normative extension per `PROTOCOL.md` §9; no `protocolVersion` bump.
