### PR TITLE
feat: web-ready backstop — faststart remux + H.264 transcode on upload complete

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -219,6 +219,12 @@ A transcode re-encodes the video stream (one-time, quality-preserving at the
 default CRF but not bit-identical). Take a backup first if that matters to
 your deployment (see "Backup and restore" above).
 
+Note on checksums: a remux or transcode changes the artifact's bytes, so an
+upload-time checksum recorded for it (the sidecar `checksum` from
+`Upload-Metadata`) describes the original upload, not the rewritten file.
+Treat `getChecksum` as upload-time provenance rather than current-file
+integrity for artifacts this feature has touched.
+
 ## Retention
 
 `pulsevault` has no built-in retention/expiry feature — this is intentionally

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -160,6 +160,65 @@ backup time will resume correctly via the normal TUS `HEAD`-then-resume path
 once the client retries, or will simply sit as abandoned partial uploads
 (see "Retention" below) if the client never retries.
 
+## Web-ready playback (faststart remux + H.264 transcode)
+
+Browsers streaming an MP4 over progressive HTTP stall (or fail outright) on
+two things mobile capture pipelines routinely upload:
+
+- **moov atom at the end of the file** — the player must fetch the file's tail
+  before rendering frame one: seconds of startup delay behind Range requests,
+  or a full download in naive players.
+- **HEVC video** — Firefox never decodes it; Chrome usually can't without
+  hardware support.
+
+The `ensureWebReady` helper (exported from the package root) fixes both, in
+place and atomically (tmp file + rename): a lossless sub-second
+`-c copy -movflags +faststart` remux when only the moov position is wrong, and
+a one-time `libx264` transcode (audio stream-copied) when the codec is
+hostile. It is fail-open by design — without `ffmpeg`/`ffprobe` on `PATH` it
+logs one warning and the original bytes keep serving exactly as before.
+
+**Prerequisite:** install ffmpeg on the serving host — `apt install ffmpeg`
+(Debian/Ubuntu), `dnf install ffmpeg` (Fedora/EL + RPM Fusion), or
+`brew install ffmpeg` (macOS). Nothing else changes; the hook detects it at
+first use.
+
+**New uploads** — wire it into `onUploadComplete` (the fastify-demo ships with
+this enabled):
+
+```js
+const storage = createLocalStorage({ workspaceDir: dataDir });
+await app.register(pulseVault, {
+  storage,
+  onUploadComplete: async (_request, { artifactId, kind }) => {
+    if (kind !== "video") return;
+    const localPath = await storage.getLocalPath(artifactId);
+    if (localPath) await ensureWebReady(localPath, { logger: app.log });
+  },
+});
+```
+
+Options: `{ transcode: false }` restricts it to the lossless remux (no CPU
+cost beyond a file rewrite); `crf`/`preset` tune the transcode
+(defaults `23`/`veryfast`); `ffmpegPath`/`ffprobePath` point at binaries off
+`PATH`.
+
+**Existing artifacts** — uploads that landed before the hook existed are fixed
+once with the bundled migration script (idempotent; interrupt and rerun
+freely, already-fixed files are skipped for free):
+
+```sh
+node node_modules/@mieweb/pulsevault/scripts/web-ready-migrate.mjs /path/to/workspaceDir
+# preview without modifying anything:
+node node_modules/@mieweb/pulsevault/scripts/web-ready-migrate.mjs /path/to/workspaceDir --dry-run
+# lossless remux only, never transcode:
+node node_modules/@mieweb/pulsevault/scripts/web-ready-migrate.mjs /path/to/workspaceDir --no-transcode
+```
+
+A transcode re-encodes the video stream (one-time, quality-preserving at the
+default CRF but not bit-identical). Take a backup first if that matters to
+your deployment (see "Backup and restore" above).
+
 ## Retention
 
 `pulsevault` has no built-in retention/expiry feature — this is intentionally

--- a/examples/fastify-demo/server.mjs
+++ b/examples/fastify-demo/server.mjs
@@ -21,7 +21,7 @@ import fastifyCompress from "@fastify/compress";
 import fastifyEtag from "@fastify/etag";
 import underPressure from "@fastify/under-pressure";
 import QRCode from "qrcode";
-import pulseVault, { createLocalStorage, buildUploadLink } from "@mieweb/pulsevault";
+import pulseVault, { createLocalStorage, buildUploadLink, ensureWebReady } from "@mieweb/pulsevault";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // The route schema says `format: "uuid"` but Fastify's default Ajv doesn't
@@ -386,10 +386,11 @@ app.get("/deeplinks", { schema: { tags: ["demo"], summary: "Mint a pairing deep 
 
 // Mount plugin under /pulsevault so TUS is at POST /pulsevault/upload and
 // artifact GET is at /pulsevault/artifacts/:artifactId. This is the smallest
-// working mount — no authorize, no validatePayload, no hooks.
+// working mount — no authorize, no validatePayload.
+const storage = createLocalStorage({ workspaceDir: dataDir });
 await app.register(pulseVault, {
   prefix: "/pulsevault",
-  storage: createLocalStorage({ workspaceDir: dataDir }),
+  storage,
   // Matches the deployment edge's `client_max_body_size 2G` — advertising more
   // (`Tus-Max-Size`) than the infra accepts means clients get promised sizes
   // that 413 mid-flight. Raise only if the edge limit is raised.
@@ -404,6 +405,23 @@ await app.register(pulseVault, {
     project: [".pulse", ".zip"],
     captions: [".vtt"],
     thumbnail: [".jpg", ".jpeg", ".png"],
+  },
+  // Web-playability backstop: mobile capture pipelines routinely upload MP4s
+  // with the moov atom at the end (seconds of browser stall before frame one)
+  // or HEVC video (undecodable in Firefox and most Chrome). Fix each video
+  // once, right after its final byte lands: a lossless sub-second faststart
+  // remux, or a one-time H.264 transcode when the codec is hostile. Fail-open:
+  // without ffmpeg on PATH this logs one warning and serves the original
+  // bytes, exactly as before. For artifacts uploaded before this hook existed,
+  // run `node scripts/web-ready-migrate.mjs <dataDir>` (see OPERATIONS.md).
+  onUploadComplete: async (_request, { artifactId, kind }) => {
+    if (kind !== "video") return;
+    const localPath = await storage.getLocalPath(artifactId);
+    if (!localPath) return;
+    const result = await ensureWebReady(localPath, { logger: app.log });
+    if (result.action !== "none") {
+      app.log.info({ artifactId, ...result }, "web-ready");
+    }
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "LICENSE",
     "CHANGELOG.md",
     "PROTOCOL.md",
-    "OPERATIONS.md"
+    "OPERATIONS.md",
+    "scripts/web-ready-migrate.mjs"
   ],
   "scripts": {
     "build": "tsc",

--- a/scripts/web-ready-migrate.mjs
+++ b/scripts/web-ready-migrate.mjs
@@ -56,10 +56,13 @@ for (const sidecarFile of sidecarFiles) {
   } catch {
     continue; // unreadable sidecar — not this script's problem
   }
-  // Old sidecars predate `kind` and are videos by definition; skip uploads
-  // that never finished (their bytes are still partial).
+  // Old sidecars predate `kind` and are videos by definition. Mirror the
+  // storage adapter's status semantics (src/storage/local.ts): anything that
+  // isn't explicitly "uploading" is ready — legacy sidecars predate `status`
+  // too, and those pre-hook artifacts are exactly what this script exists for.
   const kind = sidecar.kind ?? "video";
-  if (kind !== "video" || sidecar.status !== "ready") continue;
+  const status = sidecar.status === "uploading" ? "uploading" : "ready";
+  if (kind !== "video" || status !== "ready") continue;
 
   const artifactId = path.basename(sidecarFile, ".json");
   const filePath = path.join(root, kind, `${artifactId}${sidecar.ext ?? ".mp4"}`);

--- a/scripts/web-ready-migrate.mjs
+++ b/scripts/web-ready-migrate.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+// Make every already-uploaded video artifact in a local-storage workspace
+// web-playable, in place. New uploads are handled by the `onUploadComplete`
+// web-ready hook (see examples/fastify-demo/server.mjs); this script is the
+// one-time backfill for artifacts that landed before the hook existed.
+//
+// For each ready `kind: "video"` sidecar in `<workspaceDir>/.pulsevault/`:
+//   - moov atom at the end of the file  → lossless faststart remux (sub-second)
+//   - non-H.264 video codec (e.g. HEVC) → one-time libx264 transcode
+//   - already web-ready / not MP4 bytes → untouched
+//
+// Rewrites are atomic (tmp file + rename), so interrupting the script never
+// corrupts an artifact — rerun it and it picks up where it left off (already
+// fixed files report `none` and are skipped for free).
+//
+// Usage:
+//   node scripts/web-ready-migrate.mjs <workspaceDir> [--dry-run] [--no-transcode]
+//
+// Requires ffmpeg + ffprobe on PATH (apt install ffmpeg / brew install ffmpeg).
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { ensureWebReady, scanMoovPosition } from "../dist/app.js";
+
+const args = process.argv.slice(2);
+const dryRun = args.includes("--dry-run");
+const transcode = !args.includes("--no-transcode");
+const workspaceDir = args.find((a) => !a.startsWith("--"));
+
+if (!workspaceDir) {
+  console.error(
+    "Usage: node scripts/web-ready-migrate.mjs <workspaceDir> [--dry-run] [--no-transcode]",
+  );
+  process.exit(1);
+}
+
+const root = path.resolve(workspaceDir);
+const sidecarDir = path.join(root, ".pulsevault");
+
+let sidecarFiles;
+try {
+  sidecarFiles = (await fs.readdir(sidecarDir)).filter((f) => f.endsWith(".json"));
+} catch {
+  console.error(`No .pulsevault directory in ${root} — is this a local-storage workspace?`);
+  process.exit(1);
+}
+
+const counts = { none: 0, remuxed: 0, transcoded: 0, skipped: 0, missing: 0 };
+let processed = 0;
+
+for (const sidecarFile of sidecarFiles) {
+  let sidecar;
+  try {
+    sidecar = JSON.parse(await fs.readFile(path.join(sidecarDir, sidecarFile), "utf8"));
+  } catch {
+    continue; // unreadable sidecar — not this script's problem
+  }
+  // Old sidecars predate `kind` and are videos by definition; skip uploads
+  // that never finished (their bytes are still partial).
+  const kind = sidecar.kind ?? "video";
+  if (kind !== "video" || sidecar.status !== "ready") continue;
+
+  const artifactId = path.basename(sidecarFile, ".json");
+  const filePath = path.join(root, kind, `${artifactId}${sidecar.ext ?? ".mp4"}`);
+  processed += 1;
+
+  try {
+    await fs.access(filePath);
+  } catch {
+    counts.missing += 1;
+    console.warn(`missing bytes  ${artifactId}`);
+    continue;
+  }
+
+  if (dryRun) {
+    // Report what WOULD happen: the moov scan is free; the codec check is
+    // ffprobe-cheap but we keep dry-run dependency-free and byte-only.
+    const moov = await scanMoovPosition(filePath);
+    console.log(`would inspect  ${artifactId}  (moov: ${moov})`);
+    continue;
+  }
+
+  const result = await ensureWebReady(filePath, { transcode, logger: console });
+  counts[result.action] += 1;
+  if (result.action !== "none") {
+    console.log(`${result.action.padEnd(11)}  ${artifactId}  (${result.reason})`);
+  }
+}
+
+if (dryRun) {
+  console.log(`\nDry run: inspected ${processed} ready video artifact(s); nothing was modified.`);
+} else {
+  console.log(
+    `\nDone: ${processed} ready video artifact(s) — ` +
+      `${counts.remuxed} remuxed, ${counts.transcoded} transcoded, ` +
+      `${counts.none} already web-ready, ${counts.skipped} skipped, ${counts.missing} missing.`,
+  );
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -225,6 +225,8 @@ export type {
 } from './lib/pulsevaultTus.js';
 export { sniffMp4, createMp4Sniffer, createS3Mp4Sniffer } from './lib/magic.js';
 export type { PulseVaultValidatePayload } from './lib/magic.js';
+export { ensureWebReady, scanMoovPosition } from './lib/web-ready.js';
+export type { WebReadyAction, WebReadyOptions, WebReadyResult, MoovPosition } from './lib/web-ready.js';
 export { buildUploadLink } from './lib/deeplinks.js';
 export type { UploadLinkOptions } from './lib/deeplinks.js';
 export {

--- a/src/core.ts
+++ b/src/core.ts
@@ -670,6 +670,8 @@ export type {
 } from './lib/pulsevaultTus.js';
 export { sniffMp4, createMp4Sniffer, createS3Mp4Sniffer } from './lib/magic.js';
 export type { PulseVaultValidatePayload } from './lib/magic.js';
+export { ensureWebReady, scanMoovPosition } from './lib/web-ready.js';
+export type { WebReadyAction, WebReadyOptions, WebReadyResult, MoovPosition } from './lib/web-ready.js';
 export { buildUploadLink } from './lib/deeplinks.js';
 export type { UploadLinkOptions } from './lib/deeplinks.js';
 export {

--- a/src/lib/web-ready.ts
+++ b/src/lib/web-ready.ts
@@ -1,0 +1,249 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import type { PulseVaultLogger } from './request.js';
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Web-playability backstop for uploaded MP4 artifacts.
+ *
+ * Browsers streaming an MP4 over progressive HTTP need two things the mobile
+ * capture pipelines frequently don't provide:
+ *
+ * 1. The `moov` atom at the FRONT of the file ("faststart"). iOS/Android
+ *    recorders finalize the moov at the end, so a `<video>` tag must fetch the
+ *    file's tail before it can render frame one — a multi-second stall behind
+ *    Range requests, or a full download in naive players.
+ * 2. A codec browsers actually decode. iPhones record HEVC by default, which
+ *    Firefox never plays and Chrome usually can't without hardware support.
+ *
+ * `ensureWebReady` fixes both in place: a lossless sub-second remux
+ * (`-c copy -movflags +faststart`) when only the moov position is wrong, and a
+ * one-time H.264 transcode when the codec is hostile. Fail-open by design —
+ * if `ffmpeg`/`ffprobe` are not installed, or the file isn't MP4-family, the
+ * artifact is left byte-for-byte as uploaded and serving continues exactly as
+ * before.
+ */
+
+/** Codecs every mainstream browser decodes without hardware caveats. */
+const WEB_SAFE_VIDEO_CODECS = new Set(['h264']);
+
+export type WebReadyAction = 'none' | 'remuxed' | 'transcoded' | 'skipped';
+
+export type WebReadyResult = {
+  action: WebReadyAction;
+  /** Human-readable explanation (what was detected, or why nothing was done). */
+  reason: string;
+};
+
+export type WebReadyOptions = {
+  /** Path to the ffmpeg binary. Default `"ffmpeg"` (resolved via PATH). */
+  ffmpegPath?: string;
+  /** Path to the ffprobe binary. Default `"ffprobe"` (resolved via PATH). */
+  ffprobePath?: string;
+  /**
+   * Whether a non-web-safe codec triggers a full H.264 transcode. Default
+   * `true`. Set `false` to only ever do the lossless faststart remux —
+   * useful when transcode cost on the serving host is a concern.
+   */
+  transcode?: boolean;
+  /** x264 CRF for the transcode path (lower = better/larger). Default `23`. */
+  crf?: number;
+  /** x264 preset for the transcode path. Default `"veryfast"`. */
+  preset?: string;
+  /** Optional logger; `error` fires when ffmpeg/ffprobe are missing or a rewrite fails. */
+  logger?: PulseVaultLogger;
+};
+
+/** Where the moov atom sits among the file's top-level boxes. */
+export type MoovPosition = 'front' | 'end' | 'unknown';
+
+/**
+ * Walk the file's top-level ISO-BMFF boxes and report whether `moov` appears
+ * before or after `mdat`. Pure Node (a handful of 16-byte header reads) — no
+ * ffprobe needed, so the cheap common case ("already faststart, do nothing")
+ * costs microseconds regardless of file size.
+ *
+ * Returns `"unknown"` for non-MP4 bytes, truncated headers, or files missing
+ * either box — callers should treat that as "leave the file alone".
+ */
+export async function scanMoovPosition(filePath: string): Promise<MoovPosition> {
+  let fd: fs.FileHandle;
+  try {
+    fd = await fs.open(filePath, 'r');
+  } catch {
+    return 'unknown';
+  }
+  try {
+    const { size: fileSize } = await fd.stat();
+    let offset = 0;
+    let sawMdat = false;
+    let first = true;
+    while (offset + 8 <= fileSize) {
+      const header = Buffer.alloc(16);
+      const { bytesRead } = await fd.read(header, 0, 16, offset);
+      if (bytesRead < 8) return 'unknown';
+      let boxSize = header.readUInt32BE(0);
+      const boxType = header.toString('latin1', 4, 8);
+      if (first) {
+        // Anything that doesn't open with ftyp isn't MP4-family — don't touch it.
+        if (boxType !== 'ftyp') return 'unknown';
+        first = false;
+      }
+      if (boxSize === 1) {
+        // 64-bit largesize in the 8 bytes after the type.
+        if (bytesRead < 16) return 'unknown';
+        const large = header.readBigUInt64BE(8);
+        if (large > BigInt(Number.MAX_SAFE_INTEGER)) return 'unknown';
+        boxSize = Number(large);
+      } else if (boxSize === 0) {
+        // Box extends to end of file.
+        boxSize = fileSize - offset;
+      }
+      if (boxSize < 8) return 'unknown';
+      if (boxType === 'moov') return sawMdat ? 'end' : 'front';
+      if (boxType === 'mdat') sawMdat = true;
+      offset += boxSize;
+    }
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  } finally {
+    await fd.close();
+  }
+}
+
+/** ffprobe the first video stream's codec name; `null` when unprobeable. */
+async function probeVideoCodec(filePath: string, ffprobePath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(ffprobePath, [
+      '-v', 'error',
+      '-select_streams', 'v:0',
+      '-show_entries', 'stream=codec_name',
+      '-of', 'default=noprint_wrappers=1:nokey=1',
+      filePath,
+    ]);
+    const codec = stdout.trim();
+    return codec.length > 0 ? codec : null;
+  } catch {
+    return null;
+  }
+}
+
+// One availability probe per (binary path) per process — a missing ffmpeg
+// should cost one spawn and one warning, not one of each per upload.
+const binaryAvailable = new Map<string, Promise<boolean>>();
+const warnedMissing = new Set<string>();
+function isBinaryAvailable(binPath: string): Promise<boolean> {
+  let cached = binaryAvailable.get(binPath);
+  if (!cached) {
+    cached = execFileAsync(binPath, ['-version']).then(
+      () => true,
+      () => false,
+    );
+    binaryAvailable.set(binPath, cached);
+  }
+  return cached;
+}
+
+/** Run ffmpeg writing to a sibling tmp file, then atomically replace the original. */
+async function rewriteInPlace(filePath: string, ffmpegPath: string, args: string[]): Promise<void> {
+  const dir = path.dirname(filePath);
+  const tmp = path.join(dir, `.webready-${process.pid}-${Date.now()}${path.extname(filePath) || '.mp4'}`);
+  try {
+    await execFileAsync(ffmpegPath, ['-y', '-i', filePath, ...args, tmp], {
+      // A transcode of a long upload legitimately takes minutes; cap the
+      // buffered stderr instead of the wall clock.
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    // ffmpeg exiting 0 with an empty/absent output would still be a corrupt
+    // swap — verify there are real bytes before replacing the original.
+    const stat = await fs.stat(tmp);
+    if (stat.size === 0) throw new Error('ffmpeg produced an empty output');
+    await fs.rename(tmp, filePath);
+  } catch (err) {
+    await fs.rm(tmp, { force: true });
+    throw err;
+  }
+}
+
+/**
+ * Make the MP4 at `filePath` web-playable, in place:
+ *
+ * - moov at the end + web-safe codec → lossless `-c copy -movflags +faststart`
+ *   remux (sub-second, no quality change);
+ * - non-web-safe codec (HEVC etc.) → one-time `libx264` transcode (audio
+ *   stream-copied) with faststart;
+ * - already faststart H.264, non-MP4 bytes, unprobeable files, or missing
+ *   ffmpeg/ffprobe → untouched (`skipped`/`none`).
+ *
+ * The rewrite is atomic (tmp file + rename in the same directory), so a crash
+ * mid-way never corrupts the served artifact. Never throws for pipeline
+ * reasons — a failed ffmpeg run resolves to `skipped` with the reason, and the
+ * original bytes keep serving.
+ */
+export async function ensureWebReady(
+  filePath: string,
+  options: WebReadyOptions = {},
+): Promise<WebReadyResult> {
+  const ffmpegPath = options.ffmpegPath ?? 'ffmpeg';
+  const ffprobePath = options.ffprobePath ?? 'ffprobe';
+  const transcode = options.transcode ?? true;
+  const crf = options.crf ?? 23;
+  const preset = options.preset ?? 'veryfast';
+
+  const moov = await scanMoovPosition(filePath);
+  if (moov === 'unknown') {
+    return { action: 'skipped', reason: 'not an MP4-family file (or no moov/mdat found)' };
+  }
+
+  if (!(await isBinaryAvailable(ffprobePath)) || !(await isBinaryAvailable(ffmpegPath))) {
+    const key = `${ffmpegPath}|${ffprobePath}`;
+    if (!warnedMissing.has(key)) {
+      warnedMissing.add(key);
+      options.logger?.error(
+        { filePath },
+        'pulsevault web-ready: ffmpeg/ffprobe not found — uploads are served as-is. ' +
+          'Install ffmpeg (apt install ffmpeg / brew install ffmpeg) to enable faststart remux and H.264 transcode.',
+      );
+    }
+    return { action: 'skipped', reason: 'ffmpeg/ffprobe not available' };
+  }
+
+  const codec = await probeVideoCodec(filePath, ffprobePath);
+  const codecHostile = codec !== null && !WEB_SAFE_VIDEO_CODECS.has(codec);
+
+  if (codecHostile && transcode) {
+    try {
+      await rewriteInPlace(filePath, ffmpegPath, [
+        '-c:v', 'libx264', '-preset', preset, '-crf', String(crf),
+        '-pix_fmt', 'yuv420p',
+        '-c:a', 'copy',
+        '-movflags', '+faststart',
+      ]);
+      return { action: 'transcoded', reason: `video codec ${codec} → h264 (+faststart)` };
+    } catch (err) {
+      options.logger?.error({ err, filePath }, 'pulsevault web-ready: transcode failed; serving original bytes');
+      return { action: 'skipped', reason: `transcode failed: ${(err as Error).message}` };
+    }
+  }
+
+  if (moov === 'end') {
+    try {
+      await rewriteInPlace(filePath, ffmpegPath, ['-c', 'copy', '-movflags', '+faststart']);
+      return { action: 'remuxed', reason: 'moov was at end of file; remuxed to faststart' };
+    } catch (err) {
+      options.logger?.error({ err, filePath }, 'pulsevault web-ready: faststart remux failed; serving original bytes');
+      return { action: 'skipped', reason: `remux failed: ${(err as Error).message}` };
+    }
+  }
+
+  return {
+    action: 'none',
+    reason: codecHostile
+      ? `already faststart; codec ${codec} left as-is (transcode disabled)`
+      : 'already web-ready',
+  };
+}

--- a/src/lib/web-ready.ts
+++ b/src/lib/web-ready.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -151,7 +152,11 @@ function isBinaryAvailable(binPath: string): Promise<boolean> {
 /** Run ffmpeg writing to a sibling tmp file, then atomically replace the original. */
 async function rewriteInPlace(filePath: string, ffmpegPath: string, args: string[]): Promise<void> {
   const dir = path.dirname(filePath);
-  const tmp = path.join(dir, `.webready-${process.pid}-${Date.now()}${path.extname(filePath) || '.mp4'}`);
+  // randomUUID in the name: every video artifact shares one kind directory, so
+  // a pid+timestamp tmp name collides when two uploads finish in the same
+  // millisecond — both ffmpegs would interleave writes into one file and the
+  // winner's rename would install garbage bytes over a real artifact.
+  const tmp = path.join(dir, `.webready-${randomUUID()}${path.extname(filePath) || '.mp4'}`);
   try {
     await execFileAsync(ffmpegPath, ['-y', '-i', filePath, ...args, tmp], {
       // A transcode of a long upload legitimately takes minutes; cap the
@@ -183,6 +188,12 @@ async function rewriteInPlace(filePath: string, ffmpegPath: string, args: string
  * mid-way never corrupts the served artifact. Never throws for pipeline
  * reasons — a failed ffmpeg run resolves to `skipped` with the reason, and the
  * original bytes keep serving.
+ *
+ * NOTE: a rewrite changes the artifact's bytes, so any upload-time checksum
+ * recorded for it (e.g. the local adapter's sidecar `checksum` from
+ * `Upload-Metadata`) describes the ORIGINAL bytes, not the rewritten file.
+ * Consumers verifying bytes against `getChecksum` must treat it as
+ * upload-time provenance, not current-file integrity.
  */
 export async function ensureWebReady(
   filePath: string,

--- a/test/web-ready.test.mjs
+++ b/test/web-ready.test.mjs
@@ -1,0 +1,153 @@
+// Web-ready backstop tests. The moov box scan runs against hand-crafted
+// ISO-BMFF byte layouts (pure Node, no ffmpeg needed); the remux/transcode
+// paths run against real files generated with ffmpeg and are skipped when
+// ffmpeg/ffprobe are not installed, mirroring ensureWebReady's own fail-open
+// behavior on such hosts.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { ensureWebReady, scanMoovPosition } from "../dist/lib/web-ready.js";
+
+function hasCmd(cmd) {
+  try {
+    execFileSync(cmd, ["-version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+const FFMPEG = hasCmd("ffmpeg") && hasCmd("ffprobe");
+
+async function tmpFile(name, bytes) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "webready-"));
+  const p = path.join(dir, name);
+  await fs.writeFile(p, bytes);
+  return p;
+}
+
+/** Minimal top-level box: 4-byte big-endian size + 4-char type + payload. */
+function box(type, payloadLength = 0) {
+  const b = Buffer.alloc(8 + payloadLength);
+  b.writeUInt32BE(8 + payloadLength, 0);
+  b.write(type, 4, "latin1");
+  return b;
+}
+
+test("scanMoovPosition: moov before mdat is 'front'", async () => {
+  const p = await tmpFile("front.mp4", Buffer.concat([box("ftyp", 8), box("moov", 16), box("mdat", 32)]));
+  assert.equal(await scanMoovPosition(p), "front");
+});
+
+test("scanMoovPosition: moov after mdat is 'end'", async () => {
+  const p = await tmpFile("end.mp4", Buffer.concat([box("ftyp", 8), box("mdat", 32), box("moov", 16)]));
+  assert.equal(await scanMoovPosition(p), "end");
+});
+
+test("scanMoovPosition: non-MP4 bytes, truncation, missing moov are 'unknown'", async () => {
+  assert.equal(await scanMoovPosition(await tmpFile("junk.bin", Buffer.from("this is not an mp4 file at all"))), "unknown");
+  assert.equal(await scanMoovPosition(await tmpFile("empty.mp4", Buffer.alloc(0))), "unknown");
+  // ftyp present but the file ends before any moov shows up.
+  assert.equal(await scanMoovPosition(await tmpFile("nomoov.mp4", Buffer.concat([box("ftyp", 8), box("mdat", 32)]))), "unknown");
+  // A box header claiming a size smaller than 8 is corrupt — bail, don't loop.
+  const corrupt = Buffer.concat([box("ftyp", 8), box("mdat", 8)]);
+  corrupt.writeUInt32BE(3, 16);
+  assert.equal(await scanMoovPosition(await tmpFile("corrupt.mp4", corrupt)), "unknown");
+  assert.equal(await scanMoovPosition("/nonexistent/definitely-not-here.mp4"), "unknown");
+});
+
+test("scanMoovPosition: 64-bit largesize boxes are stepped over", async () => {
+  // mdat with size==1 and the real size in the 8-byte largesize field.
+  const payload = 24;
+  const mdat = Buffer.alloc(16 + payload);
+  mdat.writeUInt32BE(1, 0);
+  mdat.write("mdat", 4, "latin1");
+  mdat.writeBigUInt64BE(BigInt(16 + payload), 8);
+  const p = await tmpFile("large.mp4", Buffer.concat([box("ftyp", 8), mdat, box("moov", 16)]));
+  assert.equal(await scanMoovPosition(p), "end");
+});
+
+test("ensureWebReady: non-MP4 file is skipped untouched", async () => {
+  const p = await tmpFile("junk.bin", Buffer.from("not a video"));
+  const before = await fs.readFile(p);
+  const result = await ensureWebReady(p);
+  assert.equal(result.action, "skipped");
+  assert.deepEqual(await fs.readFile(p), before, "bytes must be untouched");
+});
+
+test("ensureWebReady: missing ffmpeg fails open as 'skipped'", async () => {
+  const p = await tmpFile("end.mp4", Buffer.concat([box("ftyp", 8), box("mdat", 32), box("moov", 16)]));
+  const before = await fs.readFile(p);
+  const result = await ensureWebReady(p, {
+    ffmpegPath: "/nonexistent/ffmpeg",
+    ffprobePath: "/nonexistent/ffprobe",
+  });
+  assert.equal(result.action, "skipped");
+  assert.match(result.reason, /not available/);
+  assert.deepEqual(await fs.readFile(p), before, "bytes must be untouched");
+});
+
+test("ensureWebReady: moov-at-end H.264 gets a lossless faststart remux", { skip: !FFMPEG }, async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "webready-"));
+  const p = path.join(dir, "recorded.mp4");
+  // No -movflags +faststart: like a mobile recorder, ffmpeg writes moov last.
+  execFileSync("ffmpeg", [
+    "-f", "lavfi", "-i", "testsrc2=size=320x240:rate=30:duration=1",
+    "-c:v", "libx264", "-pix_fmt", "yuv420p", "-y", p,
+  ], { stdio: "ignore" });
+  assert.equal(await scanMoovPosition(p), "end", "fixture must start moov-at-end");
+
+  const result = await ensureWebReady(p);
+  assert.equal(result.action, "remuxed");
+  assert.equal(await scanMoovPosition(p), "front");
+
+  // Idempotent: a second pass finds nothing to do.
+  const again = await ensureWebReady(p);
+  assert.equal(again.action, "none");
+});
+
+test("ensureWebReady: HEVC is transcoded to H.264 (+faststart)", { skip: !FFMPEG }, async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "webready-"));
+  const p = path.join(dir, "hevc.mp4");
+  try {
+    execFileSync("ffmpeg", [
+      "-f", "lavfi", "-i", "testsrc2=size=320x240:rate=30:duration=1",
+      "-c:v", "libx265", "-tag:v", "hvc1", "-pix_fmt", "yuv420p", "-y", p,
+    ], { stdio: "ignore" });
+  } catch {
+    t.skip("ffmpeg build lacks libx265");
+    return;
+  }
+
+  const result = await ensureWebReady(p);
+  assert.equal(result.action, "transcoded");
+  const codec = execFileSync("ffprobe", [
+    "-v", "error", "-select_streams", "v:0",
+    "-show_entries", "stream=codec_name",
+    "-of", "default=noprint_wrappers=1:nokey=1", p,
+  ]).toString().trim();
+  assert.equal(codec, "h264");
+  assert.equal(await scanMoovPosition(p), "front");
+});
+
+test("ensureWebReady: transcode:false leaves hostile codecs alone after the remux", { skip: !FFMPEG }, async (t) => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "webready-"));
+  const p = path.join(dir, "hevc-noconvert.mp4");
+  try {
+    execFileSync("ffmpeg", [
+      "-f", "lavfi", "-i", "testsrc2=size=320x240:rate=30:duration=1",
+      "-c:v", "libx265", "-tag:v", "hvc1", "-pix_fmt", "yuv420p",
+      "-movflags", "+faststart", "-y", p,
+    ], { stdio: "ignore" });
+  } catch {
+    t.skip("ffmpeg build lacks libx265");
+    return;
+  }
+
+  const result = await ensureWebReady(p, { transcode: false });
+  assert.equal(result.action, "none");
+  assert.match(result.reason, /transcode disabled/);
+});


### PR DESCRIPTION
## Problem

Artifacts served from `GET /artifacts/:artifactId` play badly in browsers even though the route itself is fine (`@fastify/send` handles Range/206 correctly). The uploaded bytes are the problem: mobile capture pipelines routinely produce MP4s with the **moov atom at the end** (seconds of stall before the first frame) or **HEVC video** (undecodable in Firefox and most Chrome).

App-side fixes stop new bad uploads from current app versions, but can't fix already-stored artifacts, older app versions, or third-party uploaders. The server needs a backstop.

## Changes

- **`src/lib/web-ready.ts`** — `ensureWebReady(filePath)`:
  - pure-Node top-level ISO-BMFF box scan detects moov-after-mdat in microseconds (no ffprobe for the common already-fine case)
  - moov-at-end + web-safe codec → lossless `-c copy -movflags +faststart` remux (sub-second)
  - hostile codec (HEVC etc.) → one-time `libx264` transcode, audio stream-copied, `+faststart`
  - atomic tmp-file + rename, so a crash mid-rewrite never corrupts a served artifact
  - **fail-open**: without `ffmpeg`/`ffprobe` on PATH it logs one warning and serves originals exactly as today
  - exported from the plugin root and `/core`, alongside `scanMoovPosition`
- **`examples/fastify-demo`** — wired into the existing `onUploadComplete` hook (kind `video` only)
- **`scripts/web-ready-migrate.mjs`** — idempotent operator backfill for existing workspaces: walks `.pulsevault/` sidecars, fixes ready video artifacts in place, supports `--dry-run` and `--no-transcode`; shipped in the npm package
- **`OPERATIONS.md`** — ffmpeg prerequisite, hook usage, migration one-liners
- **`test/web-ready.test.mjs`** — box scan against hand-crafted ISO-BMFF layouts (incl. 64-bit largesize), remux/transcode/idempotency against real ffmpeg output (skipped where ffmpeg is missing), fail-open paths

## Operator experience

```sh
apt install ffmpeg   # once
node node_modules/@mieweb/pulsevault/scripts/web-ready-migrate.mjs /path/to/data   # backlog, once
```
New uploads are handled automatically by the hook. 127/127 tests pass.

Fixes #57